### PR TITLE
Reset the PIN keyboard option when the password is changed

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesFragment.java
@@ -36,9 +36,7 @@ import com.beemdevelopment.aegis.services.NotificationService;
 import com.beemdevelopment.aegis.ui.models.ImportEntry;
 import com.beemdevelopment.aegis.ui.preferences.SwitchPreference;
 import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
-import com.beemdevelopment.aegis.ui.tasks.ProgressDialogTask;
 import com.beemdevelopment.aegis.util.UUIDMap;
-import com.beemdevelopment.aegis.vault.Vault;
 import com.beemdevelopment.aegis.vault.VaultBackupManager;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
@@ -925,6 +923,11 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
             _vault.setCredentials(creds);
             saveVault();
+
+            if (_prefs.isPinKeyboardEnabled()) {
+                setPinKeyboardPreference(false);
+                Toast.makeText(getContext(), R.string.pin_keyboard_disabled, Toast.LENGTH_SHORT).show();
+            }
         }
 
         @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="pin_keyboard_description">Enter your password to enable the PIN keyboard. Note that this only works if your password only consists of numbers</string>
     <string name="pin_keyboard_error">Error enabling PIN keyboard</string>
     <string name="pin_keyboard_error_description">It\'s not possible to set PIN keyboard. Your password must only consists of numbers.</string>
+    <string name="pin_keyboard_disabled">Password changed. The PIN keyboard will no longer be shown.</string>
     <string name="selected">Selected</string>
     <string name="dark_theme_title">Dark theme</string>
     <string name="light_theme_title">Light theme</string>


### PR DESCRIPTION
This fixes an issue where the PIN keyboard was shown after a password change, regardless of whether it only contained digits or not.