### PR TITLE
Add support for the new andOTP backup format

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,9 @@
     <string name="enable_encryption_error">An error occurred while enabling encryption</string>
     <string name="disable_encryption_error">An error occurred while disabling encryption</string>
     <string name="permission_denied">Permission denied</string>
+    <string name="andotp_new_format">New format (v0.6.3 or newer) </string>
+    <string name="andotp_old_format">Old format (v0.6.2 or older) </string>
+    <string name="choose_andotp_importer">Which format does the andOTP backup file have?</string>
     <string name="choose_application">Select the application you\'d like to import a database from</string>
     <string name="choose_theme">Select your desired theme</string>
     <string name="choose_view_mode">Select your desired view mode</string>


### PR DESCRIPTION
This patch adds support for the new backup file format of andOTP. andOTP has improved their security by switching from SHA-256 to PBKDF2 to derive the key for encrypted backups.

Glad to see this has been addressed now. Awesome work, @flocke!

See: andOTP/andOTP@d96b037.

Close #215.