### PR TITLE
Change hidden text to the 'Black circle' character

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -24,10 +24,12 @@ import com.beemdevelopment.aegis.otp.TotpInfo;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.google.zxing.common.StringUtils;
 
 public class EntryHolder extends RecyclerView.ViewHolder {
     private static final float DEFAULT_ALPHA = 1.0f;
     private static final float DIMMED_ALPHA = 0.2f;
+    private static final char HIDDEN_CHAR = '●';
 
     private TextView _profileName;
     private TextView _profileCode;
@@ -221,17 +223,23 @@ public class EntryHolder extends RecyclerView.ViewHolder {
 
         String otp = info.getOtp();
         if (!(info instanceof SteamInfo)) {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < otp.length(); i++) {
-                if (i != 0 && i % _codeGroupSize == 0) {
-                    sb.append(" ");
-                }
-                sb.append(otp.charAt(i));
-            }
-            otp = sb.toString();
+            otp = formatCode(otp);
         }
 
         _profileCode.setText(otp);
+    }
+
+    private String formatCode(String code) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < code.length(); i++) {
+            if (i != 0 && i % _codeGroupSize == 0) {
+                sb.append(" ");
+            }
+            sb.append(code.charAt(i));
+        }
+        code = sb.toString();
+
+        return code;
     }
 
     public void revealCode() {
@@ -240,7 +248,9 @@ public class EntryHolder extends RecyclerView.ViewHolder {
     }
 
     public void hideCode() {
-        _profileCode.setText(R.string.tap_to_reveal);
+        String hiddenText = new String(new char[_entry.getInfo().getDigits()]).replace("\0", Character.toString(HIDDEN_CHAR));
+        hiddenText = formatCode(hiddenText);
+        _profileCode.setText(hiddenText);
         _hidden = true;
     }
 

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -159,7 +159,6 @@
     <string name="pref_search_name_summary">Zahrnout shody názvů účtů do výsledků hledání</string>
     <string name="pref_highlight_entry_title">Zvýraznit tokeny po klepnutí</string>
     <string name="pref_highlight_entry_summary">Usnadnit vzájemné rozlišení tokenů dočasným zvýrazněním po kleputí</string>
-    <string name="tap_to_reveal">– skryto –</string>
     <string name="selected">Vybráno</string>
     <string name="dark_theme_title">Tmavý vzhled</string>
     <string name="light_theme_title">Světlý vzhled</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -136,7 +136,6 @@
     <string name="preference_manage_groups_summary">Verwalte und lösche deine Gruppen hier</string>
     <string name="pref_search_name_title">In Kontonamen suchen</string>
     <string name="pref_search_name_summary">Entsprechende Kontonamen in den Suchergebnissen miteinbeziehen</string>
-    <string name="tap_to_reveal">Versteckt</string>
     <string name="selected">Ausgewählt</string>
     <string name="dark_theme_title">Dunkles Thema</string>
     <string name="light_theme_title">Helles Thema</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -159,7 +159,6 @@
     <string name="pref_search_name_summary">Συμπερίληψη αντιστοίχισης ονόματος λογαριασμού στα αποτελέσματα αναζήτησης</string>
     <string name="pref_highlight_entry_title">Επισήμανση αναγνωριστικών όταν πατηθεί</string>
     <string name="pref_highlight_entry_summary">Κάνετε τα αναγνωριστικά να ξεχωρίζουν ευκολότερα το ένα από το άλλο, επισημαίνοντας τα προσωρινά όταν τα πατήσετε</string>
-    <string name="tap_to_reveal">Κρυφό</string>
     <string name="selected">Επιλεγμένο</string>
     <string name="dark_theme_title">Σκούρο θέμα</string>
     <string name="light_theme_title">Φωτεινό θέμα</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -170,7 +170,6 @@
     <string name="pref_search_name_summary">Incluir coincidencias del nombre de la cuenta en los resultados de búsqueda</string>
     <string name="pref_highlight_entry_title">Resaltar tokens al pulsarlos</string>
     <string name="pref_highlight_entry_summary">Hace que los tokens sean más fáciles de distinguir entre ellos resaltándolos temporalmente tras ser pulsados</string>
-    <string name="tap_to_reveal">Oculto</string>
     <string name="selected">Seleccionado</string>
     <string name="dark_theme_title">Tema oscuro</string>
     <string name="light_theme_title">Tema claro</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -187,7 +187,6 @@
     <string name="pref_search_name_summary">Sisällytä vastaavat tilinimet hakutuloksiin</string>
     <string name="pref_highlight_entry_title">Korosta todennustunnukset napautettaessa</string>
     <string name="pref_highlight_entry_summary">Tee todennustunnusten erottamisesta toisistaan helpompaa, korostamalla niitä väliaikaisesti, kun niitä napautetaan</string>
-    <string name="tap_to_reveal">Piilotettu</string>
     <string name="selected">Valittu</string>
     <string name="dark_theme_title">Tumma teema</string>
     <string name="light_theme_title">Vaalea teema</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -159,7 +159,6 @@
     <string name="pref_search_name_summary">Inclure les correspondances de noms de comptes dans les résultats de recherche</string>
     <string name="pref_highlight_entry_title">Surligner les jetons lorsqu\'ils sont appuyés</string>
     <string name="pref_highlight_entry_summary">Rendre les jetons plus faciles à distinguer les uns des autres en les surlignant temporairement lorsqu\'ils sont appuyés</string>
-    <string name="tap_to_reveal">Masqué</string>
     <string name="selected">Sélectionné</string>
     <string name="dark_theme_title">Thème sombre</string>
     <string name="light_theme_title">Thème</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -182,7 +182,6 @@
     <string name="pref_search_name_summary">A fióknévben egyezéseinek belevétele a találatokba</string>
     <string name="pref_highlight_entry_title">Tokenek kiemelése koppintáskor</string>
     <string name="pref_highlight_entry_summary">A tokenek könnyebb megkülönböztethetősége érdekében ideiglenesen ki lesznek emeve koppintáskor</string>
-    <string name="tap_to_reveal">Rejtett</string>
     <string name="selected">Kiválasztott</string>
     <string name="dark_theme_title">Sötét téma</string>
     <string name="light_theme_title">Világos téma</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -147,7 +147,6 @@
     <string name="pref_search_name_summary">Includi il nome dell\'account nei risultati di ricerca</string>
     <string name="pref_highlight_entry_title">Evidenzia i token quando premuti</string>
     <string name="pref_highlight_entry_summary">Rendi i token più facili da distinguere, evidenziandoli temporaneamente quando vengono toccati</string>
-    <string name="tap_to_reveal">Nascosto</string>
     <string name="selected">Selezionato</string>
     <string name="dark_theme_title">Tema scuro</string>
     <string name="light_theme_title">Tema chiaro</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -136,7 +136,6 @@
     <string name="preference_manage_groups_summary">ಇಲ್ಲಿ ನಿಮ್ಮ ಗುಂಪುಗಳನ್ನು ನಿರ್ವಹಿಸು ಮತ್ತು ಅಳಿಸು</string>
     <string name="pref_search_name_title">ಖಾತೆಯ ಹೆಸರುಗಳಲ್ಲಿ ಹುಡುಕು</string>
     <string name="pref_search_name_summary">ಹುಡುಕಾಟ ಫಲಿತಂಶದಲ್ಲಿ ಖಾತೆಯ ಹೆಸರನ್ನು ಒಳಗೊಂಡಿಸು</string>
-    <string name="tap_to_reveal">ಬಚ್ಚಿಟ್ಟಿರುವುದು</string>
     <string name="selected">ಆಯ್ಕೆ ಮಾಡಿರುವುದು</string>
     <string name="dark_theme_title">ಗಾಢ ಥೀಮ್</string>
     <string name="light_theme_title">ತಿಳಿ ಥೀಮ್</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -146,7 +146,6 @@
     <string name="pref_search_name_title">Zoek in accountnamen</string>
     <string name="pref_search_name_summary">Neem accountnaamovereenkomsten op in de zoekresultaten</string>
     <string name="pref_highlight_entry_title">Tokens markeren na aantikken</string>
-    <string name="tap_to_reveal">Verborgen</string>
     <string name="selected">Geselecteerd</string>
     <string name="dark_theme_title">Donker thema</string>
     <string name="light_theme_title">Licht thema</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -186,7 +186,6 @@
     <string name="pref_search_name_summary">Uwzględnij nazwę konta w wynikach wyszukiwania</string>
     <string name="pref_highlight_entry_title">Podświetl tokeny podczas kliknięcia</string>
     <string name="pref_highlight_entry_summary">Wyróżnij tokeny od siebie, poprzez tymczasowe podświetlenie po ich kliknięciu</string>
-    <string name="tap_to_reveal">Ukryty</string>
     <string name="selected">Wybrany</string>
     <string name="dark_theme_title">Ciemny motyw</string>
     <string name="light_theme_title">Jasny motyw</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -130,7 +130,6 @@
     <string name="group_name_hint">Название группы</string>
     <string name="preference_manage_groups">Редактировать группы</string>
     <string name="preference_manage_groups_summary">Редактирование и удаление ваших групп</string>
-    <string name="tap_to_reveal">Скрытый</string>
     <string name="selected">Выбрано</string>
     <string name="dark_theme_title">Темная тема</string>
     <string name="light_theme_title">Светлая тема</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -189,7 +189,6 @@
     <string name="pref_search_name_summary">Arama sonuçlarına hesap adı eşleşmelerini de ekle</string>
     <string name="pref_highlight_entry_title">Dokunulan kodları belirt</string>
     <string name="pref_highlight_entry_summary">Kodların birbirlerinden ayırt edilmelerini kolaylaştırmak için geçici olarak belirginleştir</string>
-    <string name="tap_to_reveal">Gizli</string>
     <string name="selected">Seçilen</string>
     <string name="dark_theme_title">Karanlık Tema</string>
     <string name="light_theme_title">Aydınlık Tema</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -161,7 +161,6 @@
     <string name="pref_search_name_summary">在搜索结果中包含匹配的帐户名称</string>
     <string name="pref_highlight_entry_title">点击时高亮令牌</string>
     <string name="pref_highlight_entry_summary">使令牌在点击后暂时高亮显示以便区分</string>
-    <string name="tap_to_reveal">隐藏</string>
     <string name="selected">选择</string>
     <string name="dark_theme_title">黑暗主题</string>
     <string name="light_theme_title">明亮主题</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,7 +203,6 @@
     <string name="pref_highlight_entry_summary">Make tokens easier to distinguish from each other by temporarily highlighting them when tapped</string>
     <string name="pref_copy_on_tap_title">Copy tokens when tapped</string>
     <string name="pref_copy_on_tap_summary">Copy tokens to the clipboard by tapping them</string>
-    <string name="tap_to_reveal">Hidden</string>
     <string name="selected">Selected</string>
     <string name="dark_theme_title">Dark theme</string>
     <string name="light_theme_title">Light theme</string>


### PR DESCRIPTION
This pull request changes the 'Hidden' text to a repeating single character as suggested [here](https://github.com/beemdevelopment/Aegis/issues/475). We went for the black circle unicode character (●) as it looks better than asterisks since these are centered and bigger. This feature also respects the 'Code digit grouping' preference as seen in the image below.


![image](https://user-images.githubusercontent.com/7524012/85310162-f6bdc900-b4b3-11ea-8d45-f1fc706e2322.png)

Fixes #475.
