### PR TITLE
Replace SpongyCastle with BouncyCastle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'com.github.apl-devs:appintro:v4.2.2'
     implementation 'com.github.avito-tech:krop:0.44'
-    implementation 'com.madgag.spongycastle:core:1.58.0.0'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.61'
     implementation 'com.mattprecious.swirl:swirl:1.0.0'
     implementation 'de.hdodenhof:circleimageview:2.2.0'
     implementation 'me.dm7.barcodescanner:zxing:1.9'

--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
@@ -2,7 +2,8 @@ package com.beemdevelopment.aegis.crypto;
 
 import android.os.Build;
 
-import org.spongycastle.crypto.generators.SCrypt;
+import org.bouncycastle.crypto.generators.SCrypt;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -12,7 +13,9 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
 
@@ -35,6 +38,15 @@ public class CryptoUtils {
     public static final int CRYPTO_SCRYPT_N = 1 << 15;
     public static final int CRYPTO_SCRYPT_r = 8;
     public static final int CRYPTO_SCRYPT_p = 1;
+
+    // replace the BC provider from Android with the one bundled with the app
+    static {
+        final Provider provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+        if (provider != null && !provider.getClass().equals(BouncyCastleProvider.class)) {
+            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
 
     public static SecretKey deriveKey(byte[] input, SCryptParameters params) {
         byte[] keyBytes = SCrypt.generate(input, params.getSalt(), params.getN(), params.getR(), params.getP(), CRYPTO_AEAD_KEY_SIZE);


### PR DESCRIPTION
SpongyCastle is a fork of BouncyCastle. We originally used this fork to 1) have access to scrypt and 2) prevent a package name collision with the bundled BouncyCastle. We don't actually need to use the fork anymore, because the package name of the bundled BouncyCastle was changed in Android. SpongyCastle has also gotten quite outdated in recent years.

This also replaces the built-in version of BouncyCastle with the one bundled with the app, so that we have a recent version even on older Android versions. Recent versions of BouncyCastle also provide Argon2, which is a KDF I would like to experiment with as [a replacement for scrypt](https://github.com/beemdevelopment/Aegis/blob/master/docs/vault.md#kdf).