### PR TITLE
Let Android handle the lifecycle of BiometricPrompt

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -144,7 +144,7 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
      * the vault was locked by an external trigger while the Activity was still open.
      */
     private boolean isOrphan() {
-        return !(this instanceof MainActivity) && _app.isVaultLocked();
+        return !(this instanceof MainActivity) && !(this instanceof AuthActivity) && _app.isVaultLocked();
     }
 
     protected Theme getCurrentTheme() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -145,6 +145,10 @@ public class AuthActivity extends AegisActivity {
         biometricsButton.setOnClickListener(v -> {
             showBiometricPrompt();
         });
+
+        if (_bioKey != null) {
+            showBiometricPrompt();
+        }
     }
 
     @Override
@@ -196,13 +200,7 @@ public class AuthActivity extends AegisActivity {
     public void onResume() {
         super.onResume();
 
-        if (_bioKey != null) {
-            if (_prefs.isPasswordReminderNeeded()) {
-                focusPasswordField();
-            } else {
-                showBiometricPrompt();
-            }
-        } else {
+        if (_bioKey == null || _prefs.isPasswordReminderNeeded()) {
             focusPasswordField();
         }
     }
@@ -250,15 +248,6 @@ public class AuthActivity extends AegisActivity {
                 .setConfirmationRequired(false)
                 .build();
         _bioPrompt.authenticate(info, cryptoObj);
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-
-        if (_bioPrompt != null) {
-            _bioPrompt.cancelAuthentication();
-        }
     }
 
     private void finish(MasterKey key, boolean isSlotRepaired) {


### PR DESCRIPTION
We previously stopped/started the biometric prompt every time in
onPause/onResume, but that's apparently not necessary (and discouraged according
to the documentation). This caused issues where the prompt would get stuck on
some devices. While working on this I ran into another issue where AuthActivity
was closed and reopened for no reason after rotation of the device, compounding
the issue. This patch also fixes that.

Fixes #342.