### PR TITLE
Use most frequent period to show progress

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -104,7 +104,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
 
             @Override
             public long getMillisTillNextRefresh() {
-                return TotpInfo.getMillisTillNextRotation(_adapter.getUniformPeriod());
+                return TotpInfo.getMillisTillNextRotation(_adapter.getMostFrequentPeriod());
             }
         });
 


### PR DESCRIPTION
This pull request changes the way the timers are shown as suggested #231. The EntryAdapter now finds the most frequent period to differentiate between the listview progressbar and the entry progressbar.

![image](https://user-images.githubusercontent.com/7524012/80324080-373ff400-882f-11ea-8f24-2fba42a27b5b.png)

Closes #231