### PR TITLE
Display a warning if automatic time sync is not enabled

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -159,4 +159,12 @@ public class Preferences {
     public void setBackupsVersionCount(int versions) {
         _prefs.edit().putInt("pref_backups_versions", versions).apply();
     }
+
+    public boolean isTimeSyncWarningEnabled() {
+        return _prefs.getBoolean("pref_warn_time_sync", true);
+    }
+
+    public void setIsTimeSyncWarningEnabled(boolean enabled) {
+        _prefs.edit().putBoolean("pref_warn_time_sync", enabled).apply();
+    }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
@@ -6,6 +6,8 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
+import android.provider.Settings;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -291,6 +293,31 @@ public class Dialogs {
         });
 
         Dialogs.showSecureDialog(dialog);
+    }
+
+    public static void showTimeSyncWarningDialog(Context context, Dialog.OnClickListener listener) {
+        Preferences prefs = new Preferences(context);
+        View view = LayoutInflater.from(context).inflate(R.layout.dialog_time_sync, null);
+        CheckBox checkBox = view.findViewById(R.id.check_warning_disable);
+
+        showSecureDialog(new AlertDialog.Builder(context)
+                .setTitle(R.string.time_sync_warning_title)
+                .setView(view)
+                .setCancelable(false)
+                .setPositiveButton(R.string.yes, (dialog, which) -> {
+                    if (checkBox.isChecked()) {
+                        prefs.setIsTimeSyncWarningEnabled(false);
+                    }
+                    if (listener != null) {
+                        listener.onClick(dialog, which);
+                    }
+                })
+                .setNegativeButton(R.string.no, (dialog, which) -> {
+                    if (checkBox.isChecked()) {
+                        prefs.setIsTimeSyncWarningEnabled(false);
+                    }
+                })
+                .create());
     }
 
     public interface NumberInputListener {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -10,6 +10,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -343,11 +344,23 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     private void onDoIntroResult() {
         _vault = _app.getVaultManager();
         loadEntries();
+        checkTimeSyncSetting();
+    }
+
+    private void checkTimeSyncSetting() {
+        boolean autoTime = Settings.Global.getInt(getContentResolver(), Settings.Global.AUTO_TIME, 1) == 1;
+        if (!autoTime && getPreferences().isTimeSyncWarningEnabled()) {
+            Dialogs.showTimeSyncWarningDialog(this, (dialog, which) -> {
+                Intent intent = new Intent(Settings.ACTION_DATE_SETTINGS);
+                startActivity(intent);
+            });
+        }
     }
 
     private void onDecryptResult() {
         _vault = _app.getVaultManager();
         loadEntries();
+        checkTimeSyncSetting();
     }
 
     private void startScanActivity() {
@@ -450,6 +463,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             _entryListView.refresh(false);
         } else {
             loadEntries();
+            checkTimeSyncSetting();
         }
 
         handleDeeplink();

--- a/app/src/main/res/layout/dialog_time_sync.xml
+++ b/app/src/main/res/layout/dialog_time_sync.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="10dp"
+    android:paddingTop="10dp">
+    <TextView
+        android:layout_marginStart="25dp"
+        android:layout_marginEnd="25dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/time_sync_warning_message"/>
+    <CheckBox
+        android:id="@+id/check_warning_disable"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="@string/time_sync_warning_disable"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,6 +231,9 @@
     <string name="support_rate_description">Support us by leaving a review in the Google Play Store</string>
     <string name="webview_error">This device doesn\'t support web view, which is necessary to view the changelog. It is missing a system component.</string>
     <string name="email">Email</string>
+    <string name="time_sync_warning_title">Automatic time synchronization</string>
+    <string name="time_sync_warning_message">Aegis relies on the system time to be in sync to generate correct codes. A deviation of only a few seconds could result in incorrect codes. It looks like your device is not configured to automatically synchronize the time. Would you like to do so now?</string>
+    <string name="time_sync_warning_disable">Stop warning me. I know what I\'m doing.</string>
 
     <string name="custom_notices_format_style" translatable="false" >
         body {


### PR DESCRIPTION
This'll display a warning to users who don't have automatic time synchronization enabled on their device. Aegis will try to take the user to the right settings menu if they tap "Yes". Users also have the option to silence the warning.

[<img width=300 src="https://alexbakker.me/u/jf1o8087lr.png">](https://alexbakker.me/u/jf1o8087lr.png)