### PR TITLE
Add ability to select multiple entries

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
@@ -57,6 +57,24 @@ public class Dialogs {
                 .create());
     }
 
+    public static void showDeleteEntriesDialog(Activity activity, DialogInterface.OnClickListener onDelete, int totalEntries) {
+        String title, message;
+        if (totalEntries > 1) {
+            title = activity.getString(R.string.delete_entries);
+            message = String.format(activity.getString(R.string.delete_entries_description), totalEntries);
+        } else {
+            title = activity.getString(R.string.delete_entry);
+            message = activity.getString(R.string.delete_entry_description);
+        }
+
+        showSecureDialog(new AlertDialog.Builder(activity)
+                .setTitle(title)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.yes, onDelete)
+                .setNegativeButton(android.R.string.no, null)
+                .create());
+    }
+
     public static void showDiscardDialog(Activity activity, DialogInterface.OnClickListener onSave, DialogInterface.OnClickListener onDiscard) {
         showSecureDialog(new AlertDialog.Builder(activity)
                 .setTitle(activity.getString(R.string.discard_changes))

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -132,10 +132,14 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         }
     }
 
+    public void setIsLongPressDragEnabled(boolean enabled) {
+        _touchCallback.setIsLongPressDragEnabled(enabled);
+    }
+
     public void setActionModeState(boolean enabled, VaultEntry entry) {
         _touchCallback.setSelectedEntry(entry);
         _touchCallback.setIsLongPressDragEnabled(enabled && _adapter.isDragAndDropAllowed());
-        _adapter.setSelectedEntry(entry);
+        _adapter.addSelectedEntry(entry);
     }
 
     public void setSortCategory(SortCategory sortCategory, boolean apply) {
@@ -193,6 +197,12 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
     public void onEntryChange(VaultEntry entry) {
         _listener.onEntryChange(entry);
     }
+
+    @Override
+    public void onSelect(VaultEntry entry) { _listener.onSelect(entry); }
+
+    @Override
+    public void onDeselect(VaultEntry entry) { _listener.onDeselect(entry); }
 
     @Override
     public void onPeriodUniformityChanged(boolean isUniform) {
@@ -298,6 +308,8 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         void onEntryChange(VaultEntry entry);
         void onLongEntryClick(VaultEntry entry);
         void onScroll(int dx, int dy);
+        void onSelect(VaultEntry entry);
+        void onDeselect(VaultEntry entry);
     }
 
     private class VerticalSpaceItemDecoration extends RecyclerView.ItemDecoration {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,8 @@
     <string name="encrypting_vault">Encrypting the vault</string>
     <string name="delete_entry">Delete entry</string>
     <string name="delete_entry_description">Are you sure you want to delete this entry?</string>
+    <string name="delete_entries">Delete entries</string>
+    <string name="delete_entries_description">Are you sure you want to delete %d entries?</string>
     <string name="discard_changes">Discard changes?</string>
     <string name="discard_changes_description">Your changes have not been saved</string>
     <string name="folder">Folder</string>


### PR DESCRIPTION
This pull request adds the ability to select multiple entries as proposed in #277.

It automatically disables the copy, edit and drag features as these are not supported when having multiple entries selected. Please test this feature with 'tap to reveal' / 'highlight' enabled and disabled.