### PR TITLE
Add AboutActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,11 +70,15 @@ dependencies {
     implementation "com.github.topjohnwu.libsu:io:${libsuVersion}"
     implementation 'com.github.bumptech.glide:annotations:4.9.0'
     implementation 'com.github.bumptech.glide:glide:4.9.0'
-    implementation ("com.github.bumptech.glide:recyclerview-integration:4.9.0") {
+    implementation "com.mikepenz:iconics-core:3.2.5"
+    implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.5@aar'
+    implementation 'de.psdev.licensesdialog:licensesdialog:2.1.0'
+    implementation("com.github.bumptech.glide:recyclerview-integration:4.9.0") {
         transitive = false
     }
     annotationProcessor 'androidx.annotation:annotation:1.1.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
         tools:ignore="GoogleAppIndexingWarning"
         tools:replace="android:theme">
         <activity
+            android:name=".ui.AboutActivity"
+            android:label="@string/title_activity_about"></activity>
+        <activity
             android:name=".ui.SelectEntriesActivity"
             android:label="Select entries" />
         <activity
@@ -26,12 +29,15 @@
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data android:scheme="otpauth" />
             </intent-filter>
         </activity>

--- a/app/src/main/assets/changelog.html
+++ b/app/src/main/assets/changelog.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+    <style type="text/css">
+        * {
+        word-wrap: break-word;
+        }
+        body {
+            background-color: #%1$s;
+            color: #%2$s;
+        }
+        ul {
+            list-style-position: inside;
+            padding: 0;
+            padding-left: 5px;
+        }
+        li {
+            padding-bottom: 8px;
+            list-style-position: outside;
+            margin-left: 1em;
+        }
+        h3 {
+            padding-bottom: 0;
+        }
+    </style>
+</head>
+<body>
+<div></div>
+<h3>Version 1.0</h3>
+<h4>New</h4>
+<ul>
+    <li>New icon</li>
+    <li>Overhaul of interaction with the entry list</li>
+    <li>Persistent notification while the vault is unlocked</li>
+    <li>Language override option</li>
+    <li>Support for importing from FreeOTP+</li>
+    <li>Ability to toggle password visibility during unlock</li>
+    <li>Support for deeplinking otpauth URIs</li>
+</ul>
+<h4>Fixes</h4>
+<ul>
+    <li>Bad overall performance and high battery usage</li>
+    <li>Codes with an uneven number of digits are displayed incorrectly</li>
+    <li>Crash when entering a large value for OTP period</li>
+</ul>
+</body>

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
@@ -1,0 +1,121 @@
+package com.beemdevelopment.aegis.ui;
+
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.graphics.Color;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import com.beemdevelopment.aegis.Preferences;
+import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.Theme;
+import com.beemdevelopment.aegis.helpers.ThemeHelper;
+import com.beemdevelopment.aegis.ui.glide.GlideLicense;
+import com.mikepenz.iconics.Iconics;
+import com.mikepenz.iconics.context.IconicsLayoutInflater2;
+import com.mikepenz.material_design_iconic_typeface_library.MaterialDesignIconic;
+
+import androidx.core.view.LayoutInflaterCompat;
+
+import de.psdev.licensesdialog.LicenseResolver;
+import de.psdev.licensesdialog.LicensesDialog;
+import de.psdev.licensesdialog.licenses.License;
+
+public class AboutActivity extends AegisActivity {
+
+    private static String GITHUB = "https://github.com/beemdevelopment/Aegis";
+    private static String WEBSITE_ALEXANDER = "https://alexbakker.me";
+    private static String GITHUB_MICHAEL = "https://github.com/michaelschattgen";
+
+    private static String MAIL_BEEMDEVELOPMENT = "beemdevelopment@gmail.com";
+    private static String WEBSITE_BEEMDEVELOPMENT = "https://beem.dev/";
+    private static String PLAYSTORE_BEEMDEVELOPMENT = "https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        LayoutInflaterCompat.setFactory2(getLayoutInflater(), new IconicsLayoutInflater2(getDelegate()));
+
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_about);
+
+        Iconics.init(getApplicationContext());
+        Iconics.registerFont(new MaterialDesignIconic());
+
+        View btnLicenses = findViewById(R.id.btn_licenses);
+        btnLicenses.setOnClickListener(v -> showLicenseDialog());
+
+        TextView appVersion = findViewById(R.id.app_version);
+        appVersion.setText(getCurrentVersion());
+
+        View btnGithub = findViewById(R.id.btn_github);
+        btnGithub.setOnClickListener(v -> openUrl(GITHUB));
+
+        View btnAlexander = findViewById(R.id.btn_alexander);
+        btnAlexander.setOnClickListener(v -> openUrl(WEBSITE_ALEXANDER));
+
+        View btnMichael = findViewById(R.id.btn_michael);
+        btnMichael.setOnClickListener(v -> openUrl(GITHUB_MICHAEL));
+
+        View btnMail = findViewById(R.id.btn_email);
+        btnMail.setOnClickListener(v -> openMail(MAIL_BEEMDEVELOPMENT));
+
+        View btnWebsite = findViewById(R.id.btn_website);
+        btnWebsite.setOnClickListener(v -> openUrl(WEBSITE_BEEMDEVELOPMENT));
+
+        View btnRate = findViewById(R.id.btn_rate);
+        btnRate.setOnClickListener(v -> openUrl(PLAYSTORE_BEEMDEVELOPMENT ));
+
+        View btnChangelog = findViewById(R.id.btn_changelog);
+        btnChangelog.setOnClickListener(v -> {
+            ChangelogDialog.create().setTheme(getCurrentTheme()).show(getSupportFragmentManager(), "CHANGELOG_DIALOG");
+        });
+    }
+
+    private String getCurrentVersion() {
+        try {
+            return getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        return "Unknown version";
+    }
+
+    private void openUrl(String url) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW);
+        browserIntent.setData(Uri.parse(url));
+        browserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        startActivity(browserIntent);
+    }
+
+    private void openMail(String mailaddress) {
+        Intent mailIntent = new Intent(Intent.ACTION_SENDTO);
+        mailIntent.setData(Uri.parse("mailto:" + mailaddress));
+        mailIntent.putExtra(Intent.EXTRA_EMAIL, mailaddress);
+        mailIntent.putExtra(Intent.EXTRA_SUBJECT, R.string.app_name_full);
+
+        startActivity(Intent.createChooser(mailIntent, this.getString(R.string.email)));
+    }
+
+    private void showLicenseDialog() {
+        String stylesheet = getString(R.string.custom_notices_format_style);
+        int backgroundColorResource = getCurrentTheme() == Theme.AMOLED ? R.attr.cardBackgroundFocused : R.attr.cardBackground;
+        String backgroundColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(backgroundColorResource, getTheme())));
+        String textColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(R.attr.primaryText, getTheme())));
+        String licenseColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(R.attr.cardBackgroundFocused, getTheme())));
+
+        stylesheet = String.format(stylesheet, backgroundColor, textColor, licenseColor);
+
+        LicenseResolver.registerLicense(new GlideLicense());
+        new LicensesDialog.Builder(this)
+                .setNotices(R.raw.notices)
+                .setTitle(R.string.licenses)
+                .setNoticesCssStyle(stylesheet)
+                .setIncludeOwnLicense(true)
+                .build()
+                .show();
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 public abstract class AegisActivity extends AppCompatActivity implements AegisApplication.LockListener {
     private boolean _resumed;
     private AegisApplication _app;
+    private Theme _currentTheme;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -89,6 +90,8 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
     }
 
     protected void setPreferredTheme(Theme theme) {
+        _currentTheme = theme;
+
         switch (theme) {
             case LIGHT:
                 setTheme(R.style.AppTheme);
@@ -135,5 +138,9 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
                 Toast.makeText(this, R.string.progressbar_error, Toast.LENGTH_SHORT).show();
             }
         }
