### PR TITLE
Option to Disable Automatic Refresh for Selected Code

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -53,6 +53,12 @@ public class Preferences {
         return _prefs.getBoolean("pref_highlight_entry", false);
     }
 
+    public boolean isPauseFocusedEnabled() {
+        boolean dependenciesEnabled = isTapToRevealEnabled() || isEntryHighlightEnabled();
+        if (!dependenciesEnabled) return false;
+        return _prefs.getBoolean("pref_pause_entry", false);
+    }
+
     public boolean isPanicTriggerEnabled() {
         return _prefs.getBoolean("pref_panic_trigger", false);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -114,6 +114,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _entryListView.setCodeGroupSize(getPreferences().getCodeGroupSize());
         _entryListView.setShowAccountName(getPreferences().isAccountNameVisible());
         _entryListView.setHighlightEntry(getPreferences().isEntryHighlightEnabled());
+        _entryListView.setPauseFocused(getPreferences().isPauseFocusedEnabled());
         _entryListView.setTapToReveal(getPreferences().isTapToRevealEnabled());
         _entryListView.setTapToRevealTime(getPreferences().getTapToRevealTime());
         _entryListView.setSortCategory(getPreferences().getCurrentSortCategory(), false);
@@ -239,6 +240,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                 boolean showAccountName = getPreferences().isAccountNameVisible();
                 int codeGroupSize = getPreferences().getCodeGroupSize();
                 boolean highlightEntry = getPreferences().isEntryHighlightEnabled();
+                boolean pauseFocused = getPreferences().isPauseFocusedEnabled();
                 boolean tapToReveal = getPreferences().isTapToRevealEnabled();
                 int tapToRevealTime = getPreferences().getTapToRevealTime();
                 ViewMode viewMode = getPreferences().getCurrentViewMode();
@@ -246,6 +248,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                 _entryListView.setShowAccountName(showAccountName);
                 _entryListView.setCodeGroupSize(codeGroupSize);
                 _entryListView.setHighlightEntry(highlightEntry);
+                _entryListView.setPauseFocused(pauseFocused);
                 _entryListView.setTapToReveal(tapToReveal);
                 _entryListView.setTapToRevealTime(tapToRevealTime);
                 _entryListView.setViewMode(viewMode);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/BehaviorPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/BehaviorPreferencesFragment.java
@@ -3,13 +3,21 @@ package com.beemdevelopment.aegis.ui.fragments;
 import android.os.Bundle;
 
 import androidx.preference.Preference;
+
+import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 
 public class BehaviorPreferencesFragment extends PreferencesFragment {
+
+    private Preferences _prefs;
+    private Preference _entryPausePreference;
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         super.onCreatePreferences(savedInstanceState, rootKey);
         addPreferencesFromResource(R.xml.preferences_behavior);
+
+        _prefs = getPreferences();
 
         Preference copyOnTapPreference = findPreference("pref_copy_on_tap");
         copyOnTapPreference.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -20,7 +28,15 @@ public class BehaviorPreferencesFragment extends PreferencesFragment {
         Preference entryHighlightPreference = findPreference("pref_highlight_entry");
         entryHighlightPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             getResult().putExtra("needsRefresh", true);
+            _entryPausePreference.setEnabled(_prefs.isTapToRevealEnabled() || (boolean) newValue);
             return true;
         });
+
+        _entryPausePreference = findPreference("pref_pause_entry");
+        _entryPausePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            getResult().putExtra("needsRefresh", true);
+            return true;
+        });
+        _entryPausePreference.setEnabled(_prefs.isTapToRevealEnabled() || _prefs.isEntryHighlightEnabled());
     }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -49,6 +49,7 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
     private boolean _isPeriodUniform = true;
     private int _uniformPeriod = -1;
     private Handler _dimHandler;
+    private boolean _pauseFocused;
 
     // keeps track of the viewholders that are currently bound
     private List<EntryHolder> _holders;
@@ -97,6 +98,10 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
 
     public void setIsCopyOnTapEnabled(boolean enabled) {
         _copyOnTap = enabled;
+    }
+
+    public void setPauseFocused(boolean pauseFocused) {
+        _pauseFocused = pauseFocused;
     }
 
     public VaultEntry getEntryAt(int position) {
@@ -352,9 +357,10 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
         VaultEntry entry = _shownEntries.get(position);
 
         boolean hidden = _tapToReveal && entry != _focusedEntry;
+        boolean paused = _pauseFocused && entry == _focusedEntry;
         boolean dimmed = (_highlightEntry || _tempHighlightEntry) && _focusedEntry != null && _focusedEntry != entry;
         boolean showProgress = entry.getInfo() instanceof TotpInfo && ((TotpInfo) entry.getInfo()).getPeriod() != getMostFrequentPeriod();
-        holder.setData(entry, _codeGroupSize, _showAccountName, showProgress, hidden, dimmed);
+        holder.setData(entry, _codeGroupSize, _showAccountName, showProgress, hidden, paused, dimmed);
         holder.setFocused(_selectedEntries.contains(entry));
         holder.loadIcon(_view);
 
@@ -522,12 +528,18 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
                 if (_tapToReveal) {
                     holder.hideCode();
                 }
+                if (_pauseFocused) {
+                    holder.setPaused(false);
+                }
             } else {
                 if (_highlightEntry || _tempHighlightEntry) {
                     holder.highlight();
                 }
                 if (_tapToReveal) {
                     holder.revealCode();
+                }
+                if (_pauseFocused) {
+                    holder.setPaused(true);
                 }
             }
         }
