### PR TITLE
Move entry divider logic to EntryListView

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ViewMode.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ViewMode.java
@@ -30,4 +30,15 @@ public enum ViewMode {
                 return R.layout.card_entry;
         }
     }
+
+    /**
+     * Retrieves the height (in dp) that the divider between entries should have in this view mode.
+     */
+    public float getDividerHeight() {
+        if (this == ViewMode.COMPACT) {
+            return 0;
+        }
+
+        return 20;
+    }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -27,7 +27,6 @@ public class EntryHolder extends RecyclerView.ViewHolder {
     private ImageView _profileDrawable;
     private DatabaseEntry _entry;
     private ImageView _buttonRefresh;
-    private View _entryDivider;
 
     private boolean _hidden;
     private int _tapToRevealTime;
@@ -45,8 +44,6 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         _profileIssuer = view.findViewById(R.id.profile_issuer);
         _profileDrawable = view.findViewById(R.id.ivTextDrawable);
         _buttonRefresh = view.findViewById(R.id.buttonRefresh);
-
-        _entryDivider = view.findViewById(R.id.entryDivider);
 
         _progressBar = view.findViewById(R.id.progressBar);
         int primaryColorId = view.getContext().getResources().getColor(R.color.colorPrimary);
@@ -122,11 +119,6 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         _progressBar.setVisibility(showProgress ? View.VISIBLE : View.GONE);
         if (showProgress) {
             _progressBar.setPeriod(((TotpInfo) _entry.getInfo()).getPeriod());
-
-            if (_entryDivider != null) {
-                _entryDivider.setVisibility(View.GONE);
-            }
-
             startRefreshLoop();
         } else {
             stopRefreshLoop();

--- a/app/src/main/res/drawable/entry_divider.xml
+++ b/app/src/main/res/drawable/entry_divider.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/divider"/>
+    <size android:height="0.1dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:background="?attr/background"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.AuthActivity">
+    tools:context="com.beemdevelopment.aegis.ui.AuthActivity">
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:background="?attr/background"
-
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context="com.beemdevelopment.aegis.ui.EditEntryActivity">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_groups.xml
+++ b/app/src/main/res/layout/activity_groups.xml
@@ -6,12 +6,12 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:background="?attr/background"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.GroupManagerActivity">
+    tools:context="com.beemdevelopment.aegis.ui.GroupManagerActivity">
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -5,6 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.IntroActivity">
+    tools:context="com.beemdevelopment.aegis.ui.IntroActivity">
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,14 +6,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.MainActivity">
+    tools:context="com.beemdevelopment.aegis.ui.MainActivity">
 
     <fragment
         android:name="com.beemdevelopment.aegis.ui.views.EntryListView"
         android:id="@+id/key_profiles"
         android:layout_height="match_parent"
         android:layout_width="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"/>
 
     <!-- note: the fab should always be the last element to be sure it's displayed on top -->
     <com.getbase.floatingactionbutton.FloatingActionsMenu

--- a/app/src/main/res/layout/activity_scanner.xml
+++ b/app/src/main/res/layout/activity_scanner.xml
@@ -9,6 +9,6 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.ScannerActivity">
+    tools:context="com.beemdevelopment.aegis.ui.ScannerActivity">
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_slots.xml
+++ b/app/src/main/res/layout/activity_slots.xml
@@ -6,15 +6,12 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:background="?attr/background"
-
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.SlotManagerActivity">
-
-
+    tools:context="com.beemdevelopment.aegis.ui.SlotManagerActivity">
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/card_entry.xml
+++ b/app/src/main/res/layout/card_entry.xml
@@ -6,7 +6,6 @@
               android:clickable="true"
               android:focusable="true"
               android:layout_height="wrap_content"
-              android:layout_marginTop="20dp"
               android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/main/res/layout/card_entry_compact.xml
+++ b/app/src/main/res/layout/card_entry_compact.xml
@@ -128,10 +128,4 @@
             android:layout_weight="1"/>
     </LinearLayout>
 
-    <View
-        android:id="@+id/entryDivider"
-        android:layout_width="match_parent"
-        android:layout_height="0.1dp"
-        android:background="@color/divider" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/card_entry_small.xml
+++ b/app/src/main/res/layout/card_entry_small.xml
@@ -6,7 +6,6 @@
     android:clickable="true"
     android:focusable="true"
     android:layout_height="wrap_content"
-    android:layout_marginTop="20dp"
     android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/main/res/menu/menu_edit.xml
+++ b/app/src/main/res/menu/menu_edit.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.EditEntryActivity">
+    tools:context="com.beemdevelopment.aegis.ui.EditEntryActivity">
     <item
         android:id="@+id/action_save"
         app:showAsAction="ifRoom"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.MainActivity">
+    tools:context="com.beemdevelopment.aegis.ui.MainActivity">
     <item
         android:id="@+id/mi_search"
         android:title="@string/search"

--- a/app/src/main/res/menu/menu_scanner.xml
+++ b/app/src/main/res/menu/menu_scanner.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.ScannerActivity">
+    tools:context="com.beemdevelopment.aegis.ui.ScannerActivity">
     <item
         android:id="@+id/action_camera"
         android:icon="@drawable/ic_camera_front_24dp"

--- a/app/src/main/res/menu/menu_slots.xml
+++ b/app/src/main/res/menu/menu_slots.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.beemdevelopment.aegis.com.impy.aegis.ui.SlotManagerActivity">
+    tools:context="com.beemdevelopment.aegis.ui.SlotManagerActivity">
     <item
         android:id="@+id/action_save"
         app:showAsAction="ifRoom"


### PR DESCRIPTION
This patch makes EntryListView responsible for providing the divider between entries, instead of setting a margin on every entry like we do now. It also fixes a couple of miscellaneous issues, like use of the old package name.