+    }
+
+    protected Theme getCurrentTheme() {
+        return _currentTheme;
     }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/ChangelogDialog.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/ChangelogDialog.java
@@ -1,0 +1,90 @@
+package com.beemdevelopment.aegis.ui;
+
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.InflateException;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.webkit.WebView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.Theme;
+import com.beemdevelopment.aegis.helpers.ThemeHelper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+
+public class ChangelogDialog extends DialogFragment {
+    private Theme _themeStyle;
+
+    public static ChangelogDialog create() {
+        return new ChangelogDialog();
+    }
+
+    @SuppressLint("InflateParams")
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final View customView;
+        try {
+            customView = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_web_view, null);
+        } catch (InflateException e) {
+            e.printStackTrace();
+            return new AlertDialog.Builder(getActivity())
+                    .setTitle(android.R.string.dialog_alert_title)
+                    .setMessage(getString(R.string.webview_error))
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show();
+        }
+        AlertDialog dialog = new AlertDialog.Builder(getActivity())
+                .setTitle("Changelog")
+                .setView(customView)
+                .setPositiveButton(android.R.string.ok, null)
+                .show();
+
+        final WebView webView = customView.findViewById(R.id.web_view);
+        StringBuilder buf = new StringBuilder();
+
+        try (InputStream html = getActivity().getAssets().open("changelog.html")) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(html, "UTF-8"));
+            String str;
+            while ((str = in.readLine()) != null)
+                buf.append(str);
+
+            in.close();
+            String changelog = buf.toString();
+            changelog = replaceStylesheet(changelog);
+            webView.loadData(changelog, "text/html", "UTF-8");
+        } catch (IOException e) {
+            webView.loadData("<h1>Unable to load</h1><p>" + e.getLocalizedMessage() + "</p>", "text/html", "UTF-8");
+        }
+        return dialog;
+    }
+
+    private String replaceStylesheet(String changelog) {
+        int backgroundColorResource = _themeStyle == Theme.AMOLED ? R.attr.cardBackgroundFocused : R.attr.cardBackground;
+        String backgroundColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(backgroundColorResource, getContext().getTheme())));
+        String textColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(R.attr.primaryText, getContext().getTheme())));
+
+        return String.format(changelog, backgroundColor, textColor);
+    }
+
+    public ChangelogDialog setTheme(Theme theme) {
+        _themeStyle = theme;
+
+        return this;
+    }
+}
+

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -45,6 +45,7 @@ import com.google.zxing.RGBLuminanceSource;
 import com.google.zxing.Reader;
 import com.google.zxing.Result;
 import com.google.zxing.common.HybridBinarizer;
