### PR TITLE
Always launch AuthActivity on lock if MainActivity is resumed

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -17,6 +17,7 @@ import androidx.annotation.CallSuper;
 import androidx.appcompat.app.AppCompatActivity;
 
 public abstract class AegisActivity extends AppCompatActivity implements AegisApplication.LockListener {
+    private boolean _resumed;
     private AegisApplication _app;
 
     @Override
@@ -53,6 +54,18 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
         super.onDestroy();
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        _resumed = true;
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        _resumed = false;
+    }
+
     @CallSuper
     @Override
     public void onLocked() {
@@ -82,6 +95,13 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
                 setTheme(R.style.AppTheme_TrueBlack);
                 break;
         }
+    }
+
+    /**
+     * Reports whether this Activity has been resumed. (i.e. onResume was called)
+     */
+    protected boolean isOpen() {
+        return _resumed;
     }
 
     /**

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -483,7 +483,6 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                 return true;
             case R.id.action_lock:
                 _app.lock();
-                startAuthActivity();
                 return true;
             default:
                 if (item.getGroupId() == R.id.action_filter_group) {
@@ -612,6 +611,11 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     public void onLocked() {
         _entryListView.clearEntries();
         _loaded = false;
+
+        if (isOpen()) {
+            startAuthActivity();
+        }
+
         super.onLocked();
     }
 }


### PR DESCRIPTION
This patch ensures that AuthActivity is always launched on lock, even from ScreenOffReceiver events, but only if MainActivity is resumed.

Fixes #96.