### PR TITLE
Add dark theme variants of the fullscreen style

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ThemeMap.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ThemeMap.java
@@ -20,4 +20,10 @@ public class ThemeMap {
             Theme.DARK, R.style.AppTheme_Dark_NoActionBar,
             Theme.AMOLED, R.style.AppTheme_TrueBlack_NoActionBar
     );
+
+    public static final Map<Theme, Integer> FULLSCREEN = ImmutableMap.of(
+            Theme.LIGHT, R.style.AppTheme_Fullscreen,
+            Theme.DARK, R.style.AppTheme_Fullscreen_Dark,
+            Theme.AMOLED, R.style.AppTheme_Fullscreen_TrueBlack
+    );
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/ScannerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/ScannerActivity.java
@@ -17,6 +17,7 @@ import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
 
 import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.ThemeMap;
 import com.beemdevelopment.aegis.helpers.QrCodeAnalyzer;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfo;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfoException;
@@ -77,7 +78,7 @@ public class ScannerActivity extends AegisActivity implements QrCodeAnalyzer.Lis
 
     @Override
     protected void onSetTheme() {
-        setTheme(R.style.AppTheme_Fullscreen);
+        setTheme(ThemeMap.FULLSCREEN);
     }
 
     @Override

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -126,6 +126,30 @@
         <item name="android:windowFullscreen">true</item>
     </style>
 
+    <style name="AppTheme.Fullscreen.Dark" parent="AppTheme.Dark">
+        <!-- AppTheme.TransparentActionBar-->
+        <item name="android:actionBarStyle">@style/ThemeActionBar</item>
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="actionBarStyle">@style/ThemeActionBar</item>
+        <item name="windowActionBarOverlay">true</item>
+
+        <!-- AppTheme.Fullscreen-->
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+
+    <style name="AppTheme.Fullscreen.TrueBlack" parent="AppTheme.TrueBlack">
+        <!-- AppTheme.TransparentActionBar-->
+        <item name="android:actionBarStyle">@style/ThemeActionBar</item>
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="actionBarStyle">@style/ThemeActionBar</item>
+        <item name="windowActionBarOverlay">true</item>
+
+        <!-- AppTheme.Fullscreen-->
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+
     <style name="AppTheme.Dark" parent="Theme.AppCompat">
         <item name="primaryText">@color/primary_text_dark</item>
         <item name="secondaryText">@color/secondary_text_dark</item>


### PR DESCRIPTION
Fixes #658.

The current full screen style does not support the Dark and AMOLED themes. This change adds two new full screen themes, `AppTheme.Fullscreen.Dark` and `AppTheme.Fullscreen.TrueBlack`. A new ThemeMap is added, `FULLSCREEN`, which is now  used by the ScannerActivity to set an appropriately themed full screen style.

I would have preferred to simply merge the existing `AppTheme.Fullscreen` style with an appropriate `DEFAULT` ThemeMap value but I could not find a way to merge two styles together, nor apply multiple styles at the same time. Additionally, since style inheritance is limited to a single parent, I could not inherit from more than one style when creating the new full screen styles. The end result is that some style items had to be manually copied across (I opted to copy across the existing full screen style's items, including its parent's items).

If there's a cleaner way to do this change let me know and I'll amend the commit.