### PR TITLE
Minor color improvements for dark themes

### DIFF
--- a/app/src/main/res/drawable/entry_divider.xml
+++ b/app/src/main/res/drawable/entry_divider.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/divider"/>
+    <solid android:color="?attr/divider"/>
     <size android:height="0.1dp"/>
 </shape>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -34,8 +34,8 @@
     <color name="code_primary_text">#1058C9</color>
     <color name="code_primary_text_dark">#ffffff</color>
 
-    <color name="card_background_dark">#363636</color>
-    <color name="card_background_focused_dark">#6B6B6B</color>
+    <color name="card_background_dark">#2B2B2B</color>
+    <color name="card_background_focused_dark">#303030</color>
     <color name="card_background_focused_true_dark">#363636</color>
     <color name="primary_text_dark">#ffffff</color>
     <color name="hint_text_dark">#a7a7a7</color>
@@ -43,6 +43,8 @@
     <color name="background_dark">#212121</color>
     <color name="background_dark_statusbar">#101010</color>
     <color name="background_true_dark">#000000</color>
+    <color name="divider_dark">#393939</color>
+    <color name="divider_true_dark">#222222</color>
 
     <color name="warning_color">#f4511e</color>
     <color name="hint_color">#42000000</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,6 +24,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="background">@color/background</item>
+        <item name="divider">@color/divider</item>
 
         <item name="iconColorPrimary">@color/icon_primary</item>
         <item name="iconColorInverted">@color/icon_primary_inverted</item>
@@ -135,6 +136,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="background">@color/background_dark</item>
+        <item name="divider">@color/divider_dark</item>
 
         <item name="iconColorPrimary">@color/icon_primary_dark</item>
         <item name="iconColorInverted">@color/icon_primary_dark_inverted</item>
@@ -158,6 +160,7 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="actionModeStyle">@style/ActionModeStyle.TrueBlack</item>
         <item name="alertDialogTheme">@style/DialogStyle.TrueDark</item>
+        <item name="divider">@color/divider_true_dark</item>
 
         <item name="android:navigationBarColor" tools:targetApi="lollipop">@color/background_true_dark</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>


### PR DESCRIPTION
This pull request adds some minor theme improvement as discussed in #294.


Left: this pull request, right: old color
![image](https://user-images.githubusercontent.com/7524012/90338951-92b80c80-dfed-11ea-9602-8ce52009de69.png)


Closes #294