### PR TITLE
Improve Action Bar consistency for Settings and About

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,7 +54,9 @@
             android:name=".ui.IntroActivity"
             android:theme="@style/Theme.Intro" />
         <activity android:name=".ui.AuthActivity" />
-        <activity android:name=".ui.PreferencesActivity" />
+        <activity
+            android:name=".ui.PreferencesActivity"
+            android:label="@string/title_activity_preferences" />
         <activity
             android:name=".ui.SlotManagerActivity"
             android:label="Manage key slots" />

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -42,6 +43,11 @@ public class AboutActivity extends AegisActivity {
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_about);
+
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+        }
 
         View btnLicenses = findViewById(R.id.btn_licenses);
         btnLicenses.setOnClickListener(v -> showLicenseDialog());
@@ -132,5 +138,18 @@ public class AboutActivity extends AegisActivity {
 
     private String getThemeColorAsHex(@AttrRes int attributeId) {
         return String.format("%06X", (0xFFFFFF & ThemeHelper.getThemeColor(attributeId, getTheme())));
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                break;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+
+        return true;
     }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
@@ -11,7 +11,6 @@ import java.text.Collator;
 import java.util.ArrayList;
 import java.util.TreeSet;
 
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -29,9 +28,10 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
         _groups = new TreeSet<>(Collator.getInstance());
         _groups.addAll(intent.getStringArrayListExtra("groups"));
 
-        ActionBar bar = getSupportActionBar();
-        bar.setHomeAsUpIndicator(R.drawable.ic_close);
-        bar.setDisplayHomeAsUpEnabled(true);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+        }
 
         // set up the recycler view
         _adapter = new GroupAdapter(this);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -1,6 +1,7 @@
 package com.beemdevelopment.aegis.ui;
 
 import android.os.Bundle;
+import android.view.MenuItem;
 
 public class PreferencesActivity extends AegisActivity {
     private PreferencesFragment _fragment;
@@ -8,6 +9,11 @@ public class PreferencesActivity extends AegisActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+        }
 
         if (savedInstanceState == null) {
             _fragment = new PreferencesFragment();
@@ -39,5 +45,18 @@ public class PreferencesActivity extends AegisActivity {
         // this is done so we don't lose anything if the fragment calls recreate on this activity
         outState.putParcelable("result", _fragment.getResult());
         super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                break;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+
+        return true;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="group_name_hint">Group name</string>
     <string name="preference_manage_groups">Edit groups</string>
     <string name="preference_manage_groups_summary">Manage and delete your groups here</string>
+    <string name="title_activity_preferences">Settings</string>
     <string name="pref_search_name_title">Search in account names</string>
     <string name="pref_search_name_summary">Include account name matches in the search results</string>
     <string name="pref_highlight_entry_title">Highlight tokens when tapped</string>


### PR DESCRIPTION
For the sake of consistency I added the back button to the action bar for both the "Settings" and "About" intents. "Settings" now also has a translatable string as title instead of the app title.

Does it make sense to replace the cross by an arrow in the "Manage Groups" action bar?