### PR TITLE
Rewrite the export functionality to use the Storage Access Framework

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,8 +19,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar"
         tools:ignore="GoogleAppIndexingWarning"
-        tools:replace="android:theme"
-        android:requestLegacyExternalStorage="true">
+        tools:replace="android:theme">
         <activity
             android:name=".ui.AboutActivity"
             android:label="@string/title_activity_about"></activity>

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -2,10 +2,7 @@ package com.beemdevelopment.aegis.vault;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.Environment;
 
-import com.beemdevelopment.aegis.BuildConfig;
-import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.services.NotificationService;
 
 import org.json.JSONObject;
@@ -15,14 +12,15 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.text.Collator;
 import java.util.Collection;
 import java.util.TreeSet;
 
 public class VaultManager {
     private static final String FILENAME = "aegis.json";
-    private static final String FILENAME_EXPORT = "aegis_export.json";
-    private static final String FILENAME_EXPORT_PLAIN = "aegis_export_plain.json";
+    public static final String FILENAME_EXPORT = "aegis_export";
+    public static final String FILENAME_EXPORT_PLAIN = "aegis_export_plain";
 
     private Vault _vault;
     private VaultFile _file;
@@ -104,7 +102,7 @@ public class VaultManager {
         }
     }
 
-    public String export(boolean encrypt) throws VaultManagerException {
+    public void export(OutputStream stream, boolean encrypt) throws VaultManagerException {
         assertState(false, true);
 
         try {
@@ -115,19 +113,8 @@ public class VaultManager {
                 vaultFile.setContent(_vault.toJson());
             }
 
-            String dirName = !BuildConfig.DEBUG ? _context.getString(R.string.app_name) : _context.getString(R.string.app_name_dev);
-            File dir = new File(Environment.getExternalStorageDirectory(), dirName);
-            if (!dir.exists() && !dir.mkdirs()) {
-                throw new IOException("error creating external storage directory");
-            }
-
             byte[] bytes = vaultFile.toBytes();
-            File file = new File(dir.getAbsolutePath(), encrypt ? FILENAME_EXPORT : FILENAME_EXPORT_PLAIN);
-            try (FileOutputStream stream = new FileOutputStream(file)) {
-                stream.write(bytes);
-            }
-
-            return file.getAbsolutePath();
+            stream.write(bytes);
         } catch (IOException | VaultFileException e) {
             throw new VaultManagerException(e);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="read_entries_count">Read %d entries. %d errors.</string>
     <string name="import_error_title">One or more errors occurred during the import</string>
     <string name="exporting_vault_error">An error occurred while trying to export the vault</string>
-    <string name="export_vault_location">The vault has been exported to:</string>
+    <string name="exported_vault">The vault has been exported</string>
     <string name="export_warning">This action will export the vault out of Aegis\' private storage.</string>
     <string name="encryption_set_password_error">An error occurred while trying to set the password: </string>
     <string name="encryption_enable_biometrics_error">An error occurred while trying to enable biometric unlock</string>


### PR DESCRIPTION
We noticed after the v1.1 release that we need to switch our external storage access code over to use the Storage Access Framework. The export functionality was the only piece of code that still used the deprecated method and this patch addresses that.

The Storage Access Framework is a little annoying to work with, but I don't think it'll be too painful for our usecase. This switch comes with some nice benefits for users as well. Users are now able to select a custom storage location, which can be local or in the cloud.

This also removes ``requestLegacyExternalStorage`` from the manifest, as we don't need it anymore.