### PR TITLE
Replace SpongyCastle with BouncyCastle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'com.github.apl-devs:appintro:6.0.0'
     implementation 'com.github.avito-tech:krop:0.44'
-    implementation 'com.madgag.spongycastle:core:1.58.0.0'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.65'
     implementation 'de.hdodenhof:circleimageview:3.0.1'
     implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation "com.github.topjohnwu.libsu:core:${libsuVersion}"

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore regexp="X509LDAPCertStoreSpi" />
+    </issue>
+</lint>

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,4 @@
 -keep class com.beemdevelopment.aegis.importers.** { *; }
 
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+-keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi { *; }

--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
@@ -2,7 +2,8 @@ package com.beemdevelopment.aegis.crypto;
 
 import android.os.Build;
 
-import org.spongycastle.crypto.generators.SCrypt;
+import org.bouncycastle.crypto.generators.SCrypt;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -12,7 +13,9 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
 
@@ -35,6 +38,15 @@ public class CryptoUtils {
     public static final int CRYPTO_SCRYPT_N = 1 << 15;
     public static final int CRYPTO_SCRYPT_r = 8;
     public static final int CRYPTO_SCRYPT_p = 1;
+
+    // replace the BC provider from Android with the one bundled with the app
+    static {
+        final Provider provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+        if (provider != null && !provider.getClass().equals(BouncyCastleProvider.class)) {
+            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
 
     public static SecretKey deriveKey(byte[] input, SCryptParameters params) {
         byte[] keyBytes = SCrypt.generate(input, params.getSalt(), params.getN(), params.getR(), params.getP(), CRYPTO_AEAD_KEY_SIZE);

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,7 +93,7 @@
     <string name="delete_entry">删除条目</string>
     <string name="delete_entry_description">您确定要删除这个条目吗？</string>
     <string name="delete_entries">删除条目</string>
-    <string name="delete_entries_description">您确定要删除 ％d 个条目吗？</string>
+    <string name="delete_entries_description">您确定要删除 %d 个条目吗？</string>
     <string name="discard_changes">放弃更改？</string>
     <string name="discard_changes_description">您的更改尚未保存</string>
     <string name="folder">文件夹</string>


### PR DESCRIPTION
SpongyCastle is a fork of BouncyCastle. We originally used this fork to 1) have access to scrypt and 2) prevent a package name collision with the bundled BouncyCastle. We don't actually need to use the fork anymore, because the package name of the bundled BouncyCastle was changed in Android. SpongyCastle has also gotten quite outdated in recent years.

The built-in version of BouncyCastle is replaced with the one bundled with the app at runtime, so that we have a recent version even on older Android versions.

This also updates Gradle and the Gradle Android plugin, to fix a build error I was running into when I added the dependency to BouncyCastle.

Fixes #360.