### PR TITLE
Use glide to load and cache icons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,5 +50,12 @@ dependencies {
     implementation 'me.dm7.barcodescanner:zxing:1.9'
     implementation "com.github.topjohnwu.libsu:core:${libsuVersion}"
     implementation "com.github.topjohnwu.libsu:io:${libsuVersion}"
+    implementation 'com.github.bumptech.glide:annotations:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.9.0'
+    implementation ("com.github.bumptech.glide:recyclerview-integration:4.9.0") {
+        transitive = false
+    }
+    annotationProcessor 'androidx.annotation:annotation:1.1.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/glide/AegisGlideModule.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/glide/AegisGlideModule.java
@@ -1,0 +1,21 @@
+package com.beemdevelopment.aegis.ui.glide;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.beemdevelopment.aegis.db.DatabaseEntry;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.Registry;
+import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.module.AppGlideModule;
+
+import java.nio.ByteBuffer;
+
+@GlideModule
+public class AegisGlideModule extends AppGlideModule {
+    @Override
+    public void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
+        registry.prepend(DatabaseEntry.class, ByteBuffer.class, new IconLoader.Factory());
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/glide/IconLoader.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/glide/IconLoader.java
@@ -1,0 +1,76 @@
+package com.beemdevelopment.aegis.ui.glide;
+
+import androidx.annotation.NonNull;
+
+import com.beemdevelopment.aegis.db.DatabaseEntry;
+import com.bumptech.glide.Priority;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.data.DataFetcher;
+import com.bumptech.glide.load.model.ModelLoader;
+import com.bumptech.glide.load.model.ModelLoaderFactory;
+import com.bumptech.glide.load.model.MultiModelLoaderFactory;
+
+import java.nio.ByteBuffer;
+
+public class IconLoader implements ModelLoader<DatabaseEntry, ByteBuffer> {
+    @Override
+    public LoadData<ByteBuffer> buildLoadData(@NonNull DatabaseEntry model, int width, int height, @NonNull Options options) {
+        return new LoadData<>(new UUIDKey(model.getUUID()), new Fetcher(model));
+    }
+
+    @Override
+    public boolean handles(@NonNull DatabaseEntry model) {
+        return true;
+    }
+
+    public static class Fetcher implements DataFetcher<ByteBuffer> {
+        private DatabaseEntry _model;
+
+        private Fetcher(DatabaseEntry model) {
+            _model = model;
+        }
+
+        @Override
+        public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super ByteBuffer> callback) {
+            byte[] bytes = _model.getIcon();
+            ByteBuffer buf = ByteBuffer.wrap(bytes);
+            callback.onDataReady(buf);
+        }
+
+        @Override
+        public void cleanup() {
+
+        }
+
+        @Override
+        public void cancel() {
+
+        }
+
+        @NonNull
+        @Override
+        public Class<ByteBuffer> getDataClass() {
+            return ByteBuffer.class;
+        }
+
+        @NonNull
+        @Override
+        public DataSource getDataSource() {
+            return DataSource.MEMORY_CACHE;
+        }
+    }
+
+    public static class Factory implements ModelLoaderFactory<DatabaseEntry, ByteBuffer> {
+        @NonNull
+        @Override
+        public ModelLoader<DatabaseEntry, ByteBuffer> build(@NonNull MultiModelLoaderFactory unused) {
+            return new IconLoader();
+        }
+
+        @Override
+        public void teardown() {
+
+        }
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/glide/UUIDKey.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/glide/UUIDKey.java
@@ -1,0 +1,31 @@
+package com.beemdevelopment.aegis.ui.glide;
+
+import androidx.annotation.NonNull;
+
+import com.bumptech.glide.load.Key;
+
+import java.security.MessageDigest;
+import java.util.UUID;
+
+public class UUIDKey implements Key {
+    private UUID _uuid;
+
+    public UUIDKey(UUID uuid) {
+        _uuid = uuid;
+    }
+
+    @Override
+    public void updateDiskCacheKey(@NonNull MessageDigest messageDigest) {
+        messageDigest.update(_uuid.toString().getBytes(CHARSET));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return _uuid.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return _uuid.hashCode();
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -1,7 +1,5 @@
 package com.beemdevelopment.aegis.ui.views;
 
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.PorterDuff;
 import android.os.Handler;
 import android.view.View;
@@ -17,7 +15,10 @@ import com.beemdevelopment.aegis.otp.HotpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfo;
 import com.beemdevelopment.aegis.otp.SteamInfo;
 import com.beemdevelopment.aegis.otp.TotpInfo;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
+import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 
 public class EntryHolder extends RecyclerView.ViewHolder {
@@ -84,15 +85,6 @@ public class EntryHolder extends RecyclerView.ViewHolder {
             _profileName.setText(" - " + entry.getName());
         }
 
-        if (_entry.hasIcon()) {
-            byte[] imageBytes = entry.getIcon();
-            Bitmap image = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.length);
-            _profileDrawable.setImageBitmap(image);
-        } else {
-            TextDrawable drawable = TextDrawableHelper.generate(entry.getIssuer(), entry.getName(), _profileDrawable);
-            _profileDrawable.setImageDrawable(drawable);
-        }
-
         // cancel any scheduled hideCode calls
         _hiddenHandler.removeCallbacksAndMessages(null);
 
@@ -101,6 +93,24 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         } else {
             refreshCode();
         }
+    }
+
+    public void loadIcon(Fragment fragment) {
+        if (_entry.hasIcon()) {
+            Glide.with(fragment)
+                .asDrawable()
+                .load(_entry)
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(false)
+                .into(_profileDrawable);
+        } else {
+            TextDrawable drawable = TextDrawableHelper.generate(_entry.getIssuer(), _entry.getName(), _profileDrawable);
+            _profileDrawable.setImageDrawable(drawable);
+        }
+    }
+
+    public ImageView getIconView() {
+        return _profileDrawable;
     }
 
     public void setTapToRevealTime(int number) {


### PR DESCRIPTION
This patch adds a dependency to glide to handle the loading and caching of icons. In my testing it eliminated the lag previously experienced in the main activity when quickly scrolling through a large list of entries. It does add an extra 1MB to the APK size, but I think that's acceptable for the amount of complexity it handles for us. 

Addresses #125 partially.