### PR TITLE
Fix exception when importing an old export

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/ProgressDialogTask.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/ProgressDialogTask.java
@@ -9,7 +9,7 @@ import com.beemdevelopment.aegis.ui.Dialogs;
 
 import androidx.annotation.CallSuper;
 
-public abstract class ProgressDialogTask<Params, Result> extends AsyncTask<Params, Void, Result> {
+public abstract class ProgressDialogTask<Params, Result> extends AsyncTask<Params, String, Result> {
     private ProgressDialog _dialog;
 
     public ProgressDialogTask(Context context, String message) {
@@ -30,6 +30,13 @@ public abstract class ProgressDialogTask<Params, Result> extends AsyncTask<Param
     protected void onPostExecute(Result result) {
         if (_dialog.isShowing()) {
             _dialog.dismiss();
+        }
+    }
+
+    @Override
+    protected void onProgressUpdate(String... values) {
+        if (values.length == 1) {
+            _dialog.setMessage(values[0]);
         }
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/SlotListTask.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/SlotListTask.java
@@ -1,6 +1,5 @@
 package com.beemdevelopment.aegis.ui.tasks;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 
 import com.beemdevelopment.aegis.R;
@@ -72,8 +71,7 @@ public class SlotListTask<T extends Slot> extends ProgressDialogTask<SlotListTas
                 throw e;
             }
 
-            ProgressDialog dialog = getDialog();
-            dialog.setMessage(dialog.getContext().getString(R.string.unlocking_vault_repair));
+            publishProgress(getDialog().getContext().getString(R.string.unlocking_vault_repair));
 
             // try to decrypt the password slot with the old key
             SecretKey oldKey = slot.deriveKey(oldPasswordBytes);


### PR DESCRIPTION
The import failed because `Dialog.setMessage()` happens on the wrong thread. I decided to use the progress update mechanism, as `new Handler(Looper.getMainLooper()).post(runnable)` felt more awkward than it needed to be. If you don't agree feel free to do it differently.