### PR TITLE
Move the creation of exports/backups to a background thread

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/AegisApplication.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/AegisApplication.java
@@ -140,7 +140,9 @@ public class AegisApplication extends Application {
      * @param userInitiated whether or not the user initiated the lock in MainActivity.
      */
     public void lock(boolean userInitiated) {
+        _manager.destroy();
         _manager = null;
+
         for (LockListener listener : _lockListeners) {
             listener.onLocked(userInitiated);
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/ExportTask.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/tasks/ExportTask.java
@@ -1,0 +1,64 @@
+package com.beemdevelopment.aegis.ui.tasks;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.util.IOUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ExportTask extends ProgressDialogTask<ExportTask.Params, Exception> {
+    private final Callback _cb;
+
+    public ExportTask(Context context, Callback cb) {
+        super(context, context.getString(R.string.exporting_vault));
+        _cb = cb;
+    }
+
+    @Override
+    protected Exception doInBackground(ExportTask.Params... args) {
+        setPriority();
+
+        ExportTask.Params params = args[0];
+        try (InputStream inStream = new FileInputStream(params.getFile());
+             OutputStream outStream = getDialog().getContext().getContentResolver().openOutputStream(params.getDestUri(), "w")) {
+            IOUtils.copy(inStream, outStream);
+            return null;
+        } catch (IOException e) {
+            return e;
+        }
+    }
+
+    @Override
+    protected void onPostExecute(Exception e) {
+        super.onPostExecute(e);
+        _cb.onTaskFinished(e);
+    }
+
+    public static class Params {
+        private final File _file;
+        private final Uri _destUri;
+
+        public Params(File file, Uri destUri) {
+            _file = file;
+            _destUri = destUri;
+        }
+
+        public File getFile() {
+            return _file;
+        }
+
+        public Uri getDestUri() {
+            return _destUri;
+        }
+    }
+
+    public interface Callback {
+        void onTaskFinished(Exception e);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="password_equality_error">Passwords should be identical and non-empty</string>
     <string name="snackbar_authentication_method">Please select an authentication method</string>
     <string name="encrypting_vault">Encrypting the vault</string>
+    <string name="exporting_vault">Exporting the vault</string>
     <string name="delete_entry">Delete entry</string>
     <string name="delete_entry_description">Are you sure you want to delete this entry?</string>
     <string name="delete_entries">Delete entries</string>
@@ -165,7 +166,7 @@
     <string name="disable_encryption_description">Are you sure you want to disable encryption? This will cause the vault to be stored in plain text.</string>
     <string name="enable_encryption_error">An error occurred while enabling encryption</string>
     <string name="disable_encryption_error">An error occurred while disabling encryption</string>
-    <string name="backup_successful">The backup was created successfully</string>
+    <string name="backup_successful">The backup was scheduled successfully</string>
     <string name="backup_error">An error occurred while trying to create a backup</string>
     <string name="permission_denied">Permission denied</string>
     <string name="andotp_new_format">New format (v0.6.3 or newer) </string>


### PR DESCRIPTION
This writes exports/backups to the cache directory first and then hands off to a background thread to pipe the file to SAF. I'm cheating a bit, but it's the easiest fix with our current architecture. In the future, we should skip the first step by making VaultManager itself thread-safe.

Fixes #610.