### PR TITLE
Add ability to search in account names

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -19,6 +19,8 @@ public class Preferences {
         return _prefs.getBoolean("pref_tap_to_reveal", false);
     }
 
+    public boolean isSearchAccountNameEnabled() { return _prefs.getBoolean("pref_search_names", false); }
+
     public boolean isSecureScreenEnabled() {
         // screen security should be enabled by default, but not for debug builds
         return _prefs.getBoolean("pref_secure_screen", !BuildConfig.DEBUG);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -101,6 +101,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _entryListView = (EntryListView) getSupportFragmentManager().findFragmentById(R.id.key_profiles);
         _entryListView.setListener(this);
         _entryListView.setShowAccountName(getPreferences().isAccountNameVisible());
+        _entryListView.setSearchAccountName(getPreferences().isSearchAccountNameEnabled());
         _entryListView.setTapToReveal(getPreferences().isTapToRevealEnabled());
         _entryListView.setTapToRevealTime(getPreferences().getTapToRevealTime());
         _entryListView.setSortCategory(getPreferences().getCurrentSortCategory(), false);
@@ -216,10 +217,12 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             recreate();
         } else if (data.getBooleanExtra("needsRefresh", false)) {
             boolean showAccountName = getPreferences().isAccountNameVisible();
+            boolean searchAccountName = getPreferences().isSearchAccountNameEnabled();
             boolean tapToReveal = getPreferences().isTapToRevealEnabled();
             int tapToRevealTime = getPreferences().getTapToRevealTime();
             ViewMode viewMode = getPreferences().getCurrentViewMode();
             _entryListView.setShowAccountName(showAccountName);
+            _entryListView.setSearchAccountName(searchAccountName);
             _entryListView.setTapToReveal(tapToReveal);
             _entryListView.setTapToRevealTime(tapToRevealTime);
             _entryListView.setViewMode(viewMode);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -201,6 +201,12 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
             }
         });
 
+        Preference searchAccountNamePreference = findPreference("pref_search_names");
+        searchAccountNamePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            _result.putExtra("needsRefresh", true);
+            return true;
+        });
+
         Preference tapToRevealPreference = findPreference("pref_tap_to_reveal");
         tapToRevealPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             _result.putExtra("needsRefresh", true);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -26,6 +26,7 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
     private List<DatabaseEntry> _shownEntries;
     private DatabaseEntry _selectedEntry;
     private boolean _showAccountName;
+    private boolean _searchAccountName;
     private boolean _tapToReveal;
     private int _tapToRevealTime;
     private String _groupFilter;
@@ -62,6 +63,8 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
     public void setTapToRevealTime(int number) {
         _tapToRevealTime = number;
     }
+
+    public void setSearchAccountName(boolean searchAccountName) { _searchAccountName = searchAccountName; }
 
     public DatabaseEntry getEntryAt(int position) {
         return _shownEntries.get(position);
@@ -153,12 +156,17 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
     private boolean isEntryFiltered(DatabaseEntry entry) {
         String group = entry.getGroup();
         String issuer = entry.getIssuer().toLowerCase();
+        String name = entry.getName().toLowerCase();
 
         if (_groupFilter != null && (group == null || !group.equals(_groupFilter))) {
             return true;
         }
 
-        return _searchFilter != null && !issuer.contains(_searchFilter);
+        if (_searchFilter == null) {
+            return false;
+        }
+
+        return !issuer.contains(_searchFilter) && !(_searchAccountName && name.contains(_searchFilter));
     }
 
     public void refresh(boolean hard) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -211,6 +211,10 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         _adapter.setShowAccountName(showAccountName);
     }
 
+    public void setSearchAccountName(boolean searchAccountName) {
+        _adapter.setSearchAccountName(searchAccountName);
+    }
+
     public void setTapToReveal(boolean tapToReveal) {
         _adapter.setTapToReveal(tapToReveal);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
 
     <string name="settings">Preferences</string>
     <string name="pref_appearance_group_title">Appearance</string>
+    <string name="pref_general_group_title">General</string>
     <string name="pref_security_group_title">Security</string>
     <string name="pref_tools_group_title">Tools</string>
     <string name="pref_select_theme_title">Theme</string>
@@ -155,6 +156,8 @@
     <string name="group_name_hint">Group name</string>
     <string name="preference_manage_groups">Edit groups</string>
     <string name="preference_manage_groups_summary">Manage and delete your groups here</string>
+    <string name="pref_search_name_title">Search in account names</string>
+    <string name="pref_search_name_summary">Include account name matches in the search results</string>
     <string name="tap_to_reveal">Hidden</string>
     <string name="selected">Selected</string>
     <string name="dark_theme_title">Dark theme</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -43,6 +43,17 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/pref_general_group_title"
+        app:iconSpaceReserved="false">
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_search_names"
+            android:title="@string/pref_search_name_title"
+            android:summary="@string/pref_search_name_summary"
+            app:iconSpaceReserved="false"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/pref_security_group_title"
         app:iconSpaceReserved="false">
         <androidx.preference.SwitchPreferenceCompat


### PR DESCRIPTION
This pull requests adds an additional preference item which allows the user to include account name matches in the search results as suggested in #197.

<img src="https://user-images.githubusercontent.com/7524012/64726155-51aea280-d4d6-11e9-8b09-5119c13aaacb.png" width="250"/> <img src="https://user-images.githubusercontent.com/7524012/64726239-7c98f680-d4d6-11e9-913a-1c5e758e9f84.png" width="250"/>

Closes #197

