### PR TITLE
Change license link color so it is legible on dark

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
@@ -10,6 +10,9 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
 import androidx.annotation.StringRes;
 import androidx.core.view.LayoutInflaterCompat;
 
@@ -110,11 +113,12 @@ public class AboutActivity extends AegisActivity {
     private void showLicenseDialog() {
         String stylesheet = getString(R.string.custom_notices_format_style);
         int backgroundColorResource = getCurrentTheme() == Theme.AMOLED ? R.attr.cardBackgroundFocused : R.attr.cardBackground;
-        String backgroundColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(backgroundColorResource, getTheme())));
-        String textColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(R.attr.primaryText, getTheme())));
-        String licenseColor = String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(R.attr.cardBackgroundFocused, getTheme())));
+        String backgroundColor = getThemeColorAsHex(backgroundColorResource);
+        String textColor = getThemeColorAsHex(R.attr.primaryText);
+        String licenseColor = getThemeColorAsHex(R.attr.cardBackgroundFocused);
+        String linkColor = getThemeColorAsHex(R.attr.colorAccent);
 
-        stylesheet = String.format(stylesheet, backgroundColor, textColor, licenseColor);
+        stylesheet = String.format(stylesheet, backgroundColor, textColor, licenseColor, linkColor);
 
         LicenseResolver.registerLicense(new GlideLicense());
         new LicensesDialog.Builder(this)
@@ -124,5 +128,9 @@ public class AboutActivity extends AegisActivity {
                 .setIncludeOwnLicense(true)
                 .build()
                 .show();
+    }
+
+    private String getThemeColorAsHex(@AttrRes int attributeId) {
+        return String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(attributeId, getTheme())));
     }
 }

--- a/app/src/main/res/layout/content_about.xml
+++ b/app/src/main/res/layout/content_about.xml
@@ -62,6 +62,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-info-outline"
                     app:ico_size="16dp" />
@@ -71,7 +72,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">
@@ -97,7 +97,7 @@
                 android:id="@+id/btn_changelog"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:foreground="?attr/selectableItemBackground"
+                android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
@@ -108,6 +108,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-time-restore"
                     app:ico_size="16dp" />
@@ -116,7 +117,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">
@@ -150,6 +150,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-github"
                     app:ico_size="16dp" />
@@ -158,7 +159,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">
@@ -192,6 +192,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-file-text"
                     app:ico_size="16dp" />
@@ -200,7 +201,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">
@@ -267,6 +267,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-account"
                     app:ico_size="16dp" />
@@ -275,7 +276,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">
@@ -312,6 +312,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-account"
                     app:ico_size="16dp" />
@@ -320,7 +321,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">
@@ -357,6 +357,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-email"
                     app:ico_size="16dp" />
@@ -365,7 +366,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp"
                     android:text="@string/email_us"
@@ -389,6 +389,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-globe"
                     app:ico_size="16dp" />
@@ -396,7 +397,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp"
                     android:text="@string/visit_website"
@@ -438,7 +438,7 @@
                 android:id="@+id/btn_rate"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:foreground="?attr/selectableItemBackground"
+                android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:gravity="center_vertical"
                 android:minHeight="@dimen/list_item_height"
@@ -450,6 +450,7 @@
                 <ImageView
                     android:layout_width="20dp"
                     android:layout_height="20dp"
+                    android:importantForAccessibility="no"
                     app:ico_color="@color/icon_about"
                     app:ico_icon="gmi-star"
                     app:ico_size="16dp" />
@@ -458,7 +459,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
-                    android:layout_marginLeft="32dp"
                     android:orientation="vertical"
                     android:paddingTop="8dp"
                     android:paddingBottom="8dp">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,9 @@
             padding: 1em;
             white-space: pre-wrap;
         }
+        a {
+            color: #%4$s;
+        }
     </string>
     <string name="empty_list">There are no codes to be shown. Start adding entries by tapping the plus sign in the bottom right corner</string>
     <string name="empty_list_title">No entries found</string>


### PR DESCRIPTION
Switched from the default blue to the accent color

![](https://user-images.githubusercontent.com/1782266/81242681-9e457180-8fc2-11ea-88f1-01c211f22169.png)

Also fixed lint issues in About activity layout
