### PR TITLE
Fix an issue where the progress bar refresher ran in a tight loop

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/TotpProgressBar.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/TotpProgressBar.java
@@ -66,11 +66,12 @@ public class TotpProgressBar extends ProgressBar {
 
         // start progress animation, compensating for any changes to the animator duration scale settings
         float animPart = (float) maxProgress / _period;
-        int animEnd = (int) ((currentProgress / animPart) * animPart);
-        int animPartDuration = (int) (1000 / _animDurationScale);
+        int animEnd = (int) (Math.floor(currentProgress / animPart) * animPart);
+        int animPartDuration = _animDurationScale > 0 ? (int) (1000 / _animDurationScale) : 0;
         float animDurationFraction = (float) (currentProgress - animEnd) / animPart;
-        int realAnimDuration =  (int) (1000 * animDurationFraction);
+        int realAnimDuration = (int) (1000 * animDurationFraction);
         int animDuration =  (int) (animPartDuration * animDurationFraction);
+
         ObjectAnimator animation = ObjectAnimator.ofInt(this, "progress", currentProgress, animEnd);
         animation.setDuration(animDuration);
         animation.setInterpolator(new LinearInterpolator());


### PR DESCRIPTION
If the animator scale setting is set to 0, the progress bar refresher would run in a tight loop. This issue was introduced by 93cc945a2c9cd1cdaefc745b33a196cdeec198ac and caused the UI tests to fail.