### PR TITLE
Disable optimization in Proguard and retain line numbers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ android {
                 removeUnusedCode true
                 removeUnusedResources true
                 obfuscate false
-                optimizeCode true
+                optimizeCode false
                 proguardFiles getDefaultProguardFile('proguard-defaults.txt'), 'proguard-rules.pro'
             }
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -16,6 +16,8 @@
 #   public *;
 #}
 
+-keepattributes SourceFile,LineNumberTable
+
 -keep class com.beemdevelopment.aegis.importers.** { *; }
 
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }


### PR DESCRIPTION
With this enabled, crash reports in Play Console have incorrect line numbers,
even after uploading mapping.txt.