+import com.mikepenz.iconics.context.IconicsContextWrapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,6 +89,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         _app = (AegisApplication) getApplication();
         _db = _app.getDatabaseManager();
         _loaded = false;
@@ -497,6 +499,11 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     }
 
     @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(IconicsContextWrapper.wrap(newBase));
+    }
+
+    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         _menu = menu;
         getMenuInflater().inflate(R.menu.menu_main, menu);
@@ -542,10 +549,16 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.action_settings:
+            case R.id.action_settings: {
                 Intent intent = new Intent(this, PreferencesActivity.class);
                 startActivityForResult(intent, CODE_PREFERENCES);
                 return true;
+            }
+            case R.id.action_about: {
+                Intent intent = new Intent(this, AboutActivity.class);
+                startActivity(intent);
+                return true;
+            }
             case R.id.action_lock:
                 _app.lock();
                 return true;

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/glide/GlideLicense.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/glide/GlideLicense.java
@@ -1,0 +1,34 @@
+package com.beemdevelopment.aegis.ui.glide;
+
+import android.content.Context;
+
+import com.beemdevelopment.aegis.R;
+
+import de.psdev.licensesdialog.licenses.License;
+
+public class GlideLicense extends License {
+    @Override
+    public String getName() {
+        return "Glide License";
+    }
+
+    @Override
+    public String readSummaryTextFromResources(Context context) {
+        return getContent(context, R.raw.glide_license);
+    }
+
+    @Override
+    public String readFullTextFromResources(Context context) {
+        return getContent(context, R.raw.glide_license);
+    }
+
+    @Override
+    public String getVersion() {
+        return null;
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://github.com/bumptech/glide/blob/master/LICENSE";
+    }
+}

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:background="?attr/background"
+    tools:context="com.beemdevelopment.aegis.ui.AboutActivity">
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:isScrollContainer="true">
+
+        <include layout="@layout/content_about" />
+
+    </ScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_about.xml
+++ b/app/src/main/res/layout/content_about.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    app:cardUseCompatPadding="true">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardUseCompatPadding="true"
+        android:background="?attr/cardBackground"
+        android:layout_marginBottom="8dp"
+        tools:ignore="MissingPrefix">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="8dp"
+            android:background="?attr/cardBackground"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="72dp"
+                android:orientation="horizontal"
+                android:background="?attr/selectableItemBackground"
+                android:padding="16dp">
+
+                <ImageView
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:src="@mipmap/ic_launcher"
+                    tools:ignore="ContentDescription" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
+                    android:text="@string/app_name_full"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Headline" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-info-outline"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/version"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:id="@+id/app_version"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="0.0.0 (0)"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                        tools:ignore="HardcodedText" />
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_changelog"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:foreground="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-time-restore"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/changelog"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/whats_new"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_github"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-github"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/github"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/github_description"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_licenses"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-file-text"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/licenses"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/licenses_description"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardUseCompatPadding="true"
+        android:background="?attr/cardBackground"
+        android:layout_marginBottom="8dp"
+        tools:ignore="MissingPrefix">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="8dp"
+            android:background="?attr/cardBackground"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|center_vertical"
+                android:paddingLeft="16dp"
+                android:paddingTop="24dp"
+                android:paddingRight="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/org_name_full"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+                android:textColor="?android:textColorSecondary" />
+
+            <LinearLayout
+                android:id="@+id/btn_alexander"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/list_item_height"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-account"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/author_alex"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/country_netherlands"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_michael"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/list_item_height"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-account"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/author_michael"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/country_netherlands"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/list_item_height"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-email"
+                    app:ico_size="16dp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
+                    android:text="@string/email_us"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/btn_website"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/list_item_height"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-globe"
+                    app:ico_size="16dp" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
+                    android:text="@string/visit_website"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardUseCompatPadding="true"
+        android:layout_marginBottom="8dp"
+        android:background="?attr/cardBackground"
+        tools:ignore="MissingPrefix">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="8dp"
+            android:background="?attr/cardBackground"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|center_vertical"
+                android:paddingLeft="16dp"
+                android:paddingTop="24dp"
+                android:paddingRight="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/about_support"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+                android:textColor="?android:textColorSecondary" />
+
+            <LinearLayout
+                android:id="@+id/btn_rate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:foreground="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:gravity="center_vertical"
+                android:minHeight="@dimen/list_item_height"
+                android:orientation="horizontal"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    app:ico_color="@color/icon_about"
+                    app:ico_icon="gmi-star"
+                    app:ico_size="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginLeft="32dp"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/support_rate"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/support_rate_description"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_web_view.xml
+++ b/app/src/main/res/layout/dialog_web_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
+
+    <WebView
+        android:id="@+id/web_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none" />
+
+</FrameLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -63,4 +63,9 @@
         android:orderInCategory="100"
         android:title="@string/action_settings"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_about"