@@ -542,6 +554,9 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
             }
             if (_tapToReveal) {
                 holder.hideCode();
+            }
+            if (_pauseFocused) {
+                holder.setPaused(false);
             }
         }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -48,6 +48,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
     private int _codeGroupSize = 6;
 
     private boolean _hidden;
+    private boolean _paused;
 
     private TotpProgressBar _progressBar;
     private View _view;
@@ -87,7 +88,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         _refresher = new UiRefresher(new UiRefresher.Listener() {
             @Override
             public void onRefresh() {
-                if (!_hidden) {
+                if (!_hidden && !_paused) {
                     refreshCode();
                 }
             }
@@ -99,9 +100,10 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         });
     }
 
-    public void setData(VaultEntry entry, int codeGroupSize, boolean showAccountName, boolean showProgress, boolean hidden, boolean dimmed) {
+    public void setData(VaultEntry entry, int codeGroupSize, boolean showAccountName, boolean showProgress, boolean hidden, boolean paused, boolean dimmed) {
         _entry = entry;
         _hidden = hidden;
+        _paused = paused;
 
         if (codeGroupSize <= 0)
             throw new IllegalArgumentException("Code group size cannot be zero or negative");
@@ -129,7 +131,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
 
         if (_hidden) {
             hideCode();
-        } else {
+        } else if (!_paused) {
             refreshCode();
         }
 
@@ -227,7 +229,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
     }
 
     public void refreshCode() {
-        if (!_hidden) {
+        if (!_hidden && !_paused) {
             updateCode();
         }
     }
@@ -266,6 +268,14 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         hiddenText = formatCode(hiddenText);
         _profileCode.setText(hiddenText);
         _hidden = true;
+    }
+
+    public void setPaused(boolean paused) {
+        _paused = paused;
+
+        if (!_hidden && !_paused) {
+            updateCode();
+        }
     }
 
     public void dim() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -294,6 +294,10 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         _adapter.setHighlightEntry(highlightEntry);
     }
 
+    public void setPauseFocused(boolean pauseFocused) {
+        _adapter.setPauseFocused(pauseFocused);
+    }
+
     public void setTapToReveal(boolean tapToReveal) {
         _adapter.setTapToReveal(tapToReveal);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,9 @@
     <string name="pref_highlight_entry_summary">Make tokens easier to distinguish from each other by temporarily highlighting them when tapped</string>
     <string name="pref_copy_on_tap_title">Copy tokens when tapped</string>
     <string name="pref_copy_on_tap_summary">Copy tokens to the clipboard by tapping them</string>
+    <string name="pref_pause_entry_title">Freeze tokens when tapped</string>
+    <string name="pref_pause_entry_summary">Pause automatic refresh of tokens by tapping them. Tokens will not update as long as they are focused. Requires \"Highlight tokens when tapped\" or \"Tap to reveal\".</string>
+
     <string name="pin_keyboard_description">Enter your password to enable the PIN keyboard. Note that this only works if your password only consists of numbers</string>
     <string name="pin_keyboard_error">Error enabling PIN keyboard</string>
     <string name="pin_keyboard_error_description">It\'s not possible to set PIN keyboard. Your password must only consists of numbers.</string>

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -16,6 +16,12 @@
         app:iconSpaceReserved="false"/>
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
+        android:key="pref_pause_entry"
+        android:title="@string/pref_pause_entry_title"
+        android:summary="@string/pref_pause_entry_summary"
+        app:iconSpaceReserved="false"/>
+    <androidx.preference.SwitchPreferenceCompat
+        android:defaultValue="false"
         android:key="pref_panic_trigger"
         android:title="@string/pref_panic_trigger_title"
         android:summary="@string/pref_panic_trigger_summary"


### PR DESCRIPTION
I implemented the pause feature discussed in #789.

You can enable this new feature in the settings menu under "Behavior" > "Freeze tokens when tapped". I tested it a bit and everything works as I would like it to.

Things that I'm not quite sure of:
- Explanation in settings might not be the best to describe what the feature does?
- Maybe we should add an icon next to a frozen token to inform the user that the token is outdated/paused?

What do you think?