### PR TITLE
automatically adapt to system theme

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -90,7 +90,7 @@ public class Preferences {
     }
 
     public Theme getCurrentTheme() {
-        return Theme.fromInteger(_prefs.getInt("pref_current_theme", 0));
+        return Theme.fromInteger(_prefs.getInt("pref_current_theme", Theme.SYSTEM.ordinal()));
     }
 
     public void setCurrentTheme(Theme theme) {

--- a/app/src/main/java/com/beemdevelopment/aegis/Theme.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Theme.java
@@ -3,7 +3,9 @@ package com.beemdevelopment.aegis;
 public enum Theme {
     LIGHT,
     DARK,
-    AMOLED;
+    AMOLED,
+    SYSTEM,
+    SYSTEM_AMOLED;
 
     private static Theme[] _values;
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -89,6 +89,19 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
     }
 
     protected void setPreferredTheme(Theme theme) {
+        if (theme == Theme.SYSTEM || theme == Theme.SYSTEM_AMOLED) {
+            // set the theme based on the system theme
+            int currentNightMode = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+            switch (currentNightMode) {
+                case Configuration.UI_MODE_NIGHT_NO:
+                    theme = Theme.LIGHT;
+                    break;
+                case Configuration.UI_MODE_NIGHT_YES:
+                    theme = theme == Theme.SYSTEM_AMOLED ? Theme.AMOLED : Theme.DARK;
+                    break;
+            }
+        }
+
         _currentTheme = theme;
 
         switch (theme) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -39,21 +39,4 @@ public class PreferencesActivity extends AegisActivity {
         outState.putParcelable("result", _fragment.getResult());
         super.onSaveInstanceState(outState);
     }
-
-    @Override
-    protected void setPreferredTheme(Theme theme) {
-        switch (theme) {
-            case LIGHT:
-                setTheme(R.style.AppTheme);
-                break;
-
-            case DARK:
-                setTheme(R.style.AppTheme_Dark);
-                break;
-
-            case AMOLED:
-                setTheme(R.style.AppTheme_TrueBlack_Preferences);
-                break;
-        }
-    }
 }

--- a/app/src/main/res/values-v29/strings.xml
+++ b/app/src/main/res/values-v29/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="system_theme_title">System default</string>
+    <string name="system_amoled_theme_title">System default (AMOLED)</string>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -22,6 +22,8 @@
         <item>@string/light_theme_title</item>
         <item>@string/dark_theme_title</item>
         <item>@string/amoled_theme_title</item>
+        <item>@string/system_theme_title</item>
+        <item>@string/system_amoled_theme_title</item>
     </string-array>
 
     <string-array name="view_mode_titles">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,6 +189,8 @@
     <string name="dark_theme_title">Dark theme</string>
     <string name="light_theme_title">Light theme</string>
     <string name="amoled_theme_title">AMOLED theme</string>
+    <string name="system_theme_title">Set by Battery Saver</string>
+    <string name="system_amoled_theme_title">Set by Battery Saver (AMOLED)</string>
     <string name="normal_viewmode_title">Normal</string>
     <string name="compact_mode_title">Compact</string>
     <string name="small_mode_title">Small</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -70,9 +70,7 @@
         <item name="android:textColor">@android:color/white</item>
     </style>
 
-    <style name="AppTheme.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
+    <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowDrawsSystemBarBackgrounds" tools:targetApi="lollipop">true</item>
         <item name="android:statusBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
     </style>
@@ -123,9 +121,7 @@
 
         <item name="android:navigationBarColor" tools:targetApi="lollipop">@color/background_true_dark</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
-    </style>
 
-    <style name="AppTheme.TrueBlack.Preferences" parent="AppTheme.TrueBlack">
         <item name="android:windowBackground">@color/background_true_dark</item>
     </style>
 


### PR DESCRIPTION
added an implementation of Android 10 (API 29) dark theme

added two new theme options:
SYSTEM: dynamically switches between light and dark theme
SYSTEM_AMOLED: dynamically switches between light and amoled theme

changed the default theme to be SYSTEM

reversed [this workaround](https://github.com/beemdevelopment/Aegis/commit/59c0ca947dfec842e7b24fcddca34538bcc709d2) for amoled themed preferences to remove duplicated code in `PreferencesActivity.java`
(I'm not sure why this workaround was needed but I just added the true dark background to the normal amoled theme)

The launch screen will always follow the system theme regardless of which theme was selected. There is no other way to do it because the color of the launch screen can only be set in XML which means no preferences can be queried. Following the system theme is still an improvement from always showing a white screen.

closes #115 

**TODO**
- [x] change theme based on the system theme
- [x] launch screen is always light and doesn't follow the theme (this issue is also present when manually selecting the dark or amoled theme)
- [x] use "Set by Battery Saver" instead of "System default" on devices running Android 9 or earlier to match the [recommendation](https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#changing_themes_in-app)