### PR TITLE
Vauld.md inconsistency fix

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -151,8 +151,8 @@ The different slot types are identified with a numerical ID.
 | Type        | ID   |
 | :---------- | :--- |
 | Raw         | 0x00 |
-| Biometric   | 0x01 |
-| Password    | 0x02 |
+| Password    | 0x01 |
+| Biometric   | 0x02 |
 
 ##### Raw
 


### PR DESCRIPTION
While I was developing a software to decrypt an aegis vault I stumbled upon an inconsistency in vault.md file.
In [vault.md](https://github.com/beemdevelopment/Aegis/blob/master/docs/vault.md#slots-1) the identifier for biometric is 0x01 and password is 0x02, but in [Slot.java](https://github.com/beemdevelopment/Aegis/blob/master/app/src/main/java/com/beemdevelopment/aegis/vault/slots/Slot.java#L28) the slots values are inverted. Also in [decrypt.py](https://github.com/beemdevelopment/Aegis/blob/master/docs/decrypt.py#L41) slots with type 1 are used to fetch password slots