### PR TITLE
Explicitly define which packages (apps) we want to query

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -97,4 +97,14 @@
         </provider>
     </application>
 
+    <queries>
+        <package android:name="com.authy.authy" />
+        <package android:name="org.fedorahosted.freeotp" />
+        <package android:name="org.liberty.android.freeotpplus" />
+        <package android:name="com.google.android.apps.authenticator2" />
+        <package android:name="com.azure.authenticator" />
+        <package android:name="com.valvesoftware.android.steam.community" />
+        <package android:name="com.authenticator.authservice2" />
+    </queries>
+
 </manifest>


### PR DESCRIPTION
This is necessary to be able to see if the app a user wants to import from is installed.
See: https://developer.android.com/about/versions/11/privacy/package-visibility

Fixes #638.