### PR TITLE
Disable screen security by default for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,14 @@ android {
         debug {
             minifyEnabled false
             applicationIdSuffix ".debug"
-            manifestPlaceholders = [title:"AegisDev", iconName:"ic_launcher_debug"]
+            manifestPlaceholders = [title: "AegisDev", iconName: "ic_launcher_debug"]
+            resValue "bool", "pref_secure_screen_default", "false"
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            manifestPlaceholders = [title:"Aegis", iconName:"ic_launcher"]
+            manifestPlaceholders = [title: "Aegis", iconName: "ic_launcher"]
+            resValue "bool", "pref_secure_screen_default", "true"
         }
     }
     compileOptions {

--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -16,7 +16,8 @@ public class Preferences {
     }
 
     public boolean isSecureScreenEnabled() {
-        return _prefs.getBoolean("pref_secure_screen", true);
+        // screen security should be enabled by default, but not for debug builds
+        return _prefs.getBoolean("pref_secure_screen", !BuildConfig.DEBUG);
     }
 
     public boolean isAccountNameVisible() {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -37,7 +37,7 @@
         android:title="@string/pref_security_group_title"
         app:iconSpaceReserved="false">
         <androidx.preference.SwitchPreferenceCompat
-            android:defaultValue="true"
+            android:defaultValue="@bool/pref_secure_screen_default"
             android:key="pref_secure_screen"
             android:title="@string/pref_secure_screen_title"
             android:summary="@string/pref_secure_screen_summary"


### PR DESCRIPTION
I've lost count of how many times I've tried to record a demo video with screen security enabled.