### PR TITLE
Improve icon editing flow

### DIFF
--- a/app/src/main/res/menu/menu_edit.xml
+++ b/app/src/main/res/menu/menu_edit.xml
@@ -8,12 +8,15 @@
         app:showAsAction="ifRoom"
         android:title="@string/save"/>
     <item
-        android:id="@+id/action_delete"
-        android:title="@string/action_delete"
+        android:id="@+id/action_edit_icon"
+        android:title="@string/action_edit_icon"
         app:showAsAction="never"/>
-
     <item
         android:id="@+id/action_default_icon"
         android:title="@string/action_default_icon"
+        app:showAsAction="never"/>
+    <item
+        android:id="@+id/action_delete"
+        android:title="@string/action_delete"
         app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="action_about">About</string>
     <string name="action_import">Import</string>
     <string name="action_delete">Delete</string>
+    <string name="action_edit_icon">Edit icon</string>
     <string name="action_default_icon">Restore default icon</string>
     <string name="discard">Discard</string>
     <string name="save">Save</string>
@@ -208,6 +209,7 @@
     <string name="import_error_dialog">Aegis could not import %d tokens. These tokens will be skipped. Press \'details\' to see more information about the errors.</string>
     <string name="unable_to_read_qrcode">Unable to read and process QR code</string>
     <string name="select_picture">Select picture</string>
+    <string name="select_icon">Select icon</string>
     <string name="toggle_checkboxes">Toggle checkboxes</string>
     <string name="search">Search</string>
     <string name="channel_name_lock_status">Lock status</string>


### PR DESCRIPTION
This improves the entry icon editing flow as suggested in #252:
- Add an "Edit icon" menu item
- Save the icon even if the checkmark was not clicked
- Exit icon edit mode with the back button

Close #252.