### PR TITLE
Write entries to the vault directly in EditEntryActivity

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -8,13 +8,14 @@ import android.provider.Settings;
 import android.view.WindowManager;
 import android.widget.Toast;
 
+import androidx.annotation.CallSuper;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.beemdevelopment.aegis.AegisApplication;
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.Theme;
-
-import androidx.annotation.CallSuper;
-import androidx.appcompat.app.AppCompatActivity;
+import com.beemdevelopment.aegis.vault.VaultManagerException;
 
 import java.util.Locale;
 
@@ -124,6 +125,16 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
         config.locale = locale;
 
         this.getResources().updateConfiguration(config, this.getResources().getDisplayMetrics());
+    }
+
+    protected boolean saveVault() {
+        try {
+            getApp().getVaultManager().save();
+            return true;
+        } catch (VaultManagerException e) {
+            Toast.makeText(this, getString(R.string.saving_error), Toast.LENGTH_LONG).show();
+            return false;
+        }
     }
 
     /**

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -10,12 +10,12 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
 import com.beemdevelopment.aegis.ViewMode;
-import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.helpers.ItemTouchHelperAdapter;
 import com.beemdevelopment.aegis.otp.HotpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfoException;
 import com.beemdevelopment.aegis.otp.TotpInfo;
+import com.beemdevelopment.aegis.vault.VaultEntry;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements ItemTouchHelperAdapter {
     private EntryListView _view;
@@ -144,6 +145,11 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
         checkPeriodUniformity();
     }
 
+    public void removeEntry(UUID uuid) {
+        VaultEntry entry = getEntryByUUID(uuid);
+        removeEntry(entry);
+    }
+
     public void clearEntries() {
         _entries.clear();
         _shownEntries.clear();
@@ -151,7 +157,8 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
         checkPeriodUniformity();
     }
 
-    public void replaceEntry(VaultEntry oldEntry, VaultEntry newEntry) {
+    public void replaceEntry(UUID uuid, VaultEntry newEntry) {
+        VaultEntry oldEntry = getEntryByUUID(uuid);
         _entries.set(_entries.indexOf(oldEntry), newEntry);
 
         if (_shownEntries.contains(oldEntry)) {
@@ -172,6 +179,16 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
         }
 
         checkPeriodUniformity();
+    }
+
+    private VaultEntry getEntryByUUID(UUID uuid) {
+        for (VaultEntry entry : _entries) {
+            if (entry.getUUID().equals(uuid)) {
+                return entry;
+            }
+        }
+
+        return null;
     }
 
     private boolean isEntryFiltered(VaultEntry entry) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -22,10 +22,10 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
 import com.beemdevelopment.aegis.ViewMode;
-import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.helpers.SimpleItemTouchHelperCallback;
 import com.beemdevelopment.aegis.helpers.UiRefresher;
 import com.beemdevelopment.aegis.otp.TotpInfo;
+import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.ListPreloader;
 import com.bumptech.glide.RequestBuilder;
@@ -35,6 +35,7 @@ import com.bumptech.glide.util.ViewPreloadSizeProvider;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 public class EntryListView extends Fragment implements EntryAdapter.Listener {
     private EntryAdapter _adapter;
@@ -262,12 +263,17 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         updateEmptyState();
     }
 
+    public void removeEntry(UUID uuid) {
+        _adapter.removeEntry(uuid);
+        updateEmptyState();
+    }
+
     public void clearEntries() {
         _adapter.clearEntries();
     }
 
-    public void replaceEntry(VaultEntry oldEntry, VaultEntry newEntry) {
-        _adapter.replaceEntry(oldEntry, newEntry);
+    public void replaceEntry(UUID uuid, VaultEntry newEntry) {
+        _adapter.replaceEntry(uuid, newEntry);
     }
 
     public void runEntriesAnimation() {

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -17,6 +17,7 @@ import java.io.OutputStream;
 import java.text.Collator;
 import java.util.Collection;
 import java.util.TreeSet;
+import java.util.UUID;
 
 public class VaultManager {
     public static final String FILENAME = "aegis.json";
@@ -142,6 +143,11 @@ public class VaultManager {
     public void addEntry(VaultEntry entry) {
         assertState(false, true);
         _vault.getEntries().add(entry);
+    }
+
+    public VaultEntry getEntryByUUID(UUID uuid) {
+        assertState(false, true);
+        return _vault.getEntries().getByUUID(uuid);
     }
 
     public VaultEntry removeEntry(VaultEntry entry) {


### PR DESCRIPTION
This makes it so that EditEntryActivity directly saves entries to the vault, instead of passing them back to MainActivity through an Intent first. This prevents crashes that can occur when an entry has a large icon and the Bundle inside the Intent becomes too large.

This is the first part of a series of patches I plan on submitting, where I try to repair the damage done by my misguided obsession of only touching the global state in certain places.