### PR TITLE
Set confirmation not required on BiometricPrompt

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -191,6 +191,7 @@ public class AuthActivity extends AegisActivity implements SlotListTask.Callback
         BiometricPrompt.PromptInfo info = new BiometricPrompt.PromptInfo.Builder()
                 .setTitle(getString(R.string.authentication))
                 .setNegativeButtonText(getString(android.R.string.cancel))
+                .setConfirmationRequired(false)
                 .build();
         _bioPrompt.authenticate(info, _bioCryptoObj);
     }


### PR DESCRIPTION
I only added it to the AuthActivity since I think it's nice to have a confirmation while setting it up.

Fixes #321