### PR TITLE
Disable wizard mode when the done slide of the intro is reached

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/IntroActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/IntroActivity.java
@@ -83,6 +83,10 @@ public class IntroActivity extends AppIntro2 {
             }
         }
 
+        if (newFragment == _endSlide) {
+            setWizardMode(false);
+        }
+
         setSwipeLock(true);
     }
 


### PR DESCRIPTION
This fixes a number of issues that can happen when navigating back to previous slides, by disabling back navigation entirely. One such issue is that when navigating back from the last slide, one would always land on the password/biometrics setup slide, even if "none" was selected on the security picker slide.