### PR TITLE
Set requestLegacyExternalStorage to true in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar"
         tools:ignore="GoogleAppIndexingWarning"
-        tools:replace="android:theme">
+        tools:replace="android:theme"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".ui.AboutActivity"
             android:label="@string/title_activity_about"></activity>


### PR DESCRIPTION
This is a temporary workaround for #274 while we work on support for the Storage Access Framework.