### PR TITLE
Minify and optimize the APK using ProGuard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,16 +44,27 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled false
             applicationIdSuffix ".debug"
             manifestPlaceholders = [title: "AegisDev", iconName: "ic_launcher_debug"]
             resValue "bool", "pref_secure_screen_default", "false"
+            postprocessing {
+                removeUnusedCode true
+                removeUnusedResources true
+                obfuscate false
+                optimizeCode false
+                proguardFiles getDefaultProguardFile('proguard-defaults.txt'), 'proguard-rules.pro'
+            }
         }
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             manifestPlaceholders = [title: "Aegis", iconName: "ic_launcher"]
             resValue "bool", "pref_secure_screen_default", "true"
+            postprocessing {
+                removeUnusedCode true
+                removeUnusedResources true
+                obfuscate false
+                optimizeCode true
+                proguardFiles getDefaultProguardFile('proguard-defaults.txt'), 'proguard-rules.pro'
+            }
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keep class com.beemdevelopment.aegis.importers.** { *; }
+-keep class net.sqlcipher.** { *; }


### PR DESCRIPTION
This enables some minification and optimization options to shrink the size of
our APK. A release APK would previously be 12 MB in size, but would now be 8.2
MB.

To test, check if *all* of the functionality of the app still works,
particularly parts that refer to dependencies. You'll know if ProGuard broke
something when the app crashes with a ``ClassNotFoundException`` or similar
exception. I think I've covered all of the cases where ProGuard removed too much
in the rule file.

Also, I was curious why our APK had gotten so large to begin with. I did some
digging and found that this is caused by the SQLCipher dependency. The APK
shrinks down to 2.7 MB without it! We should consider whether having support for
importing from Authenticator Plus is worth the extra 5.5 MB in size.