### PR TITLE
Resize images to a max res of 640x480 before scanning for QR codes

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/BitmapHelper.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/BitmapHelper.java
@@ -1,0 +1,31 @@
+package com.beemdevelopment.aegis.helpers;
+
+import android.graphics.Bitmap;
+
+public class BitmapHelper {
+    private BitmapHelper() {
+
+    }
+
+    /**
+     * Scales the given Bitmap to the given maximum width/height, while keeping the aspect ratio intact.
+     */
+    public static Bitmap resize(Bitmap bitmap, int maxWidth, int maxHeight) {
+        if (maxHeight <= 0 || maxWidth <= 0) {
+            return bitmap;
+        }
+
+        float maxRatio = (float) maxWidth / maxHeight;
+        float ratio = (float) bitmap.getWidth() / bitmap.getHeight();
+
+        int width = maxWidth;
+        int height = maxHeight;
+        if (maxRatio > 1) {
+            width = (int) ((float) maxHeight * ratio);
+        } else {
+            height = (int) ((float) maxWidth / ratio);
+        }
+
+        return Bitmap.createScaledBitmap(bitmap, width, height, true);
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -29,6 +29,7 @@ import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
 import com.beemdevelopment.aegis.ViewMode;
+import com.beemdevelopment.aegis.helpers.BitmapHelper;
 import com.beemdevelopment.aegis.helpers.FabScrollHelper;
 import com.beemdevelopment.aegis.helpers.PermissionHelper;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfo;
@@ -310,6 +311,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
 
             try (InputStream inputStream = getContentResolver().openInputStream(inputFile)) {
                 bitmap = BitmapFactory.decodeStream(inputStream, null, bmOptions);
+                bitmap = BitmapHelper.resize(bitmap, 640, 480);
             }
 
             int[] intArray = new int[bitmap.getWidth() * bitmap.getHeight()];


### PR DESCRIPTION
I'm not sure why this works, but ZXing seems to have trouble with high resolution images. For example, scanning a 4032x3024 image with a QR code in it fails, but scanning a resized version of that exact same image works.

Fixes #538.