### PR TITLE
Fix the flakiness of importing from SQLite databases

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/importers/AegisImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/AegisImporter.java
@@ -4,17 +4,20 @@ import android.content.Context;
 
 import com.beemdevelopment.aegis.encoding.EncodingException;
 import com.beemdevelopment.aegis.otp.OtpInfoException;
+import com.beemdevelopment.aegis.util.IOUtils;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultFile;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
 import com.beemdevelopment.aegis.vault.VaultFileException;
 import com.beemdevelopment.aegis.vault.slots.SlotList;
+import com.topjohnwu.superuser.io.SuFile;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 public class AegisImporter extends DatabaseImporter {
 
@@ -23,19 +26,14 @@ public class AegisImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
+    protected SuFile getAppPath() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected String getAppSubPath() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         try {
-            byte[] bytes = reader.readAll();
+            byte[] bytes = IOUtils.readAll(stream);
             VaultFile file = VaultFile.fromBytes(bytes);
             if (file.isEncrypted()) {
                 return new EncryptedState(file);

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/AndOtpImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/AndOtpImporter.java
@@ -17,13 +17,16 @@ import com.beemdevelopment.aegis.otp.SteamInfo;
 import com.beemdevelopment.aegis.otp.TotpInfo;
 import com.beemdevelopment.aegis.ui.Dialogs;
 import com.beemdevelopment.aegis.ui.tasks.ProgressDialogTask;
+import com.beemdevelopment.aegis.util.IOUtils;
 import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
@@ -55,20 +58,15 @@ public class AndOtpImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
+    protected SuFile getAppPath() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected String getAppSubPath() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         byte[] bytes;
         try {
-            bytes = reader.readAll();
+            bytes = IOUtils.readAll(stream);
         } catch (IOException e) {
             throw new DatabaseImporterException(e);
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/AuthenticatorPlusImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/AuthenticatorPlusImporter.java
@@ -3,6 +3,8 @@ package com.beemdevelopment.aegis.importers;
 import android.content.Context;
 
 import com.beemdevelopment.aegis.ui.Dialogs;
+import com.beemdevelopment.aegis.util.IOUtils;
+import com.topjohnwu.superuser.io.SuFile;
 
 import net.lingala.zip4j.io.inputstream.ZipInputStream;
 import net.lingala.zip4j.model.LocalFileHeader;
@@ -11,6 +13,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 
 public class AuthenticatorPlusImporter extends DatabaseImporter {
     private static final String FILENAME = "Accounts.txt";
@@ -20,19 +23,14 @@ public class AuthenticatorPlusImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
+    protected SuFile getAppPath() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected String getAppSubPath() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         try {
-            return new EncryptedState(reader.readAll());
+            return new EncryptedState(IOUtils.readAll(stream));
         } catch (IOException e) {
             throw new DatabaseImporterException(e);
         }
@@ -55,9 +53,8 @@ public class AuthenticatorPlusImporter extends DatabaseImporter {
                     while ((header = zipStream.getNextEntry()) != null) {
                         File file = new File(header.getFileName());
                         if (file.getName().equals(FILENAME)) {
-                            FileReader reader = new FileReader(zipStream);
                             GoogleAuthUriImporter importer = new GoogleAuthUriImporter(context);
-                            GoogleAuthUriImporter.State state = importer.read(reader);
+                            DatabaseImporter.State state = importer.read(zipStream);
                             listener.onStateDecrypted(state);
                             return;
                         }

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/AuthyImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/AuthyImporter.java
@@ -1,6 +1,7 @@
 package com.beemdevelopment.aegis.importers;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.util.Xml;
 
 import com.beemdevelopment.aegis.R;
@@ -13,6 +14,7 @@ import com.beemdevelopment.aegis.otp.TotpInfo;
 import com.beemdevelopment.aegis.ui.Dialogs;
 import com.beemdevelopment.aegis.util.PreferenceParser;
 import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -21,6 +23,7 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -53,21 +56,16 @@ public class AuthyImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return _pkgName;
+    protected SuFile getAppPath() throws PackageManager.NameNotFoundException {
+        return getAppPath(_pkgName, _subPath);
     }
 
     @Override
-    protected String getAppSubPath() {
-        return _subPath;
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         try {
             XmlPullParser parser = Xml.newPullParser();
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
-            parser.setInput(reader.getStream(), null);
+            parser.setInput(stream, null);
             parser.nextTag();
 
             JSONArray array = new JSONArray();

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/FreeOtpImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/FreeOtpImporter.java
@@ -1,15 +1,17 @@
 package com.beemdevelopment.aegis.importers;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.util.Xml;
 
-import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.otp.HotpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfoException;
 import com.beemdevelopment.aegis.otp.SteamInfo;
 import com.beemdevelopment.aegis.otp.TotpInfo;
 import com.beemdevelopment.aegis.util.PreferenceParser;
+import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -18,6 +20,7 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,21 +33,16 @@ public class FreeOtpImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return _pkgName;
+    protected SuFile getAppPath() throws PackageManager.NameNotFoundException {
+        return getAppPath(_pkgName, _subPath);
     }
 
     @Override
-    protected String getAppSubPath() {
-        return _subPath;
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         try {
             XmlPullParser parser = Xml.newPullParser();
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
-            parser.setInput(reader.getStream(), null);
+            parser.setInput(stream, null);
             parser.nextTag();
 
             List<JSONObject> entries = new ArrayList<>();

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/FreeOtpPlusImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/FreeOtpPlusImporter.java
@@ -1,12 +1,17 @@
 package com.beemdevelopment.aegis.importers;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
+
+import com.beemdevelopment.aegis.util.IOUtils;
+import com.topjohnwu.superuser.io.SuFile;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,24 +25,19 @@ public class FreeOtpPlusImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return _pkgName;
+    protected SuFile getAppPath() throws PackageManager.NameNotFoundException {
+        return getAppPath(_pkgName, _subPath);
     }
 
     @Override
-    protected String getAppSubPath() {
-        return _subPath;
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         State state;
 
-        if (reader.isInternal()) {
-            state = new FreeOtpImporter(getContext()).read(reader);
+        if (isInternal) {
+            state = new FreeOtpImporter(getContext()).read(stream);
         } else {
             try {
-                String json = new String(reader.readAll(), StandardCharsets.UTF_8);
+                String json = new String(IOUtils.readAll(stream), StandardCharsets.UTF_8);
                 JSONObject obj = new JSONObject(json);
                 JSONArray array = obj.getJSONArray("tokens");
 

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/GoogleAuthImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/GoogleAuthImporter.java
@@ -1,6 +1,7 @@
 package com.beemdevelopment.aegis.importers;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 
 import com.beemdevelopment.aegis.encoding.Base32;
@@ -10,7 +11,9 @@ import com.beemdevelopment.aegis.otp.OtpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfoException;
 import com.beemdevelopment.aegis.otp.TotpInfo;
 import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
 
+import java.io.InputStream;
 import java.util.List;
 
 public class GoogleAuthImporter extends DatabaseImporter {
@@ -25,19 +28,22 @@ public class GoogleAuthImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return _pkgName;
+    protected SuFile getAppPath() throws PackageManager.NameNotFoundException {
+        return getAppPath(_pkgName, _subPath);
     }
-
+    
     @Override
-    protected String getAppSubPath() {
-        return _subPath;
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         SqlImporterHelper helper = new SqlImporterHelper(getContext());
-        List<Entry> entries = helper.read(Entry.class, reader.getStream(), "accounts");
+        List<Entry> entries = helper.read(Entry.class, stream, "accounts");
+        return new State(entries);
+    }
+
+    @Override
+    public DatabaseImporter.State readFromApp() throws PackageManager.NameNotFoundException, DatabaseImporterException {
+        SuFile path = getAppPath();
+        SqlImporterHelper helper = new SqlImporterHelper(getContext());
+        List<Entry> entries = helper.read(Entry.class, path, "accounts");
         return new State(entries);
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/GoogleAuthUriImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/GoogleAuthUriImporter.java
@@ -5,9 +5,11 @@ import android.content.Context;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfo;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfoException;
 import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 
@@ -17,20 +19,15 @@ public class GoogleAuthUriImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return null;
+    protected SuFile getAppPath() {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    protected String getAppSubPath() {
-        return null;
-    }
-
-    @Override
-    public GoogleAuthUriImporter.State read(DatabaseImporter.FileReader reader) throws DatabaseImporterException {
+    public GoogleAuthUriImporter.State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         ArrayList<String> lines = new ArrayList<>();
 
-        try (InputStreamReader streamReader = new InputStreamReader(reader.getStream());
+        try (InputStreamReader streamReader = new InputStreamReader(stream);
              BufferedReader bufferedReader = new BufferedReader(streamReader)) {
             String line;
             while ((line = bufferedReader.readLine()) != null) {

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/MicrosoftAuthImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/MicrosoftAuthImporter.java
@@ -1,6 +1,7 @@
 package com.beemdevelopment.aegis.importers;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 
 import com.beemdevelopment.aegis.encoding.Base32;
@@ -10,7 +11,9 @@ import com.beemdevelopment.aegis.otp.OtpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfoException;
 import com.beemdevelopment.aegis.otp.TotpInfo;
 import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
 
+import java.io.InputStream;
 import java.util.List;
 
 public class MicrosoftAuthImporter extends DatabaseImporter {
@@ -25,19 +28,22 @@ public class MicrosoftAuthImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return _pkgName;
+    protected SuFile getAppPath() throws PackageManager.NameNotFoundException {
+        return getAppPath(_pkgName, _subPath);
     }
 
     @Override
-    protected String getAppSubPath() {
-        return _subPath;
-    }
-
-    @Override
-    public State read(FileReader reader) throws DatabaseImporterException {
+    public State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         SqlImporterHelper helper = new SqlImporterHelper(getContext());
-        List<Entry> entries = helper.read(Entry.class, reader.getStream(), "accounts");
+        List<Entry> entries = helper.read(Entry.class, stream, "accounts");
+        return new State(entries);
+    }
+
+    @Override
+    public DatabaseImporter.State readFromApp() throws PackageManager.NameNotFoundException, DatabaseImporterException {
+        SuFile path = getAppPath();
+        SqlImporterHelper helper = new SqlImporterHelper(getContext());
+        List<Entry> entries = helper.read(Entry.class, path, "accounts");
         return new State(entries);
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/importers/WinAuthImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/WinAuthImporter.java
@@ -3,6 +3,9 @@ package com.beemdevelopment.aegis.importers;
 import android.content.Context;
 
 import com.beemdevelopment.aegis.vault.VaultEntry;
+import com.topjohnwu.superuser.io.SuFile;
+
+import java.io.InputStream;
 
 public class WinAuthImporter extends DatabaseImporter {
     public WinAuthImporter(Context context) {
@@ -10,32 +13,27 @@ public class WinAuthImporter extends DatabaseImporter {
     }
 
     @Override
-    protected String getAppPkgName() {
-        return null;
+    protected SuFile getAppPath() {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    protected String getAppSubPath() {
-        return null;
-    }
-
-    @Override
-    public WinAuthImporter.State read(FileReader reader) throws DatabaseImporterException {
+    public WinAuthImporter.State read(InputStream stream, boolean isInternal) throws DatabaseImporterException {
         GoogleAuthUriImporter importer = new GoogleAuthUriImporter(getContext());
-        GoogleAuthUriImporter.State state = importer.read(reader);
+        DatabaseImporter.State state = importer.read(stream);
         return new State(state);
     }
 
     public static class State extends DatabaseImporter.State {
-        private GoogleAuthUriImporter.State _state;
+        private DatabaseImporter.State _state;
 
-        private State(GoogleAuthUriImporter.State state) {
+        private State(DatabaseImporter.State state) {
             super(false);
             _state = state;
         }
 
         @Override
-        public Result convert() {
+        public Result convert() throws DatabaseImporterException {
             Result result = _state.convert();
 
             for (VaultEntry entry : result.getEntries()) {


### PR DESCRIPTION
This patch ensures that we also copy over any files related to the SQLite
database (databases-shm, databases-wal, databases-journal) when copying it from
an app's internal storage.

Fixes #82.