### PR TITLE
Increase password reminder period to 30 days

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -46,7 +46,7 @@ public class Preferences {
     public boolean isPasswordReminderNeeded() {
         long diff = new Date().getTime() - getPasswordReminderTimestamp().getTime();
         long days = TimeUnit.DAYS.convert(diff, TimeUnit.MILLISECONDS);
-        return isPasswordReminderEnabled() && days >= 7;
+        return isPasswordReminderEnabled() && days >= 30;
     }
 
     public Date getPasswordReminderTimestamp() {


### PR DESCRIPTION
We got multiple reports from users who think the passwords reminder triggered too fast (once every 7 days). This pull request increases that period to 30 days as suggested in #402.

Do note that we also made an option to disable this reminder entirely.

Fixes #402.