### PR TITLE
Only allow one key slot of each type in the vault

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/importers/AegisImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/AegisImporter.java
@@ -75,7 +75,7 @@ public class AegisImporter extends DatabaseImporter {
         }
 
         public State decrypt(char[] password) throws DatabaseImporterException {
-            List<PasswordSlot> slots = getSlots().findAll(PasswordSlot.class);
+            PasswordSlot slots = getSlots().get(PasswordSlot.class);
             PasswordSlotDecryptTask.Result result = PasswordSlotDecryptTask.decrypt(slots, password);
             VaultFileCredentials creds = new VaultFileCredentials(result.getKey(), getSlots());
             return decrypt(creds);
@@ -84,7 +84,7 @@ public class AegisImporter extends DatabaseImporter {
         @Override
         public void decrypt(Context context, DecryptListener listener) {
             Dialogs.showPasswordInputDialog(context, (Dialogs.TextInputListener) password -> {
-                List<PasswordSlot> slots = getSlots().findAll(PasswordSlot.class);
+                PasswordSlot slots = getSlots().get(PasswordSlot.class);
                 PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slots, password);
                 PasswordSlotDecryptTask task = new PasswordSlotDecryptTask(context, result -> {
                     try {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -45,8 +45,6 @@ import com.beemdevelopment.aegis.vault.slots.SlotException;
 import com.beemdevelopment.aegis.vault.slots.SlotIntegrityException;
 import com.beemdevelopment.aegis.vault.slots.SlotList;
 
-import java.util.List;
-
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
@@ -109,22 +107,20 @@ public class AuthActivity extends AegisActivity {
 
             try {
                 // find a biometric slot with an id that matches an alias in the keystore
-                for (BiometricSlot slot : _slots.findAll(BiometricSlot.class)) {
-                    String id = slot.getUUID().toString();
-                    KeyStoreHandle handle = new KeyStoreHandle();
-                    if (handle.containsKey(id)) {
-                        SecretKey key = handle.getKey(id);
-                        // if 'key' is null, it was permanently invalidated
-                        if (key == null) {
-                            invalidated = true;
-                            continue;
-                        }
+                BiometricSlot slot = _slots.get(BiometricSlot.class);
+                String id = slot.getUUID().toString();
 
+                KeyStoreHandle handle = new KeyStoreHandle();
+                if (handle.containsKey(id)) {
+                    SecretKey key = handle.getKey(id);
+                    // if 'key' is null, it was permanently invalidated
+                    if (key == null) {
+                        invalidated = true;
+                    } else {
                         _bioSlot = slot;
                         _bioKey = key;
                         biometricsButton.setVisibility(View.VISIBLE);
                         invalidated = false;
-                        break;
                     }
                 }
             } catch (KeyStoreHandleException e) {
@@ -144,8 +140,8 @@ public class AuthActivity extends AegisActivity {
             imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
 
             char[] password = EditTextHelper.getEditTextChars(_textPassword);
-            List<PasswordSlot> slots = _slots.findAll(PasswordSlot.class);
-            PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slots, password);
+            PasswordSlot slot = _slots.get(PasswordSlot.class);
+            PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slot, password);
             PasswordSlotDecryptTask task = new PasswordSlotDecryptTask(AuthActivity.this, new PasswordDerivationListener());
             task.execute(getLifecycle(), params);
         });
@@ -333,7 +329,7 @@ public class AuthActivity extends AegisActivity {
             _bioPrompt = null;
 
             MasterKey key;
-            BiometricSlot slot = _slots.find(BiometricSlot.class);
+            BiometricSlot slot = _slots.get(BiometricSlot.class);
 
             try {
                 key = slot.getKey(result.getCryptoObject().getCipher());

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/SlotManagerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/SlotManagerActivity.java
@@ -76,21 +76,19 @@ public class SlotManagerActivity extends AegisActivity implements SlotAdapter.Li
             _adapter.addSlot(slot);
         }
 
-        updateBiometricsButton();
+        updateSlotButtons();
     }
 
-    private void updateBiometricsButton() {
+    private void updateSlotButtons() {
         // only show the biometrics option if we can get an instance of the biometrics manager
         // and if none of the slots in the collection has a matching alias in the keystore
         int visibility = View.VISIBLE;
         if (BiometricsHelper.isAvailable(this)) {
             try {
                 KeyStoreHandle keyStore = new KeyStoreHandle();
-                for (BiometricSlot slot : _creds.getSlots().findAll(BiometricSlot.class)) {
-                    if (keyStore.containsKey(slot.getUUID().toString())) {
-                        visibility = View.GONE;
-                        break;
-                    }
+                BiometricSlot slot = _creds.getSlots().get(BiometricSlot.class);
+                if (slot != null && keyStore.containsKey(slot.getUUID().toString())) {
+                    visibility = View.GONE;
                 }
             } catch (KeyStoreHandleException e) {
                 visibility = View.GONE;
@@ -99,6 +97,9 @@ public class SlotManagerActivity extends AegisActivity implements SlotAdapter.Li
             visibility = View.GONE;
         }
         findViewById(R.id.button_add_biometric).setVisibility(visibility);
+
+        visibility = _creds.getSlots().has(PasswordSlot.class) ? View.GONE : View.VISIBLE;
+        findViewById(R.id.button_add_password).setVisibility(visibility);
     }
 
     private void onSave() {
@@ -162,7 +163,7 @@ public class SlotManagerActivity extends AegisActivity implements SlotAdapter.Li
     @Override
     public void onRemoveSlot(Slot slot) {
         SlotList slots = _creds.getSlots();
-        if (slot instanceof PasswordSlot && slots.findAll(PasswordSlot.class).size() <= 1) {
+        if (slot instanceof PasswordSlot && slots.has(PasswordSlot.class)) {
             Toast.makeText(this, R.string.password_slot_error, Toast.LENGTH_SHORT).show();
             return;
         }
@@ -174,7 +175,7 @@ public class SlotManagerActivity extends AegisActivity implements SlotAdapter.Li
                     slots.remove(slot);
                     _adapter.removeSlot(slot);
                     _edited = true;
-                    updateBiometricsButton();
+                    updateSlotButtons();
                 })
                 .setNegativeButton(android.R.string.no, null)
                 .create());
@@ -184,7 +185,7 @@ public class SlotManagerActivity extends AegisActivity implements SlotAdapter.Li
         _creds.getSlots().add(slot);
         _adapter.addSlot(slot);
         _edited = true;
-        updateBiometricsButton();
+        updateSlotButtons();
     }
 
     private void showSlotError(String error) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/SecurityPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/SecurityPreferencesFragment.java
@@ -21,8 +21,8 @@ import com.beemdevelopment.aegis.crypto.KeyStoreHandleException;
 import com.beemdevelopment.aegis.helpers.BiometricSlotInitializer;
 import com.beemdevelopment.aegis.helpers.BiometricsHelper;
 import com.beemdevelopment.aegis.services.NotificationService;
-import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
 import com.beemdevelopment.aegis.ui.SlotManagerActivity;
+import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
 import com.beemdevelopment.aegis.ui.preferences.SwitchPreference;
 import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
@@ -32,8 +32,6 @@ import com.beemdevelopment.aegis.vault.slots.PasswordSlot;
 import com.beemdevelopment.aegis.vault.slots.Slot;
 import com.beemdevelopment.aegis.vault.slots.SlotException;
 import com.beemdevelopment.aegis.vault.slots.SlotList;
-
-import java.util.List;
 
 import javax.crypto.Cipher;
 
@@ -138,7 +136,7 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
                 }
             } else {
                 // remove the biometric slot
-                BiometricSlot slot = slots.find(BiometricSlot.class);
+                BiometricSlot slot = slots.get(BiometricSlot.class);
                 slots.remove(slot);
                 getVault().setCredentials(creds);
 
@@ -179,8 +177,8 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
 
             Dialogs.showPasswordInputDialog(getActivity(), R.string.set_password_confirm, R.string.pin_keyboard_description, password -> {
                 if (isDigitsOnly(new String(password))) {
-                    List<PasswordSlot> slots = getVault().getCredentials().getSlots().findAll(PasswordSlot.class);
-                    PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slots, password);
+                    PasswordSlot slot = getVault().getCredentials().getSlots().get(PasswordSlot.class);
+                    PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slot, password);
                     PasswordSlotDecryptTask task = new PasswordSlotDecryptTask(getActivity(), new PasswordConfirmationListener());
                     task.execute(getLifecycle(), params);
                 } else {
@@ -260,14 +258,11 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
 
         if (encrypted) {
             SlotList slots = getVault().getCredentials().getSlots();
-            boolean multiPassword = slots.findAll(PasswordSlot.class).size() > 1;
-            boolean multiBio = slots.findAll(BiometricSlot.class).size() > 1;
-            boolean showSlots = BuildConfig.DEBUG || multiPassword || multiBio;
             boolean canUseBio = BiometricsHelper.isAvailable(getContext());
-            _setPasswordPreference.setEnabled(!multiPassword);
-            _biometricsPreference.setEnabled(canUseBio && !multiBio);
+            _setPasswordPreference.setEnabled(true);
+            _biometricsPreference.setEnabled(canUseBio);
             _biometricsPreference.setChecked(slots.has(BiometricSlot.class), true);
-            _slotsPreference.setVisible(showSlots);
+            _slotsPreference.setVisible(BuildConfig.DEBUG);
             _passwordReminderPreference.setVisible(slots.has(BiometricSlot.class));
         } else {
             _setPasswordPreference.setEnabled(false);
@@ -311,7 +306,7 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
                 slot.setKey(creds.getKey(), cipher);
 
                 // remove the old master password slot
-                PasswordSlot oldSlot = creds.getSlots().find(PasswordSlot.class);
+                PasswordSlot oldSlot = creds.getSlots().get(PasswordSlot.class);
                 if (oldSlot != null) {
                     slots.remove(oldSlot);
                 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/PasswordSlotDecryptTask.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/PasswordSlotDecryptTask.java
@@ -10,8 +10,6 @@ import com.beemdevelopment.aegis.vault.slots.Slot;
 import com.beemdevelopment.aegis.vault.slots.SlotException;
 import com.beemdevelopment.aegis.vault.slots.SlotIntegrityException;
 
-import java.util.List;
-
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
@@ -28,21 +26,17 @@ public class PasswordSlotDecryptTask extends ProgressDialogTask<PasswordSlotDecr
         setPriority();
 
         Params params = args[0];
-        return decrypt(params.getSlots(), params.getPassword());
+        return decrypt(params.getSlot(), params.getPassword());
     }
 
-    public static Result decrypt(List<PasswordSlot> slots, char[] password) {
-        for (PasswordSlot slot : slots) {
-            try {
-                return decryptPasswordSlot(slot, password);
-            } catch (SlotException e) {
-                throw new RuntimeException(e);
-            } catch (SlotIntegrityException ignored) {
-
-            }
+    public static Result decrypt(PasswordSlot slot, char[] password) {
+        try {
+            return decryptPasswordSlot(slot, password);
+        } catch (SlotException e) {
+            throw new RuntimeException(e);
+        } catch (SlotIntegrityException ignored) {
+            return null;
         }
-
-        return null;
     }
 
     public static Result decryptPasswordSlot(PasswordSlot slot, char[] password)
@@ -90,16 +84,16 @@ public class PasswordSlotDecryptTask extends ProgressDialogTask<PasswordSlotDecr
     }
 
     public static class Params {
-        private List<PasswordSlot> _slots;
+        private PasswordSlot _slot;
         private char[] _password;
 
-        public Params(List<PasswordSlot> slots, char[] password) {
-            _slots = slots;
+        public Params(PasswordSlot slot, char[] password) {
+            _slot = slot;
             _password = password;
         }
 
-        public List<PasswordSlot> getSlots() {
-            return _slots;
+        public PasswordSlot getSlot() {
+            return _slot;
         }
 
         public char[] getPassword() {

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/slots/SlotList.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/slots/SlotList.java
@@ -6,9 +6,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class SlotList extends UUIDMap<Slot> {
     public JSONArray toJson() {
         JSONArray array = new JSONArray();
@@ -35,7 +32,16 @@ public class SlotList extends UUIDMap<Slot> {
         return slots;
     }
 
-    public <T extends Slot> T find(Class<T> type) {
+    @Override
+    public void add(Slot slot) {
+        if (has(slot.getClass())) {
+            throw new AssertionError(String.format("Only one slot of type %s is allowed in a SlotList", slot.getClass().getSimpleName()));
+        }
+
+        super.add(slot);
+    }
+
+    public <T extends Slot> T get(Class<T> type) {
         for (Slot slot : this) {
             if (slot.getClass() == type) {
                 return type.cast(slot);
@@ -44,17 +50,7 @@ public class SlotList extends UUIDMap<Slot> {
         return null;
     }
 
-    public <T extends Slot> List<T> findAll(Class<T> type) {
-        ArrayList<T> list = new ArrayList<>();
-        for (Slot slot : this) {
-            if (slot.getClass() == type) {
-                list.add(type.cast(slot));
-            }
-        }
-        return list;
-    }
-
     public <T extends Slot> boolean has(Class<T> type) {
-        return find(type) != null;
+        return get(type) != null;
     }
 }


### PR DESCRIPTION
Aegis supports multiple passwords under the hood, but this functionality was
never exposed through the UI. This patch removes it entirely and enforces that
vaults only have one slot of each type. This is in preparation for #121, for
which I plan to introduce a new "backup password" slot type.