### PR TITLE
Reuse existing PreferencesFragment when restoring from instance state

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -2,9 +2,6 @@ package com.beemdevelopment.aegis.ui;
 
 import android.os.Bundle;
 
-import com.beemdevelopment.aegis.R;
-import com.beemdevelopment.aegis.Theme;
-
 public class PreferencesActivity extends AegisActivity {
     private PreferencesFragment _fragment;
 
@@ -12,9 +9,13 @@ public class PreferencesActivity extends AegisActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        _fragment = new PreferencesFragment();
-        _fragment.setArguments(getIntent().getExtras());
-        getSupportFragmentManager().beginTransaction().replace(android.R.id.content, _fragment).commit();
+        if (savedInstanceState == null) {
+            _fragment = new PreferencesFragment();
+            _fragment.setArguments(getIntent().getExtras());
+            getSupportFragmentManager().beginTransaction().replace(android.R.id.content, _fragment).commit();
+        } else {
+            _fragment = (PreferencesFragment) getSupportFragmentManager().findFragmentById(android.R.id.content);
+        }
     }
 
     @Override


### PR DESCRIPTION
This fixes an issue where the existing PreferencesFragment was discarded when restoring PreferencesActivity from instance state. This issue caused the PreferencesFragment to no longer receive activity results. Most notably, this resulted in 0 byte vault files being created when exporting the vault.

Fixes #401.