### PR TITLE
Add ability to enable PIN keyboard

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -168,6 +168,10 @@ public class Preferences {
         return _prefs.getString("pref_backups_error", null);
     }
 
+    public boolean isPinKeyboardEnabled() {
+        return _prefs.getBoolean("pref_pin_keyboard", false);
+    }
+
     public boolean isTimeSyncWarningEnabled() {
         return _prefs.getBoolean("pref_warn_time_sync", true);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
@@ -183,7 +183,7 @@ public class Dialogs {
         showSecureDialog(dialog);
     }
 
-    private static void showTextInputDialog(Context context, @StringRes int titleId, @StringRes int messageId, @StringRes int hintId, TextInputListener listener, boolean isSecret) {
+    private static void showTextInputDialog(Context context, @StringRes int titleId, @StringRes int messageId, @StringRes int hintId, TextInputListener listener, DialogInterface.OnDismissListener dismissListener, boolean isSecret) {
         View view = LayoutInflater.from(context).inflate(R.layout.dialog_text_input, null);
         EditText input = view.findViewById(R.id.text_input);
         if (isSecret) {
@@ -198,6 +198,11 @@ public class Dialogs {
                     char[] text = EditTextHelper.getEditTextChars(input);
                     listener.onTextInputResult(text);
                 });
+
+        if (dismissListener != null) {
+            builder.setOnDismissListener(dismissListener);
+        }
+
         if (messageId != 0) {
             builder.setMessage(messageId);
         }
@@ -207,7 +212,7 @@ public class Dialogs {
     }
 
     private static void showTextInputDialog(Context context, @StringRes int titleId, @StringRes int hintId, TextInputListener listener, boolean isSecret) {
-        showTextInputDialog(context, titleId, 0, hintId, listener, isSecret);
+        showTextInputDialog(context, titleId, 0, hintId, listener, null, isSecret);
     }
 
     public static void showTextInputDialog(Context context, @StringRes int titleId, @StringRes int hintId, TextInputListener listener) {
@@ -219,7 +224,11 @@ public class Dialogs {
     }
 
     public static void showPasswordInputDialog(Context context, @StringRes int messageId, TextInputListener listener) {
-        showTextInputDialog(context, R.string.set_password, messageId, R.string.password, listener, true);
+        showTextInputDialog(context, R.string.set_password, messageId, R.string.password, listener, null, true);
+    }
+
+    public static void showPasswordInputDialog(Context context, @StringRes int setPasswordMessageId, @StringRes int messageId, TextInputListener listener, DialogInterface.OnDismissListener dismissListener) {
+        showTextInputDialog(context, setPasswordMessageId, messageId, R.string.password, listener, dismissListener, true);
     }
 
     public static void showNumberPickerDialog(Activity activity, NumberInputListener listener) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="set_group">Please enter a group name</string>
     <string name="set_number">Please enter a number</string>
     <string name="set_password_confirm">Please confirm the password</string>
+    <string name="invalid_password">The password is incorrect</string>
     <string name="invalidated_biometrics">A change in your device\'s security settings has been detected. Please go to \"Aegis -> Settings -> Biometrics\" and re-enable biometric unlock.</string>
     <string name="password_reminder">It\'s been a while since you\'ve entered your password. Do you still remember it?</string>
     <string name="enter_password_authy_message">It looks like your Authy tokens are encrypted. Please close Aegis, open Authy and unlock the tokens with your password. Instead, Aegis can also attempt to decrypt your Authy tokens for you, if you enter your password below.</string>
@@ -203,6 +204,9 @@
     <string name="pref_highlight_entry_summary">Make tokens easier to distinguish from each other by temporarily highlighting them when tapped</string>
     <string name="pref_copy_on_tap_title">Copy tokens when tapped</string>
     <string name="pref_copy_on_tap_summary">Copy tokens to the clipboard by tapping them</string>
+    <string name="pin_keyboard_description">Enter your password to enable the PIN keyboard. Note that this only works if your password only consists of numbers</string>
+    <string name="pin_keyboard_error">Error enabling PIN keyboard</string>
+    <string name="pin_keyboard_error_description">It\'s not possible to set PIN keyboard. Your password must only consists of numbers.</string>
     <string name="selected">Selected</string>
     <string name="dark_theme_title">Dark theme</string>
     <string name="light_theme_title">Light theme</string>
@@ -281,4 +285,6 @@
     <string name="password_strength_fair">Fair</string>
     <string name="password_strength_good">Good</string>
     <string name="password_strength_strong">Strong</string>
+    <string name="pref_pin_keyboard_title">Use PIN keyboard on lockscreen</string>
+    <string name="pref_pin_keyboard_summary">Enable this if you want to enable the PIN keyboard on the lockscreen. This only works for numeric passwords</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -131,6 +131,13 @@
             app:iconSpaceReserved="false"/>
 
         <androidx.preference.SwitchPreferenceCompat
+            android:key="pref_pin_keyboard"
+            android:dependency="pref_encryption"
+            android:title="@string/pref_pin_keyboard_title"
+            android:summary="@string/pref_pin_keyboard_summary"
+            app:iconSpaceReserved="false"/>
+
+        <androidx.preference.SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="pref_auto_lock"
             android:dependency="pref_encryption"


### PR DESCRIPTION
This pull request allows the user to enable a PIN keyboard to use on the lockscreen. Before it can be enabled it will check if your password consists of digits. As a fallback we decided to set the keyboard to text after 3 failed attempts, which shouldn't be needed but we just wanted to make sure we don't lock users out of their vault.

<img src="https://user-images.githubusercontent.com/7524012/86538620-5aee7d00-bef7-11ea-944c-f7eb21a42349.png" width="200"> <img src="https://user-images.githubusercontent.com/7524012/86538621-5b871380-bef7-11ea-95dd-05d636f30625.png" width="200"><img src="https://user-images.githubusercontent.com/7524012/86538623-5b871380-bef7-11ea-94dd-8b00f1d11167.png" width="200">

I also included a fix to dismiss the keyboard if the user triggers the bioprompt.

Closes #54


