### PR TITLE
Show account name only if it's set

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -113,11 +113,13 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         // only show the button if this entry is of type HotpInfo
         _buttonRefresh.setVisibility(entry.getInfo() instanceof HotpInfo ? View.VISIBLE : View.GONE);
 
-        _profileIssuer.setText(entry.getIssuer());
-        _profileName.setText("");
-        if (showAccountName) {
-            _profileName.setText(" - " + entry.getName());
+        String profileIssuer = entry.getIssuer();
+        String profileName = showAccountName ? entry.getName() : "";
+        if (!profileIssuer.isEmpty() && !profileName.isEmpty()) {
+            profileName = " - " + profileName;
         }
+        _profileIssuer.setText(profileIssuer);
+        _profileName.setText(profileName);
 
         if (_hidden) {
             hideCode();


### PR DESCRIPTION
If you set an account name to an empty string, right now you see a trailing dash, e.g. `Github - `.

This change should fix this, so that the dash is only added when account name is not empty.