### PR TITLE
Improve backup error handling and frequency

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -160,6 +160,14 @@ public class Preferences {
         _prefs.edit().putInt("pref_backups_versions", versions).apply();
     }
 
+    public void setBackupsError(Exception e) {
+        _prefs.edit().putString("pref_backups_error", e == null ? null : e.toString()).apply();
+    }
+
+    public String getBackupsError() {
+        return _prefs.getString("pref_backups_error", null);
+    }
+
     public boolean isTimeSyncWarningEnabled() {
         return _prefs.getBoolean("pref_warn_time_sync", true);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -122,9 +122,9 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
         this.getResources().updateConfiguration(config, this.getResources().getDisplayMetrics());
     }
 
-    protected boolean saveVault() {
+    protected boolean saveVault(boolean backup) {
         try {
-            getApp().getVaultManager().save();
+            getApp().getVaultManager().save(backup);
             return true;
         } catch (VaultManagerException e) {
             Toast.makeText(this, getString(R.string.saving_error), Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -36,7 +36,6 @@ import com.beemdevelopment.aegis.helpers.UiThreadExecutor;
 import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
 import com.beemdevelopment.aegis.vault.VaultFile;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
-import com.beemdevelopment.aegis.vault.VaultManager;
 import com.beemdevelopment.aegis.vault.VaultManagerException;
 import com.beemdevelopment.aegis.vault.slots.BiometricSlot;
 import com.beemdevelopment.aegis.vault.slots.PasswordSlot;
@@ -273,10 +272,9 @@ public class AuthActivity extends AegisActivity {
         } else {
             try {
                 AegisApplication app = getApp();
-                VaultManager vault = app.initVaultManager(app.loadVaultFile(), creds);
+                app.initVaultManager(app.loadVaultFile(), creds);
                 if (isSlotRepaired) {
-                    vault.setCredentials(creds);
-                    saveVault();
+                    saveVault(true);
                 }
             } catch (VaultManagerException e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -467,7 +467,7 @@ public class EditEntryActivity extends AegisActivity {
         intent.putExtra("entryUUID", entry.getUUID());
         intent.putExtra("delete", delete);
 
-        if (saveVault()) {
+        if (saveVault(true)) {
             setResult(RESULT_OK, intent);
             finish();
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -1,5 +1,6 @@
 package com.beemdevelopment.aegis.ui;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 
@@ -21,6 +22,18 @@ public class PreferencesActivity extends AegisActivity {
             getSupportFragmentManager().beginTransaction().replace(android.R.id.content, _fragment).commit();
         } else {
             _fragment = (PreferencesFragment) getSupportFragmentManager().findFragmentById(android.R.id.content);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        Intent intent = getIntent();
+        String preference = intent.getStringExtra("pref");
+        if (preference != null) {
+            _fragment.scrollToPreference(preference);
+            intent.removeExtra("pref");
         }
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -434,8 +434,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onResume() {
+        super.onResume();
         updateEncryptionPreferences();
         updateBackupPreference();
     }
@@ -749,13 +749,14 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
         _prefs.setBackupsLocation(uri);
         _prefs.setIsBackupsEnabled(true);
+        _prefs.setBackupsError(null);
         _backupsLocationPreference.setSummary(String.format("%s: %s", getString(R.string.pref_backups_location_summary), Uri.decode(uri.toString())));
         updateBackupPreference();
     }
 
     private boolean saveVault() {
         try {
-            _vault.save();
+            _vault.save(true);
         } catch (VaultManagerException e) {
             e.printStackTrace();
             Dialogs.showErrorDialog(getContext(), R.string.saving_error, e);

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -96,7 +96,7 @@ public class VaultManager {
         }
     }
 
-    public void save() throws VaultManagerException {
+    public void save(boolean backup) throws VaultManagerException {
         try {
             JSONObject obj = _vault.toJson();
 
@@ -108,12 +108,17 @@ public class VaultManager {
             }
 
             save(_context, file);
-
-            if (_prefs.isBackupsEnabled()) {
-                backup();
-            }
         } catch (VaultFileException e) {
             throw new VaultManagerException(e);
+        }
+
+        if (backup && _prefs.isBackupsEnabled()) {
+            try {
+                backup();
+                _prefs.setBackupsError(null);
+            } catch (VaultManagerException e) {
+                _prefs.setBackupsError(e);
+            }
         }
     }
 
@@ -190,11 +195,11 @@ public class VaultManager {
 
     public void enableEncryption(VaultFileCredentials creds) throws VaultManagerException {
         _creds = creds;
-        save();
+        save(true);
     }
 
     public void disableEncryption() throws VaultManagerException {
         _creds = null;
-        save();
+        save(true);
     }
 }

--- a/app/src/main/res/drawable/ic_alert_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_alert_black_24dp.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,12 +8,43 @@
     android:fitsSystemWindows="true"
     tools:context="com.beemdevelopment.aegis.ui.MainActivity">
 
-    <fragment
-        android:name="com.beemdevelopment.aegis.ui.views.EntryListView"
-        android:id="@+id/key_profiles"
-        android:layout_height="match_parent"
+    <LinearLayout
         android:layout_width="match_parent"
-        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"/>
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <LinearLayout
+            android:id="@+id/btn_backup_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            android:clickable="true"
+            android:focusable="true"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="10dp"
+            android:background="@color/colorAccent"
+            android:foreground="?android:selectableItemBackground"
+            android:gravity="center">
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:tint="@color/icon_primary_inverted"
+                android:src="@drawable/ic_alert_black_24dp" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/backup_error_bar_message"
+                android:textColor="@color/primary_text_inverted"
+                android:layout_marginStart="5dp" />
+        </LinearLayout>
+
+        <fragment
+            android:name="com.beemdevelopment.aegis.ui.views.EntryListView"
+            android:id="@+id/key_profiles"
+            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"/>
+    </LinearLayout>
 
     <!-- note: the fab should always be the last element to be sure it's displayed on top -->
     <com.getbase.floatingactionbutton.FloatingActionsMenu

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="google_qr_export_unrelated">Unrelated QR code found. Try restarting the scanner.</string>
     <string name="google_qr_export_scanned">Scanned %d/%d QR codes</string>
     <string name="google_qr_export_unexpected">Expected QR code #%d, but scanned #%d instead</string>
+    <string name="backup_error_bar_message"><b>Vault backup failed recently</b></string>
 
     <string name="custom_notices_format_style" translatable="false" >
         body {


### PR DESCRIPTION
This patch improves our backup functionality in a number of ways:
- Only backup the vault when important changes are made, not when the order of
  entries is changed, for instance.
- Don't bubble up backup errors when saving the vault.
- Instead, show an error bar in the main view if the most recent backup attempt
  failed.

<img src="https://alexbakker.me/u/kbhhj2hcgx.png" width="300" />

Clicking on the error bar will take the user to the backup settings.