### PR TITLE
Make group chips checked when selected

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -416,7 +416,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
                 chip.setText(group);
                 chip.setCheckable(true);
                 chip.setChecked(_groupFilter != null && _groupFilter.contains(group));
-                chip.setCheckedIconVisible(false);
+                chip.setCheckedIconVisible(true);
                 chip.setOnCheckedChangeListener((group1, checkedId) -> {
                     List<String> groupFilter = getGroupFilter(chipGroup);
                     setGroupFilter(groupFilter, true);


### PR DESCRIPTION
This brings us in line with upstream Material UI guidelines - apparently before we were showing "choice chips" and with this change we show "filter chips".

See https://material.io/components/chips/android#filter-chip.