### PR TITLE
Fix an issue where the password reminder popup was not shown

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -178,7 +178,7 @@ public class AuthActivity extends AegisActivity {
 
     @Override
     public void onAttachedToWindow() {
-        if (_bioPrompt != null && _prefs.isPasswordReminderNeeded()) {
+        if (_bioKey != null && _prefs.isPasswordReminderNeeded()) {
             showPasswordReminder();
         }
     }


### PR DESCRIPTION
We no longer create BiometricPrompt prematurely, but forgot to adjust the check for the password reminder.