### PR TITLE
Preserve backwards compatibility with Android < 7.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ android {
     compileOptions {
         targetCompatibility 1.8
         sourceCompatibility 1.8
+        coreLibraryDesugaringEnabled true
     }
 }
 
@@ -150,4 +151,6 @@ dependencies {
     testImplementation "com.google.guava:guava:${guavaVersion}-jre"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 08 13:48:01 GMT 2020
+#Sun Jul 12 15:51:57 GMT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Fixes #520 <s>by downgrading com.google.zxing package to 3.3.3 (in 3.4.0 they dropped support of older Androids which are still widely used worldwide)</s> by adding desugaring for some features used in com.google.zxing