### PR TITLE
Use the old encode method for passwords over 64 bytes and repair the slot

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
@@ -137,4 +137,11 @@ public class CryptoUtils {
         byteBuf.get(bytes);
         return bytes;
     }
+
+    @Deprecated
+    public static byte[] toBytesOld(char[] chars) {
+        CharBuffer charBuf = CharBuffer.wrap(chars);
+        ByteBuffer byteBuf = StandardCharsets.UTF_8.encode(charBuf);
+        return byteBuf.array();
+    }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/db/slots/PasswordSlot.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/db/slots/PasswordSlot.java
@@ -2,6 +2,7 @@ package com.beemdevelopment.aegis.db.slots;
 
 import com.beemdevelopment.aegis.crypto.CryptParameters;
 import com.beemdevelopment.aegis.crypto.CryptoUtils;
+import com.beemdevelopment.aegis.crypto.MasterKey;
 import com.beemdevelopment.aegis.crypto.SCryptParameters;
 import com.beemdevelopment.aegis.encoding.Hex;
 
@@ -10,18 +11,21 @@ import org.json.JSONObject;
 
 import java.util.UUID;
 
+import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
 public class PasswordSlot extends RawSlot {
+    private boolean _repaired;
     private SCryptParameters _params;
 
     public PasswordSlot() {
         super();
     }
 
-    protected PasswordSlot(UUID uuid, byte[] key, CryptParameters keyParams, SCryptParameters scryptParams) {
+    protected PasswordSlot(UUID uuid, byte[] key, CryptParameters keyParams, SCryptParameters scryptParams, boolean repaired) {
         super(uuid, key, keyParams);
         _params = scryptParams;
+        _repaired = repaired;
     }
 
     @Override
@@ -32,6 +36,7 @@ public class PasswordSlot extends RawSlot {
             obj.put("r", _params.getR());
             obj.put("p", _params.getP());
             obj.put("salt", Hex.encode(_params.getSalt()));
+            obj.put("repaired", _repaired);
             return obj;
         } catch (JSONException e) {
             throw new RuntimeException(e);
@@ -46,6 +51,23 @@ public class PasswordSlot extends RawSlot {
 
     public SecretKey deriveKey(char[] password) {
         return CryptoUtils.deriveKey(password, _params);
+    }
+
+    public SecretKey deriveKey(byte[] data) {
+        return CryptoUtils.deriveKey(data, _params);
+    }
+
+    @Override
+    public void setKey(MasterKey masterKey, Cipher cipher) throws SlotException {
+        super.setKey(masterKey, cipher);
+        _repaired = true;
+    }
+
+    /**
+     * Reports whether this slot was repaired and is no longer affected by issue #95.
+     */
+    public boolean isRepaired() {
+        return _repaired;
     }
 
     @Override

--- a/app/src/main/java/com/beemdevelopment/aegis/db/slots/Slot.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/db/slots/Slot.java
@@ -129,7 +129,8 @@ public abstract class Slot implements Serializable {
                         obj.getInt("p"),
                         Hex.decode(obj.getString("salt"))
                     );
-                    slot = new PasswordSlot(uuid, key, keyParams, scryptParams);
+                    boolean repaired = obj.optBoolean("repaired", false);
+                    slot = new PasswordSlot(uuid, key, keyParams, scryptParams, repaired);
                     break;
                 case Slot.TYPE_FINGERPRINT:
                     slot = new FingerprintSlot(uuid, key, keyParams);

--- a/app/src/main/java/com/beemdevelopment/aegis/db/slots/SlotList.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/db/slots/SlotList.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 public class SlotList implements Iterable<Slot>, Serializable {
     private List<Slot> _slots = new ArrayList<>();
@@ -75,6 +76,28 @@ public class SlotList implements Iterable<Slot>, Serializable {
 
     public <T extends Slot> boolean has(Class<T> type) {
         return find(type) != null;
+    }
+
+    public void replace(Slot newSlot) {
+        Slot oldSlot = mustGetByUUID(newSlot.getUUID());
+        _slots.set(_slots.indexOf(oldSlot), newSlot);
+    }
+
+    public Slot getByUUID(UUID uuid) {
+        for (Slot slot : _slots) {
+            if (slot.getUUID().equals(uuid)) {
+                return slot;
+            }
+        }
+        return null;
+    }
+
+    private Slot mustGetByUUID(UUID uuid) {
+        Slot slot = getByUUID(uuid);
+        if (slot == null) {
+            throw new AssertionError(String.format("no slot found with UUID: %s", uuid.toString()));
+        }
+        return slot;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="read_qr_error">An error occurred while trying to read the QR code</string>
     <string name="authentication_method_raw">Raw</string>
     <string name="unlocking_vault">Unlocking the vault</string>
+    <string name="unlocking_vault_repair">Unlocking the vault (repairing)</string>
     <string name="password_slot_error">You must have at least one password slot</string>
     <string name="remove_slot">Remove slot</string>
     <string name="remove_slot_description">Are you sure you want to remove this slot?</string>


### PR DESCRIPTION
Commit afb9e597110014117722fc8353333b18d3492007 fixed a bug where the password encode function would add null bytes to the end of the output. Luckily (I thought), PBKDF2 produces collisions for inputs with trailing null bytes and thus scrypt does this as well, so we could safely change that function to remove the null bytes without any impact. Unfortunately, that doesn't hold up if the password is over 64 bytes in size. So after that change, the KDF started producing different keys than before for such passwords and thus some users could no longer unlock their vault.

This patch addresses the issue by using the old password encode function for passwords over 64 bytes and repairing the affected password slot.