+        android:orderInCategory="110"
+        android:title="@string/action_about"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/raw/glide_license.txt
+++ b/app/src/main/res/raw/glide_license.txt
@@ -1,0 +1,94 @@
+License for everything not in third_party and not otherwise marked:
+
+Copyright 2014 Google, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+         conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+         of conditions and the following disclaimer in the documentation and/or other materials
+         provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY GOOGLE, INC. ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the
+authors and should not be interpreted as representing official policies, either expressed
+or implied, of Google, Inc.
+---------------------------------------------------------------------------------------------
+License for third_party/disklrucache:
+
+Copyright 2012 Jake Wharton
+Copyright 2011 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+---------------------------------------------------------------------------------------------
+License for third_party/gif_decoder:
+
+Copyright (c) 2013 Xcellent Creations, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---------------------------------------------------------------------------------------------
+License for third_party/gif_encoder/AnimatedGifEncoder.java and
+third_party/gif_encoder/LZWEncoder.java:
+
+No copyright asserted on the source code of this class. May be used for any
+purpose, however, refer to the Unisys LZW patent for restrictions on use of
+the associated LZWEncoder class. Please forward any corrections to
+kweiner@fmsware.com.
+
+-----------------------------------------------------------------------------
+License for third_party/gif_encoder/NeuQuant.java
+
+Copyright (c) 1994 Anthony Dekker
+
+NEUQUANT Neural-Net quantization algorithm by Anthony Dekker, 1994. See
+"Kohonen neural networks for optimal colour quantization" in "Network:
+Computation in Neural Systems" Vol. 5 (1994) pp 351-367. for a discussion of
+the algorithm.
+
+Any party obtaining a copy of these files from the author, directly or
+indirectly, is granted, free of charge, a full and unrestricted irrevocable,
+world-wide, paid up, royalty-free, nonexclusive right and license to deal in
+this software and documentation files (the "Software"), including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons who
+receive copies from any such party to do so, with the only requirement being
+that this copyright notice remain intact.

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<notices>
+    <notice>
+        <name>TextDrawable</name>
+        <url>https://github.com/amulyakhare/TextDrawable</url>
+        <copyright>Copyright (C) 2014 Amulya Khare</copyright>
+        <license>MIT License</license>
+    </notice>
+    <notice>
+        <name>Preferencex</name>
+        <url>https://github.com/takisoft/preferencex-android</url>
+        <copyright />
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>FloatingActionButton</name>
+        <url>https://github.com/futuresimple/android-floating-action-button</url>
+        <copyright>Copyright 2014 Jerzy Chalupski</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>AppIntro</name>
+        <url>https://github.com/AppIntro/AppIntro</url>
+        <copyright/>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Krop</name>
+        <url>https://github.com/avito-tech/krop</url>
+        <copyright>Copyright (c) 2017 Avito Technology</copyright>
+        <license>MIT License</license>
+    </notice>
+    <notice>
+        <name>Spongycastle</name>
+        <url>https://github.com/rtyley/spongycastle/</url>
+        <copyright>Copyright (c) 2000-2017 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Swirl</name>
+        <url>https://github.com/mattprecious/swirl</url>
+        <copyright>Copyright 2016 Matthew Precious</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>CircleImageView</name>
+        <url>https://github.com/hdodenhof/CircleImageView</url>
+        <copyright>Copyright 2014 - 2019 Henning Dodenhof</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Barcodescanner</name>
+        <url>https://github.com/dm77/barcodescanner</url>
+        <copyright>Copyright (c) 2014 Dushyanth Maguluru</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>libsu</name>
+        <url>https://github.com/topjohnwu/libsu</url>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Glide</name>
+        <url>https://github.com/bumptech/glide</url>
+        <license>Glide License</license>
+    </notice>
+    <notice>
+        <name>Iconics</name>
+        <url>https://github.com/mikepenz/Android-Iconics</url>
+        <copyright/>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Android Support Libraries</name>
+        <url>http://developer.android.com/tools/support-library/index.html</url>
+        <copyright>Copyright (C) 2016 The Android Open Source Project</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+</notices>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="colorAccentPressed">#FF5252</color>
     <color name="primary_text">#212121</color>
     <color name="secondary_text">#757575</color>
