### PR TITLE
Explicitly state in AndroidManifest that a camera is not required

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+
     <application
         android:name=".AegisApplication"
         android:allowBackup="false"


### PR DESCRIPTION
This hopefully fixes #226. I tested this on a Chromebook emulator, but it let me install the app even without this patch, so we'll have to wait and see if this fixes it when we release a new version.