### PR TITLE
Check for the possibility of an overflow when parsing OTP period

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/otp/TotpInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/TotpInfo.java
@@ -55,7 +55,12 @@ public class TotpInfo extends OtpInfo {
     }
 
     public static boolean isPeriodValid(int period) {
-        return period > 0;
+        if (period <= 0) {
+            return false;
+        }
+
+        // check for the possibility of an overflow when converting to milliseconds
+        return period <= Integer.MAX_VALUE / 1000;
     }
 
     public void setPeriod(int period) throws OtpInfoException {


### PR DESCRIPTION
The conversion of the OTP period value to milliseconds may overflow for large values, causing the result to wrap around to ``Integer.MIN_VALUE``. This subsequently caused a crash when calling ``ObjectAnimator.setDuration``.

Fixes #152.