### PR TITLE
Display the password reminder popup on top instead of the bottom

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/MetricsHelper.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/MetricsHelper.java
@@ -1,0 +1,14 @@
+package com.beemdevelopment.aegis.helpers;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+
+public class MetricsHelper {
+    private MetricsHelper() {
+
+    }
+
+    public static int convertDpToPixels(Context context, float dp) {
+        return (int) (dp * (context.getResources().getDisplayMetrics().densityDpi / DisplayMetrics.DENSITY_DEFAULT));
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -31,6 +31,7 @@ import com.beemdevelopment.aegis.crypto.KeyStoreHandleException;
 import com.beemdevelopment.aegis.crypto.MasterKey;
 import com.beemdevelopment.aegis.helpers.BiometricsHelper;
 import com.beemdevelopment.aegis.helpers.EditTextHelper;
+import com.beemdevelopment.aegis.helpers.MetricsHelper;
 import com.beemdevelopment.aegis.helpers.UiThreadExecutor;
 import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
 import com.beemdevelopment.aegis.vault.VaultFile;
@@ -231,13 +232,22 @@ public class AuthActivity extends AegisActivity {
 
     private void showPasswordReminder() {
         View popupLayout = getLayoutInflater().inflate(R.layout.popup_password, null);
+        popupLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+
         PopupWindow popup = new PopupWindow(popupLayout, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         popup.setFocusable(false);
         popup.setOutsideTouchable(true);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
             popup.setElevation(5.0f);
         }
-        _textPassword.post(() -> popup.showAsDropDown(_textPassword));
+        _textPassword.post(() -> {
+            // calculating the actual height of the popup window does not seem possible
+            // adding 25dp seems to look good enough
+            int yoff = _textPassword.getHeight()
+                    + popupLayout.getMeasuredHeight()
+                    + MetricsHelper.convertDpToPixels(this, 25);
+            popup.showAsDropDown(_textPassword, 0, -yoff);
+        });
         _textPassword.postDelayed(popup::dismiss, 5000);
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
 import com.beemdevelopment.aegis.ViewMode;
+import com.beemdevelopment.aegis.helpers.MetricsHelper;
 import com.beemdevelopment.aegis.helpers.SimpleItemTouchHelperCallback;
 import com.beemdevelopment.aegis.helpers.UiRefresher;
 import com.beemdevelopment.aegis.otp.TotpInfo;
@@ -392,7 +393,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
 
         private VerticalSpaceItemDecoration(float dp) {
             // convert dp to pixels
-            _height = (int) (dp * (getContext().getResources().getDisplayMetrics().densityDpi / 160f));
+            _height = MetricsHelper.convertDpToPixels(getContext(), dp);
         }
 
         @Override


### PR DESCRIPTION
This prevents the Android's autofill popup from occluding our popup