+    <color name="icon_about">#757575</color>
     <color name="extra_info_text">#8e8e8e</color>
     <color name="primary_text_inverted">#ffffff</color>
     <color name="secondary_text_inverted">#efefef</color>b
@@ -31,7 +32,7 @@
     <color name="code_primary_text">#0d47a1</color>
     <color name="code_primary_text_dark">#ffffff</color>
 
-    <color name="card_background_dark">#424242</color>
+    <color name="card_background_dark">#363636</color>
     <color name="card_background_focused_dark">#6B6B6B</color>
     <color name="card_background_focused_true_dark">#1B1B1B</color>
     <color name="primary_text_dark">#ffffff</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
+    <dimen name="list_item_height">48dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,9 @@
     <string name="app_name">Aegis</string>
     <string name="app_name_full">Aegis Authenticator</string>
     <string name="app_name_dev">AegisDev</string>
+    <string name="org_name_full">Beem Development</string>
     <string name="action_settings">Settings</string>
+    <string name="action_about">About</string>
     <string name="action_import">Import</string>
     <string name="action_delete">Delete</string>
     <string name="action_default_icon">Restore default icon</string>
@@ -171,6 +173,38 @@
     <string name="channel_name_lock_status">Lock status</string>
     <string name="channel_description_lock_status">Aegis can create a persistent notification to notify you when the vault is locked</string>
     <string name="vault_unlocked_state">Vault is unlocked. Tap here to lock.</string>
