### PR TITLE
Darkened Krop color

### DIFF
--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -38,7 +38,7 @@
                 app:krop_aspectX="1"
                 app:krop_aspectY="1"
                 app:krop_offset="70dp"
-                app:krop_overlayColor="#aaffffff" >
+                app:krop_overlayColor="#aadddddd" >
 
                 <ImageView
                     android:id="@+id/iv_saveImage"


### PR DESCRIPTION
It is quite common to select images with white background, so they nicely fit the design of the app. Images with white background are hard to crop because the white overlay is invisible on a white image. This PR "moves" the problem - now a background of `#ddd` is hard to crop. I am pretty sure that a white background is more common, so this should affect less users.