### PR TITLE
Don't ignore the result of IntroActivity when the vault is locked

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -148,7 +148,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         }
 
         // don't process any activity results if the vault is locked
-        if (requestCode != CODE_DECRYPT && _db.isLocked()) {
+        if (requestCode != CODE_DECRYPT && requestCode != CODE_DO_INTRO && _db.isLocked()) {
             return;
         }
 


### PR DESCRIPTION
This fixes a bug where AuthActivity would be shown after finishing the intro.