+    <string name="title_activity_about">About</string>
+    <string name="version">Version</string>
+    <string name="changelog">Changelog</string>
+    <string name="whats_new">What\'s new</string>
+    <string name="github">GitHub</string>
+    <string name="github_description">Source code, issues and information</string>
+    <string name="licenses">Licenses</string>
+    <string name="licenses_description">Licenses of the libraries Aegis uses</string>
+    <string name="author_alex">Alexander Bakker</string>
+    <string name="country_netherlands">Netherlands</string>
+    <string name="author_michael">Michael Schättgen</string>
+    <string name="email_us">Write an email</string>
+    <string name="visit_website">Visit our website</string>
+    <string name="about_support">Support</string>
+    <string name="support_rate">Rate</string>
+    <string name="support_rate_description">Support us by leaving a review in the Google Play Store</string>
+    <string name="webview_error">This device doesn\'t support web view, which is necessary to view the change log. It is missing a system component.</string>
+    <string name="email">Email</string>
+
+    <string name="custom_notices_format_style" translatable="false" >
+        body {
+            background-color: #%1$s;
+            color: #%2$s;
+            font-family: sans-serif;
+            overflow-wrap: break-word;
+        }
+        pre {
+            background-color: #%3$s;
+            padding: 1em;
+            white-space: pre-wrap;
+        }
+    </string>
     <string name="empty_list">There are no codes to be shown. Start adding entries by tapping the plus sign in the bottom right corner</string>
     <string name="empty_list_title">No entries found</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,8 +17,9 @@
         <item name="android:windowIsTranslucent">true</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="primaryText">@color/primary_text</item>
@@ -39,34 +40,43 @@
 
         <item name="actionModeStyle">@style/ActionModeStyle</item>
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <item name="alertDialogTheme">@style/DialogStyle</item>
     </style>
+
     <style name="ActionModeStyle" parent="@style/Widget.AppCompat.Light.ActionMode.Inverse">
         <item name="background">@color/colorPrimary</item>
         <item name="titleTextStyle">@style/ActionModeTitleTextStyle</item>
         <item name="iconColorPrimary">@color/icon_primary</item>
         <item name="iconColorInverted">@color/icon_primary_inverted</item>
     </style>
+
     <style name="ActionModeStyle.Dark" parent="@style/Widget.AppCompat.Light.ActionMode.Inverse">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="background">@color/colorPrimary</item>
         <item name="titleTextStyle">@style/ActionModeTitleTextStyle</item>
         <item name="iconColorPrimary">@color/icon_primary</item>
         <item name="iconColorInverted">@color/icon_primary_inverted</item>
+        <item name="alertDialogStyle">@style/DialogStyle.Dark</item>
     </style>
