### PR TITLE
"Tap to reveal": change min duration from 3 to 1

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/Dialogs.java
@@ -271,7 +271,7 @@ public class Dialogs {
     public static void showNumberPickerDialog(Activity activity, NumberInputListener listener) {
         View view = activity.getLayoutInflater().inflate(R.layout.dialog_number_picker, null);
         NumberPicker numberPicker = view.findViewById(R.id.numberPicker);
-        numberPicker.setMinValue(3);
+        numberPicker.setMinValue(1);
         numberPicker.setMaxValue(60);
         numberPicker.setValue(new Preferences(activity.getApplicationContext()).getTapToRevealTime());
         numberPicker.setWrapSelectorWheel(true);


### PR DESCRIPTION
"Tap to reveal" currently allows setting the display time to 3 seconds or more.
However, as a single second is actually enough to read the token, the duration of 1 and 2 seconds should be available as option for users that want to choose such short duration for improved privacy/security.