### PR TITLE
Add empty state for GroupManagerActivity

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
@@ -3,6 +3,7 @@ package com.beemdevelopment.aegis.ui;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.View;
 
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.ui.views.GroupAdapter;
@@ -18,6 +19,8 @@ import androidx.recyclerview.widget.RecyclerView;
 public class GroupManagerActivity extends AegisActivity implements GroupAdapter.Listener {
     private GroupAdapter _adapter;
     private TreeSet<String> _groups;
+    private RecyclerView _slotsView;
+    private View _emptyStateView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -35,14 +38,27 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
 
         // set up the recycler view
         _adapter = new GroupAdapter(this);
-        RecyclerView slotsView = findViewById(R.id.list_slots);
+        _slotsView= findViewById(R.id.list_slots);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
-        slotsView.setLayoutManager(layoutManager);
-        slotsView.setAdapter(_adapter);
-        slotsView.setNestedScrollingEnabled(false);
+        _slotsView.setLayoutManager(layoutManager);
+        _slotsView.setAdapter(_adapter);
+        _slotsView.setNestedScrollingEnabled(false);
 
         for (String group : _groups) {
             _adapter.addGroup(group);
+        }
+
+        _emptyStateView = findViewById(R.id.vEmptyList);
+        updateEmptyState();
+    }
+
+    private void updateEmptyState() {
+        if (_adapter.getItemCount() > 0) {
+            _slotsView.setVisibility(View.VISIBLE);
+            _emptyStateView.setVisibility(View.GONE);
+        } else {
+            _slotsView.setVisibility(View.GONE);
+            _emptyStateView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -54,6 +70,7 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
                 .setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {
                     _groups.remove(group);
                     _adapter.removeGroup(group);
+                    updateEmptyState();
                 })
                 .setNegativeButton(android.R.string.no, null)
                 .create());

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -710,6 +710,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
                 entry.setGroup(null);
             }
         }
+
+        saveVault();
     }
 
     private void onSelectEntriesResult(int resultCode, Intent data) {

--- a/app/src/main/res/drawable/ic_layers_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_layers_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11.99,18.54l-7.37,-5.73L3,14.07l9,7 9,-7 -1.63,-1.27 -7.38,5.74zM12,16l7.36,-5.73L21,9l-9,-7 -9,7 1.63,1.27L12,16z"/>
+</vector>

--- a/app/src/main/res/layout/activity_groups.xml
+++ b/app/src/main/res/layout/activity_groups.xml
@@ -23,9 +23,50 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:scrollbars="vertical"/>
-
         </LinearLayout>
-
     </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center|fill_vertical"
+        android:id="@+id/vEmptyList"
+        android:visibility="gone"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingBottom="150dp">
+
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:src="@drawable/ic_layers_black_24dp"
+                app:tint="?attr/primaryText" />
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/empty_group_list_title"
+                android:paddingTop="17dp"
+                android:textColor="?attr/primaryText"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/textView5"
+                android:layout_width="300dp"
+                android:layout_height="wrap_content"
+                android:lineSpacingExtra="5dp"
+                android:paddingTop="7dp"
+                android:text="@string/empty_group_list"
+                android:textAlignment="center" />
+        </LinearLayout>
+    </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,6 +287,8 @@
     </string>
     <string name="empty_list">There are no codes to be shown. Start adding entries by tapping the plus sign in the bottom right corner</string>
     <string name="empty_list_title">No entries found</string>
+    <string name="empty_group_list">There are no groups to be shown. Add groups in the edit screen of an entry</string>
+    <string name="empty_group_list_title">No groups found</string>
     <string name="done">Done</string>
     <plurals name="entries_count">
         <item quantity="one">%d / %d entry</item>


### PR DESCRIPTION
This pull requests adds an empty state view for the GroupManagerActivity found in the preferences. Also added a fix where the deleted groups didn't get saved properly.

<img src="https://user-images.githubusercontent.com/7524012/90160640-589efe80-dd92-11ea-92c2-4b53b5de55ce.png" width="300"/>

Closes #553