### PR TITLE
Change auto lock preference visibility behaviour

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -81,6 +81,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
     private SwitchPreference _encryptionPreference;
     private SwitchPreference _fingerprintPreference;
+    private Preference _autoLockPreference;
     private Preference _setPasswordPreference;
     private Preference _slotsPreference;
     private Preference _groupsPreference;
@@ -333,6 +334,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
                 return true;
             }
         });
+
+        _autoLockPreference = findPreference("pref_auto_lock");
     }
 
     @Override
@@ -659,6 +662,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         _setPasswordPreference.setVisible(encrypted);
         _fingerprintPreference.setVisible(encrypted);
         _slotsPreference.setEnabled(encrypted);
+        _autoLockPreference.setVisible(encrypted);
 
         if (encrypted) {
             SlotList slots = _db.getCredentials().getSlots();

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -52,12 +52,6 @@
             android:summary="@string/pref_secure_screen_summary"
             app:iconSpaceReserved="false"/>
         <androidx.preference.SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="pref_auto_lock"
-            android:title="@string/pref_auto_lock_title"
-            android:summary="@string/pref_auto_lock_summary"
-            app:iconSpaceReserved="false"/>
-        <androidx.preference.SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="pref_tap_to_reveal"
             android:title="@string/pref_tap_to_reveal_title"
@@ -96,6 +90,14 @@
             android:title="@string/pref_fingerprint_title"
             android:summary="@string/pref_fingerprint_summary"
             android:persistent="false"
+            app:iconSpaceReserved="false"/>
+
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_auto_lock"
+            android:dependency="pref_encryption"
+            android:title="@string/pref_auto_lock_title"
+            android:summary="@string/pref_auto_lock_summary"
             app:iconSpaceReserved="false"/>
 
         <Preference


### PR DESCRIPTION
I made the "Auto lock" preference depend on the "Encryption" preference. The order is also changed and will it now be shown below the encryption preference.

If "Encryption" is disabled, the "auto lock" won't be visible.