### PR TITLE
Fix issue where VaultManager was erroneously initialized with creds in intro

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/IntroActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/IntroActivity.java
@@ -110,7 +110,11 @@ public class IntroActivity extends AppIntro2 {
             return;
         }
 
-        _app.initVaultManager(vault, creds);
+        if (cryptType == CustomAuthenticationSlide.CRYPT_TYPE_NONE) {
+            _app.initVaultManager(vault, null);
+        } else {
+            _app.initVaultManager(vault, creds);
+        }
 
         // skip the intro from now on
         _prefs.setIntroDone(true);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/slides/CustomAuthenticatedSlide.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/slides/CustomAuthenticatedSlide.java
@@ -60,7 +60,6 @@ public class CustomAuthenticatedSlide extends Fragment implements SlidePolicy, S
             }
         });
 
-        _creds = new VaultFileCredentials();
         view.findViewById(R.id.main).setBackgroundColor(_bgColor);
         return view;
     }
@@ -96,6 +95,9 @@ public class CustomAuthenticatedSlide extends Fragment implements SlidePolicy, S
     public void onSlideSelected() {
         Intent intent = getActivity().getIntent();
         _cryptType = intent.getIntExtra("cryptType", CustomAuthenticationSlide.CRYPT_TYPE_INVALID);
+        if (_cryptType != CustomAuthenticationSlide.CRYPT_TYPE_NONE) {
+            _creds = new VaultFileCredentials();
+        }
     }
 
     @Override


### PR DESCRIPTION
Also fixes another issue where previously, if a user made it to the last intro slide and then navigated back to change the security options, any changes would be ignored. Supersedes #434.