### PR TITLE
Upgrade Android Gradle plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,7 @@ android {
     lintOptions {
         abortOnError true
         disable "MissingTranslation"
+        checkDependencies true
     }
 
     testOptions {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/BackupsPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/BackupsPreferencesFragment.java
@@ -103,7 +103,7 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
             return;
         }
 
-        int flags = data.getFlags() & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
         getContext().getContentResolver().takePersistableUriPermission(data.getData(), flags);
 
         Preferences prefs = getPreferences();

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Android Studio was bugging me about this. Since the docs said to, I also set the option to lint dependencies to true. This seemed to also enable linting for the app itself (or maybe I just didn't notice these warnings before?) so I "fixed" the one error it raised, which was a false positive. There are 88 warnings remaining.

I uploaded the report it generated if anyone's interested: https://people.strugee.net/~alex/aegis-lint-results-debug.html