### PR TITLE
Show the password reminder popup after the window has been attached

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -162,12 +162,18 @@ public class AuthActivity extends AegisActivity implements SlotListTask.Callback
         if (_bioPrompt != null) {
             if (_prefs.isPasswordReminderNeeded()) {
                 focusPasswordField();
-                showPasswordReminder();
             } else {
                 showBiometricPrompt();
             }
         } else {
             focusPasswordField();
+        }
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        if (_bioPrompt != null && _prefs.isPasswordReminderNeeded()) {
+            showPasswordReminder();
         }
     }
 


### PR DESCRIPTION
I noticed a strange crash in the Play Console:

```
android.view.WindowManager$BadTokenException:
  at android.view.ViewRootImpl.setView (ViewRootImpl.java:828)
  at android.view.WindowManagerGlobal.addView (WindowManagerGlobal.jav>
  at android.view.WindowManagerImpl.addView (WindowManagerImpl.java:93)
  at android.widget.PopupWindow.invokePopup (PopupWindow.java:1434)
  at android.widget.PopupWindow.showAsDropDown (PopupWindow.java:1284)
  at android.widget.PopupWindow.showAsDropDown (PopupWindow.java:1240)
  at android.widget.PopupWindow.showAsDropDown (PopupWindow.java:1219)
  at com.beemdevelopment.aegis.ui.AuthActivity.lambda$showPasswordRemi>
  at com.beemdevelopment.aegis.ui.-$$Lambda$AuthActivity$WWHxRKllBPcyH>
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:220)
  at android.app.ActivityThread.main (ActivityThread.java:6929)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (Runt>
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:870)
```

I can't reproduce this on my device, and we haven't received any reports from
users, but it would be pretty bad if Aegis crashes on some devices when showing
the password reminder popup. This patch is an attempt to fix that (see:
https://stackoverflow.com/a/33809860/12972657).