### PR TITLE
Grammar fix (setup -> set up)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
     <string name="welcome">Welcome</string>
     <string name="app_description">Aegis is a free, secure and open source 2FA app</string>
     <string name="setup_completed">Setup completed</string>
-    <string name="setup_completed_description">Aegis has been setup and is ready to go.</string>
+    <string name="setup_completed_description">Aegis has been set up and is ready to go.</string>
     <string name="vault_not_found">Vault not found, starting setup…</string>
     <string name="copied">Copied</string>
     <string name="errors_copied">Errors copied to the clipboard</string>


### PR DESCRIPTION
Setup is a noun (i.e. the setup process), whereas "set up" is a verb. (i.e. to set something up). 
e.g. Once _the setup_ has been completed, you would say Aegis has _been  set up_. 