### PR TITLE
Fix catching ProviderException with KeyStoreException as the cause

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/KeyStoreHandle.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/KeyStoreHandle.java
@@ -63,9 +63,9 @@ public class KeyStoreHandle {
             return generator.generateKey();
         } catch (ProviderException e) {
             // a ProviderException can occur at runtime with buggy Keymaster HAL implementations
-            // so if this was caused by a KeyStoreException, throw a KeyStoreHandleException instead
+            // so if this was caused by an android.security.KeyStoreException, throw a KeyStoreHandleException instead
             Throwable cause = e.getCause();
-            if (cause instanceof KeyStoreException) {
+            if (cause != null && cause.getClass().getName().equals("android.security.KeyStoreException")) {
                 throw new KeyStoreHandleException(cause);
             }
             throw e;


### PR DESCRIPTION
We're looking for android.security.KeyStoreException as the cause of
ProviderException, not java.security.KeyStoreException. Unfortunately this is a
hidden class, so all we can do is check the class name.