+
     <style name="ActionModeStyle.TrueBlack" parent="@style/Widget.AppCompat.Light.ActionMode.Inverse">
         <item name="colorPrimary">@color/background_true_dark</item>
         <item name="background">@color/background_true_dark</item>
         <item name="titleTextStyle">@style/ActionModeTitleTextStyle</item>
         <item name="iconColorPrimary">@color/icon_primary</item>
         <item name="iconColorInverted">@color/icon_primary_inverted</item>
+        <item name="alertDialogStyle">@style/DialogStyle.TrueDark</item>
     </style>
+
     <style name="ActionModeTitleTextStyle" parent="@style/TextAppearance.AppCompat.Widget.ActionMode.Title">
         <item name="android:textColor">@android:color/white</item>
     </style>
+
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+
     <style name="AppTheme.TransparentActionBar">
         <item name="android:actionBarStyle">@style/ThemeActionBar</item>
         <item name="android:windowActionBarOverlay">true</item>
@@ -74,6 +84,7 @@
         <item name="actionBarStyle">@style/ThemeActionBar</item>
         <item name="windowActionBarOverlay">true</item>
     </style>
+
     <style name="AppTheme.Fullscreen" parent="AppTheme.TransparentActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>
@@ -97,6 +108,8 @@
         <item name="swirl_errorColor">@color/colorSwirlErrorDark</item>
 
         <item name="actionModeStyle">@style/ActionModeStyle.Dark</item>
+        <item name="alertDialogTheme">@style/DialogStyle.Dark</item>
+
     </style>
 
     <style name="AppTheme.TrueBlack" parent="AppTheme.Dark">
@@ -107,6 +120,8 @@
         <item name="colorPrimaryDark">@color/background_true_dark</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="actionModeStyle">@style/ActionModeStyle.TrueBlack</item>
+        <item name="alertDialogTheme">@style/DialogStyle.TrueDark</item>
+
     </style>
 
     <style name="AppTheme.TrueBlack.Preferences" parent="AppTheme.TrueBlack">
@@ -117,6 +132,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+
     <style name="AppTheme.Dark.TransparentActionBar">
         <item name="android:actionBarStyle">@style/ThemeActionBar</item>
         <item name="android:windowActionBarOverlay">true</item>
@@ -129,5 +145,35 @@
         <item name="android:background">@drawable/fab_label_background</item>
         <item name="android:textColor">#FFFFFF</item>
     </style>
+
+    <style name="AppTheme.NoActionBar.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="DialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:background">@color/card_background</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="textColorAlertDialogListItem">@color/primary_text</item>
+    </style>
+
+    <style name="DialogStyle.Dark" parent="Theme.AppCompat.Dialog">
+        <item name="android:background">@color/card_background_dark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="textColorAlertDialogListItem">@color/primary_text_dark</item>
+
+        <!--The following lines are needed because the non-light version of this parent changes the
+        min width to 80% or something. Looks weird.-->
+        <item name="android:windowMinWidthMajor">97%</item>
+        <item name="android:windowMinWidthMinor">97%</item>
+    </style>
+
+    <style name="DialogStyle.TrueDark" parent="DialogStyle.Dark">
+        <item name="android:background">@color/card_background_focused_true_dark</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="AppTheme.NoActionBar.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 10 14:39:47 CEST 2019
+#Sun Sep 01 21:12:20 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
This pull requests adds a new AboutActivity which is available from the overflow (3-dots) menu in the MainActivity. It currently looks like this but there is room for improvement.

<img src="https://user-images.githubusercontent.com/7524012/64285906-c759c200-cf5c-11e9-9e45-746f57246835.png" width=300 /> <img src="https://user-images.githubusercontent.com/7524012/64286000-f1ab7f80-cf5c-11e9-83fc-4af68f2fde29.png" width=300 />

I've also made light, dark and amoled themes for the dialogs which were needed for the "Licenses" and "Changelog" dialogs.

Closes #137