### PR TITLE
Limit the amount of entry info passed to SelectEntriesActivitiy

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/SelectEntriesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/SelectEntriesActivity.java
@@ -17,7 +17,6 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.beemdevelopment.aegis.R;
-import com.beemdevelopment.aegis.db.DatabaseEntry;
 import com.beemdevelopment.aegis.helpers.FabScrollHelper;
 import com.beemdevelopment.aegis.importers.DatabaseImporterEntryException;
 import com.beemdevelopment.aegis.ui.models.ImportEntry;
@@ -56,12 +55,11 @@ public class SelectEntriesActivity extends AegisActivity {
         entriesView.setNestedScrollingEnabled(false);
 
         Intent intent = getIntent();
-        List<DatabaseEntry> entries = (ArrayList<DatabaseEntry>) intent.getSerializableExtra("entries");
+        List<ImportEntry> entries = (ArrayList<ImportEntry>) intent.getSerializableExtra("entries");
         List<DatabaseImporterEntryException> errors = (ArrayList<DatabaseImporterEntryException>) intent.getSerializableExtra("errors");
 
-        for (DatabaseEntry entry : entries) {
-            ImportEntry importEntry = new ImportEntry(entry);
-            _adapter.addEntry(importEntry);
+        for (ImportEntry entry : entries) {
+            _adapter.addEntry(entry);
         }
 
         if (errors.size() > 0) {
@@ -103,9 +101,9 @@ public class SelectEntriesActivity extends AegisActivity {
     }
 
     private void returnSelectedEntries() {
-        List<DatabaseEntry> entries = _adapter.getSelectedEntries();
+        List<ImportEntry> entries = _adapter.getCheckedEntries();
         Intent intent = new Intent();
-        intent.putExtra("entries", (ArrayList<DatabaseEntry>) entries);
+        intent.putExtra("entries", (ArrayList<ImportEntry>) entries);
         setResult(RESULT_OK, intent);
         finish();
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/models/ImportEntry.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/models/ImportEntry.java
@@ -2,21 +2,37 @@ package com.beemdevelopment.aegis.ui.models;
 
 import com.beemdevelopment.aegis.db.DatabaseEntry;
 
-public class ImportEntry {
-    private DatabaseEntry _entry;
+import java.io.Serializable;
+import java.util.UUID;
+
+public class ImportEntry implements Serializable {
+    private UUID _uuid;
+    private String _name;
+    private String _issuer;
+
+    private transient Listener _listener;
     private boolean _isChecked = true;
-    private Listener _listener;
 
     public ImportEntry(DatabaseEntry entry) {
-        _entry = entry;
+        _uuid = entry.getUUID();
+        _name = entry.getName();
+        _issuer = entry.getIssuer();
+    }
+
+    public UUID getUUID() {
+        return _uuid;
+    }
+
+    public String getName() {
+        return _name;
+    }
+
+    public String getIssuer() {
+        return _issuer;
     }
 
     public void setOnCheckedChangedListener(Listener listener) {
         _listener = listener;
-    }
-
-    public DatabaseEntry getDatabaseEntry() {
-        return _entry;
     }
 
     public boolean isChecked() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/ImportEntriesAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/ImportEntriesAdapter.java
@@ -56,17 +56,7 @@ public class ImportEntriesAdapter extends RecyclerView.Adapter<ImportEntryHolder
         return _entries.size();
     }
 
-    public List<DatabaseEntry> getSelectedEntries() {
-        List<DatabaseEntry> entries = new ArrayList<>();
-
-        for (ImportEntry entry : getCheckedEntries()) {
-            entries.add(entry.getDatabaseEntry());
-        }
-
-        return entries;
-    }
-
-    private List<ImportEntry> getCheckedEntries() {
+    public List<ImportEntry> getCheckedEntries() {
         List<ImportEntry> entries = new ArrayList<>();
 
         for (ImportEntry entry : _entries) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/ImportEntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/ImportEntryHolder.java
@@ -31,9 +31,8 @@ public class ImportEntryHolder extends RecyclerView.ViewHolder implements Import
         _entry = entry;
 
         Context context = itemView.getContext();
-        DatabaseEntry dbEntry = entry.getDatabaseEntry();
-        _issuer.setText(!dbEntry.getIssuer().isEmpty() ? dbEntry.getIssuer() : context.getString(R.string.unknown_issuer));
-        _accountName.setText(!dbEntry.getName().isEmpty() ? dbEntry.getName() : context.getString(R.string.unknown_account_name));
+        _issuer.setText(!entry.getIssuer().isEmpty() ? entry.getIssuer() : context.getString(R.string.unknown_issuer));
+        _accountName.setText(!entry.getName().isEmpty() ? entry.getName() : context.getString(R.string.unknown_account_name));
         _checkbox.setChecked(entry.isChecked());
     }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -115,7 +115,7 @@
     <string name="reading_file_error">Une erreur est survenue en essayant de lire le fichier</string>
     <string name="app_lookup_error">Erreur: l\'application n\'est pas installée</string>
     <string name="root_error">Erreur : impossible d\'obtenir l\'accès root</string>
-    <string name="imported_entries_count">%d entrées importées. %d erreurs.</string>
+    <string name="imported_entries_count">%d entrées importées</string>
     <string name="read_entries_count">%d entrées lues. %d erreurs.</string>
     <string name="import_error_title">Une ou plusieurs erreurs sont survenues lors de l\'importation</string>
     <string name="exporting_database_error">Une erreur est survenue en essayant d\'exporter la base de données</string>


### PR DESCRIPTION
This horrid patch changes the vault import logic to pass an ImportEntry list to SelectEntriesActivity, instead of a DatabaseEntry list. Previously, a crash would occur when importing a vault with lots of icons, because the maximum Parcel size was exceeded.

Storing icons in the vault file was a bad idea.