### PR TITLE
Allow filtering by "No group"

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -298,7 +298,7 @@ public class EditEntryActivity extends AegisActivity {
 
     private void setGroup(String groupName) {
         int pos = 0;
-        if (groupName != null) {
+        if (groupName != "No group") {
             pos = _groups.contains(groupName) ? _groups.headSet(groupName).size() + 1 : 0;
         }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -355,7 +355,10 @@ public class EditEntryActivity extends AegisActivity {
         Resources res = getResources();
         _dropdownGroupList.clear();
         _dropdownGroupList.add(res.getString(R.string.no_group));
-        _dropdownGroupList.addAll(_groups);
+        for (String group : _groups) {
+            if (group.equals("No group")) continue;
+            _dropdownGroupList.add(group);
+        }
         _dropdownGroupList.add(res.getString(R.string.new_group));
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
@@ -47,6 +47,7 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
         _slotsView.setNestedScrollingEnabled(false);
 
         for (String group : _groups) {
+            if (group.equals("No group")) continue;
             _adapter.addGroup(group);
         }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -220,7 +220,7 @@ public class EntryAdapter extends RecyclerView.Adapter<EntryHolder> implements I
         String name = entry.getName().toLowerCase();
 
         if (!_groupFilter.isEmpty()) {
-            if (group == null || !_groupFilter.contains(group)) {
+            if (!_groupFilter.contains(group)) {
                 return true;
             }
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -413,7 +413,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
 
             for (String group : _groups) {
                 Chip chip = (Chip) this.getLayoutInflater().inflate(R.layout.chip_material, null, false);
-                chip.setText(group);
+                chip.setText(!group.equals("No group") ? group : getString(R.string.no_group));
                 chip.setCheckable(true);
                 chip.setChecked(_groupFilter != null && _groupFilter.contains(group));
                 chip.setCheckedIconVisible(false);
@@ -429,9 +429,10 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         });
     }
 
-    private static List<String> getGroupFilter(ChipGroup chipGroup) {
+    private List<String> getGroupFilter(ChipGroup chipGroup) {
         return chipGroup.getCheckedChipIds().stream()
                 .map(i -> ((Chip) chipGroup.findViewById(i)).getText().toString())
+                .map(i -> !i.equals(getString(R.string.no_group)) ? i : "No group")
                 .collect(Collectors.toList());
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultEntry.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultEntry.java
@@ -121,7 +121,7 @@ public class VaultEntry extends UUIDMap.Value {
     }
 
     public String getGroup() {
-        return _group;
+        return _group != null ? _group : "No group";
     }
 
     public byte[] getIcon() {

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -259,10 +259,7 @@ public class VaultManager {
     public TreeSet<String> getGroups() {
         TreeSet<String> groups = new TreeSet<>(Collator.getInstance());
         for (VaultEntry entry : getEntries()) {
-            String group = entry.getGroup();
-            if (group != null) {
-                groups.add(group);
-            }
+            groups.add(entry.getGroup());
         }
         return groups;
     }


### PR DESCRIPTION
Fixes #826. This should be ready for review - I actually fixed the l10n issues I was having that I mentioned in that issue! All I had to do was throw out all my existing code and start over :P

The basic approach now is to create a "virtual" `No group` group and pass that around in the app. (That's what gets persisted to shared preferences, for example.) Whenever groups come up for display, we just do the right thing and either hide this virtual group, or change its string to be localized.

I manually tested this and everything seems to be working ok. That being said, I have very little experience with Android development, so please don't assume I know what I'm doing!