### PR TITLE
Show a clearer error message when encountering phonefactor:// URI's

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/otp/GoogleAuthInfoException.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/GoogleAuthInfoException.java
@@ -1,16 +1,30 @@
 package com.beemdevelopment.aegis.otp;
 
+import android.net.Uri;
+
 public class GoogleAuthInfoException extends Exception {
-    public GoogleAuthInfoException(Throwable cause) {
+    private final Uri _uri;
+
+    public GoogleAuthInfoException(Uri uri, Throwable cause) {
         super(cause);
+        _uri = uri;
     }
 
-    public GoogleAuthInfoException(String message) {
+    public GoogleAuthInfoException(Uri uri, String message) {
         super(message);
+        _uri = uri;
     }
 
-    public GoogleAuthInfoException(String message, Throwable cause) {
+    public GoogleAuthInfoException(Uri uri, String message, Throwable cause) {
         super(message, cause);
+        _uri = uri;
+    }
+
+    /**
+     * Reports whether the scheme of the URI is phonefactor://.
+     */
+    public boolean isPhoneFactor() {
+        return _uri != null && _uri.getScheme() != null && _uri.getScheme().equals("phonefactor");
     }
 
     @Override
@@ -19,6 +33,7 @@ public class GoogleAuthInfoException extends Exception {
         if (cause == null) {
             return super.getMessage();
         }
+
         return String.format("%s (%s)", super.getMessage(), cause.getMessage());
     }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/ScannerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/ScannerActivity.java
@@ -156,7 +156,9 @@ public class ScannerActivity extends AegisActivity implements QrCodeAnalyzer.Lis
             }
         } catch (GoogleAuthInfoException e) {
             e.printStackTrace();
-            Dialogs.showErrorDialog(this, R.string.read_qr_error, e, ((dialog, which) -> bindPreview(_cameraProvider)));
+            Dialogs.showErrorDialog(this,
+                    e.isPhoneFactor() ? R.string.read_qr_error_phonefactor : R.string.read_qr_error,
+                    e, ((dialog, which) -> bindPreview(_cameraProvider)));
             _cameraProvider.unbindAll();
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,6 +192,7 @@
     <string name="encryption_enable_biometrics_error">An error occurred while trying to enable biometric unlock. Some devices have poor implementations of biometric authentication and it is likely that yours is one of them. Consider switching to a password-only configuration instead.</string>
     <string name="no_cameras_available">No cameras available</string>
     <string name="read_qr_error">An error occurred while trying to read the QR code</string>
+    <string name="read_qr_error_phonefactor">Aegis is not compatible with Microsoft\'s proprietary 2FA algorithm. Please make sure to select \"Setup application without notifications\" when configuring 2FA in Office 365.</string>
     <string name="authentication_method_raw">Raw</string>
     <string name="unlocking_vault">Unlocking the vault</string>
     <string name="unlocking_vault_repair">Unlocking the vault (repairing)</string>


### PR DESCRIPTION
Sometimes users get confused when they're trying to scan a Microsoft Authenticator QR code and think the error occurs because of a bug in Aegis.