### PR TITLE
Fix setting locale on 7.0

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -110,7 +110,7 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
         Configuration config = new Configuration();
         config.locale = locale;
 
-        getBaseContext().getResources().updateConfiguration(config, getBaseContext().getResources().getDisplayMetrics());
+        this.getResources().updateConfiguration(config, this.getResources().getDisplayMetrics());
     }
 
     /**

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Window;
 import android.view.WindowManager;
@@ -129,11 +130,16 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         });
 
         Preference langPreference = findPreference("pref_lang");
-        langPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-            _result.putExtra("needsRecreate", true);
-            getActivity().recreate();
-            return true;
-        });
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            langPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                _result.putExtra("needsRecreate", true);
+                getActivity().recreate();
+                return true;
+            });
+        } else {
+            // Setting locale doesn't work on Marshmallow or below
+            langPreference.setVisible(false);
+        }
 
         int currentViewMode = app.getPreferences().getCurrentViewMode().ordinal();
         Preference viewModePreference = findPreference("pref_view_mode");


### PR DESCRIPTION
This pull request fixes the bug with setting locale on Android 7.0 as reported in #287. 

I also hid the 'Language'-preference on KitKat since it doesn't work on Kitkat.