### PR TITLE
Unset "singleTask" as the launchMode for MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,8 +32,7 @@
             android:label="Select entries" />
         <activity
             android:name=".ui.MainActivity"
-            android:label="${title}"
-            android:launchMode="singleTask">
+            android:label="${title}">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/beemdevelopment/aegis/AegisApplication.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/AegisApplication.java
@@ -141,6 +141,7 @@ public class AegisApplication extends Application {
 
         Intent intent = new Intent(this, MainActivity.class);
         intent.putExtra("action", "scan");
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         intent.setAction(Intent.ACTION_MAIN);
 
         ShortcutInfo shortcut = new ShortcutInfo.Builder(this, "shortcut_new")

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -35,7 +35,7 @@ public abstract class AegisActivity extends AppCompatActivity implements AegisAp
         // if the app was killed, relaunch MainActivity and close everything else
         if (savedInstanceState != null && isOrphan()) {
             Intent intent = new Intent(this, MainActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             startActivity(intent);
             return;
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -161,20 +161,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     }
 
     @Override
-    protected void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        setIntent(intent);
-
-        doShortcutActions();
-    }
-
-    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        // don't process any activity results if the vault is locked
-        if (requestCode != CODE_DECRYPT && requestCode != CODE_DO_INTRO && _app.isVaultLocked()) {
-            return;
-        }
-
         if (resultCode != RESULT_OK) {
             return;
         }


### PR DESCRIPTION
We don't actually need this, and I have a feeling that it may be causing some of
the inexplicable crashes we're seeing in the Play Console. For example:
apparently the app sometimes gets itself into a state where the vault is
unlocked, but the user is still shown AuthActivity (possibly due to it being
launched twice). I can't prove that "singleTask" causes this, as I can't
reproduce the issue on my device or an emulator, but it's the only odd thing we
have in our activity lifecycle handling.

Test plan:
- Go through the intro, add an entry, change some settings, etc
- See if the app shortcuts still work. Scenarios:
    - The app is terminated.
    - The app is locked.
    - MainActivity is open.
    - Some other activity is open.
- See if auto-locking still works. Scenarios:
    - The app is locked.
    - MainActivity is open.
    - Some other activity is open.
- Turn on "Don't keep activities" in developer options and repeat the above
  steps.