### PR TITLE
Reset vault credentials when password/biometric slide is selected

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/slides/CustomAuthenticatedSlide.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/slides/CustomAuthenticatedSlide.java
@@ -60,7 +60,6 @@ public class CustomAuthenticatedSlide extends Fragment implements SlidePolicy, S
             }
         });
 
-        _creds = new VaultFileCredentials();
         view.findViewById(R.id.main).setBackgroundColor(_bgColor);
         return view;
     }
@@ -96,6 +95,7 @@ public class CustomAuthenticatedSlide extends Fragment implements SlidePolicy, S
     public void onSlideSelected() {
         Intent intent = getActivity().getIntent();
         _cryptType = intent.getIntExtra("cryptType", CustomAuthenticationSlide.CRYPT_TYPE_INVALID);
+        _creds = new VaultFileCredentials();
     }
 
     @Override


### PR DESCRIPTION
Previously, if a user made it to the last intro slide and then navigated back to
change the security options, any changes would be ignored. This fixes that issue.