### PR TITLE
Add checkbox dialog to wipe vault before import

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
@@ -231,6 +231,37 @@ public class Dialogs {
         showTextInputDialog(context, setPasswordMessageId, messageId, R.string.password, listener, dismissListener, true);
     }
 
+    public static void showCheckboxDialog(Context context, @StringRes int titleId, @StringRes int messageId, @StringRes int checkboxMessageId, CheckboxInputListener listener) {
+        View view = LayoutInflater.from(context).inflate(R.layout.dialog_checkbox, null);
+        CheckBox checkBox = view.findViewById(R.id.checkbox);
+        checkBox.setText(checkboxMessageId);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(context)
+                .setTitle(titleId)
+                .setView(view)
+                .setNegativeButton(R.string.no, (dialog1, which) ->
+                        listener.onCheckboxInputResult(false))
+                .setPositiveButton(R.string.yes, (dialog1, which) ->
+                        listener.onCheckboxInputResult(checkBox.isChecked()));
+
+        if (messageId != 0) {
+            builder.setMessage(messageId);
+        }
+
+        AlertDialog dialog = builder.create();
+
+        final AtomicReference<Button> buttonOK = new AtomicReference<>();
+        dialog.setOnShowListener(d -> {
+            Button button = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+            button.setEnabled(false);
+            buttonOK.set(button);
+        });
+
+        checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> buttonOK.get().setEnabled(isChecked));
+
+        showSecureDialog(dialog);
+    }
+
     public static void showNumberPickerDialog(Activity activity, NumberInputListener listener) {
         View view = activity.getLayoutInflater().inflate(R.layout.dialog_number_picker, null);
         NumberPicker numberPicker = view.findViewById(R.id.numberPicker);
@@ -348,6 +379,10 @@ public class Dialogs {
                     }
                 })
                 .create());
+    }
+
+    public interface CheckboxInputListener {
+        void onCheckboxInputResult(boolean checkbox);
     }
 
     public interface NumberInputListener {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -38,6 +38,7 @@ import com.beemdevelopment.aegis.ui.models.ImportEntry;
 import com.beemdevelopment.aegis.ui.preferences.SwitchPreference;
 import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
 import com.beemdevelopment.aegis.util.UUIDMap;
+import com.beemdevelopment.aegis.vault.Vault;
 import com.beemdevelopment.aegis.vault.VaultBackupManager;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
@@ -657,6 +658,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         Intent intent = new Intent(getActivity(), SelectEntriesActivity.class);
         intent.putExtra("entries", (ArrayList<ImportEntry>) entries);
         intent.putExtra("errors", (ArrayList<DatabaseImporterEntryException>) result.getErrors());
+        intent.putExtra("vaultContainsEntries", _vault.getEntries().size() > 0);
         startActivityForResult(intent, CODE_SELECT_ENTRIES);
     }
 
@@ -717,6 +719,11 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
     private void onSelectEntriesResult(int resultCode, Intent data) {
         if (resultCode != Activity.RESULT_OK) {
             return;
+        }
+
+        boolean wipeEntries = data.getBooleanExtra("wipeEntries", false);
+        if (wipeEntries) {
+            _vault.wipeEntries();
         }
 
         List<ImportEntry> selectedEntries = (ArrayList<ImportEntry>) data.getSerializableExtra("entries");

--- a/app/src/main/java/com/beemdevelopment/aegis/util/UUIDMap.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/util/UUIDMap.java
@@ -45,6 +45,13 @@ public class UUIDMap <T extends UUIDMap.Value> implements Iterable<T>, Serializa
     }
 
     /**
+     * Clears the internal map.
+     */
+    public void wipe() {
+        _map.clear();
+    }
+
+    /**
      * Replaces an old value (with the same UUID as the new given value) in the
      * internal map with the new given value.
      * @throws AssertionError if no map value exists with the UUID of the given value.

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -154,6 +154,10 @@ public class VaultManager {
         return _vault.getEntries().remove(entry);
     }
 
+    public void wipeEntries() {
+        _vault.getEntries().wipe();
+    }
+
     public VaultEntry replaceEntry(VaultEntry entry) {
         return _vault.getEntries().replace(entry);
     }

--- a/app/src/main/res/layout/dialog_checkbox.xml
+++ b/app/src/main/res/layout/dialog_checkbox.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp"
+    android:paddingTop="20dp">
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <requestFocus/>
+    </CheckBox>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,4 +315,7 @@
     <string name="title_activity_scan_qr">Scan a QR code</string>
     <string name="title_activity_manage_slots">Manage key slots</string>
     <string name="title_activity_select_entries">Select entries</string>
+    <string name="dialog_wipe_entries_title">Wipe entries</string>
+    <string name="dialog_wipe_entries_message">Your vault already contains entries. Do you want to remove these entries before importing this file?\n\n<b>In doing so, you will permanently lose access to the existing entries in the vault.</b></string>
+    <string name="dialog_wipe_entries_checkbox">Wipe vault contents</string>
 </resources>


### PR DESCRIPTION
This pull request adds a checkbox dialog when importing a file when the vault already contains entries. When the checkbox is checked, all the existing entries will be wiped. This was suggested in #276.

<img src="https://user-images.githubusercontent.com/7524012/90324758-079a3080-df73-11ea-86d8-09078f50ded0.png" width="300"/>

Closes #276.