### PR TITLE
add shortcut for applying group filter

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.Menu;
@@ -56,6 +57,7 @@ import com.google.zxing.qrcode.QRCodeReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -403,6 +405,10 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             case "scan":
                 startScanActivity();
                 break;
+            case "set_group_filter":
+                String[] groups = intent.getStringArrayExtra("groups");
+                _entryListView.setPrefGroupFilter(Arrays.asList(groups));
+                break;
         }
 
         intent.removeExtra("action");
@@ -727,6 +733,10 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     @Override
     public void onSaveGroupFilter(List<String> groupFilter) {
         getPreferences().setGroupFilter(groupFilter);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            _app.initAppShortcuts();
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,4 +391,9 @@
 
     <string name="importer_help_direct">Import entries directly from %s. This requires the app to be installed on this device and for root access to be granted to Aegis.</string>
     <string name="groups">Groups</string>
+
+    <plurals name="open_groups">
+        <item quantity="one">Open group %1$s</item>
+        <item quantity="other">Open groups %1$s</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
This adds a shortcut for applying a given group filter. Clicking on the shortcut opens the app and applies the group filter that was saved. This is useful for rapidly viewing entries for a specific group.

Currently the app only generates a shortcut for the current group filter. The way Android handles shortcuts is that the intent gets saved with the shortcut, so even if the group filter within the app is changed/removed, the group filter for the shortcut stays the same. If you want to create one shortcut for group "foo" and another for group "bar", you'd set the group filter to "foo", go to home screen, drag the shortcut "Open group foo" to home screen, open the app, change the group filter to "bar", go to home screen, and drag the shortcut for "Open group bar" to homescreen. At this point tapping on the "foo" icon would open the app with the "foo" filter applied, and tapping on the "bar" icon would open the app with the "bar" filter applied. Group filters with multiple groups selected is also supported.

TODOs:
* find/make an appropriate icon for the shortcut

<img width="300" src="https://user-images.githubusercontent.com/8795734/121820591-4710d680-cc83-11eb-8e63-c2a3bf7324dc.png"/>