### PR TITLE
Downgrade zip4j to 2.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,7 +152,8 @@ dependencies {
     implementation 'com.nulab-inc:zxcvbn:1.3.1'
     implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation 'de.psdev.licensesdialog:licensesdialog:2.1.0'
-    implementation 'net.lingala.zip4j:zip4j:2.6.4'
+    // NOTE: this is kept at an old version on purpose (something in newer versions breaks the Authenticator Plus importer)
+    implementation 'net.lingala.zip4j:zip4j:2.6.0'
     implementation 'info.guardianproject.trustedintents:trustedintents:0.2'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.68'
 


### PR DESCRIPTION
It looks like we broke the Authenticator Plus importer in
d660fbc6d1aa2facfa5358d38782d92b80cb769f by upgrading zip4j. So this patch
downgrades it again. I couldn't immediately find this issue in their issue
tracker, so it may be worth spending some time reporting this to them later.

Fixes #665.