### PR TITLE
Feature: Add Yandex OTP support

### DIFF
--- a/app/src/androidTest/java/com/beemdevelopment/aegis/OverallTest.java
+++ b/app/src/androidTest/java/com/beemdevelopment/aegis/OverallTest.java
@@ -12,6 +12,7 @@ import com.beemdevelopment.aegis.encoding.Base32;
 import com.beemdevelopment.aegis.otp.HotpInfo;
 import com.beemdevelopment.aegis.otp.SteamInfo;
 import com.beemdevelopment.aegis.otp.TotpInfo;
+import com.beemdevelopment.aegis.otp.YandexInfo;
 import com.beemdevelopment.aegis.ui.MainActivity;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultManager;
@@ -68,7 +69,8 @@ public class OverallTest extends AegisTest {
                 generateEntry(TotpInfo.class, "Frank", "Google"),
                 generateEntry(HotpInfo.class, "John", "GitHub"),
                 generateEntry(TotpInfo.class, "Alice", "Office 365"),
-                generateEntry(SteamInfo.class, "Gaben", "Steam")
+                generateEntry(SteamInfo.class, "Gaben", "Steam"),
+                generateEntry(YandexInfo.class, "Ivan", "Yandex")
         );
         for (VaultEntry entry : entries) {
             addEntry(entry);
@@ -171,6 +173,8 @@ public class OverallTest extends AegisTest {
                 otpType = "Steam";
             } else if (entry.getInfo() instanceof TotpInfo) {
                 otpType = "TOTP";
+            } else if (entry.getInfo() instanceof YandexInfo) {
+                otpType = "Yandex";
             } else {
                 throw new RuntimeException(String.format("Unexpected entry type: %s", entry.getInfo().getClass().getSimpleName()));
             }

--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/otp/YAOTP.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/otp/YAOTP.java
@@ -1,0 +1,83 @@
+package com.beemdevelopment.aegis.crypto.otp;
+
+import androidx.annotation.NonNull;
+
+import com.beemdevelopment.aegis.util.YandexUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+public class YAOTP {
+    private static final int EN_ALPHABET_LENGTH = 26;
+    private final long _code;
+    private final int _digits;
+
+    private YAOTP(long code, int digits) {
+        _code = code;
+        _digits = digits;
+    }
+
+    public static YAOTP generateOTP(byte[] secret, byte[] pin, int digits, String otpAlgo, long period)
+            throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+        long seconds = System.currentTimeMillis() / 1000;
+        return generateOTP(secret, pin, digits, otpAlgo, seconds, period);
+    }
+
+    public static YAOTP generateOTP(byte[] secret, byte[] pin, int digits, String otpAlgo, long seconds, long period)
+            throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+
+        long counter = (long) Math.floor((double) seconds / period);
+
+        try (ByteArrayOutputStream pinWithHashStream =
+                     new ByteArrayOutputStream(pin.length + secret.length)) {
+
+            pinWithHashStream.write(pin);
+            pinWithHashStream.write(secret, 0, YandexUtils.APPROVED_SECRET_LENGTH);
+
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] keyHash = md.digest(pinWithHashStream.toByteArray());
+
+            if (keyHash[0] == 0) {
+                keyHash = Arrays.copyOfRange(keyHash, 1, keyHash.length);
+            }
+
+            byte[] periodHash = HOTP.getHash(keyHash, otpAlgo, counter);
+            int offset = periodHash[periodHash.length - 1] & 0xf;
+
+            periodHash[offset] &= 0x7f;
+            long otp = ByteBuffer.wrap(periodHash)
+                    .order(ByteOrder.BIG_ENDIAN)
+                    .getLong(offset);
+
+            return new YAOTP(otp, digits);
+        }
+    }
+
+    public long getCode() {
+        return _code;
+    }
+
+    public int getDigits() {
+        return _digits;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        long code = _code % (long) Math.pow(EN_ALPHABET_LENGTH, _digits);
+        char[] chars = new char[_digits];
+
+        for (int i = _digits - 1; i >= 0; i--) {
+            chars[i] = (char) ('a' + (code % EN_ALPHABET_LENGTH));
+            code /= EN_ALPHABET_LENGTH;
+        }
+
+        return new String(chars);
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/otp/OtpInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/OtpInfo.java
@@ -115,6 +115,10 @@ public abstract class OtpInfo implements Serializable {
                 case HotpInfo.ID:
                     info = new HotpInfo(secret, algo, digits, obj.getLong("counter"));
                     break;
+                case YandexInfo.ID:
+                    byte[] pin = Base32.decode(obj.getString("pin"));
+                    info = new YandexInfo(secret, pin);
+                    break;
                 default:
                     throw new OtpInfoException("unsupported otp type: " + type);
             }

--- a/app/src/main/java/com/beemdevelopment/aegis/otp/YandexInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/YandexInfo.java
@@ -1,0 +1,89 @@
+package com.beemdevelopment.aegis.otp;
+
+import com.beemdevelopment.aegis.crypto.otp.YAOTP;
+import com.beemdevelopment.aegis.encoding.Base32;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Locale;
+
+public class YandexInfo extends TotpInfo {
+    public static final String DEFAULT_ALGORITHM = "SHA256";
+    public static final int DIGITS = 8;
+
+    public static final int SECRET_LENGTH = 26;
+    public static final int SECRET_FULL_LENGTH = 42;
+    public static final String ID = "yandex";
+    public static final String OTP_SCHEMA_ID = "yaotp";
+
+    private byte[] _pin;
+
+    public YandexInfo(byte[] secret) throws OtpInfoException {
+        super(secret, DEFAULT_ALGORITHM, DIGITS, TotpInfo.DEFAULT_PERIOD);
+    }
+
+    public YandexInfo(byte[] secret, byte[] pin) throws OtpInfoException {
+        super(secret, DEFAULT_ALGORITHM, DIGITS, TotpInfo.DEFAULT_PERIOD);
+        this._pin = pin;
+    }
+
+    @Override
+    public String getOtp() {
+        try {
+            YAOTP otp = YAOTP.generateOTP(getSecret(), _pin, getDigits(), getAlgorithm(true), getPeriod());
+            return otp.toString();
+        } catch (InvalidKeyException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getPin() {
+        return _pin != null ? new String(_pin, StandardCharsets.UTF_8) : "";
+    }
+
+    public byte[] getPinBytes() {
+        return _pin;
+    }
+
+    @Override
+    public String getTypeId() {
+        return ID;
+    }
+
+    @Override
+    public String getType() {
+        String id = getTypeId();
+        return id.substring(0, 1).toUpperCase(Locale.ROOT) + id.substring(1);
+    }
+
+    @Override
+    public JSONObject toJson() {
+        JSONObject result = super.toJson();
+        try {
+            result.put("pin", Base32.encode(getPinBytes()));
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof YandexInfo)) return false;
+
+        YandexInfo that = (YandexInfo) o;
+        return super.equals(o) && Arrays.equals(_pin, that._pin);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + Arrays.hashCode(_pin);
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -22,6 +22,7 @@ import com.beemdevelopment.aegis.otp.HotpInfo;
 import com.beemdevelopment.aegis.otp.OtpInfo;
 import com.beemdevelopment.aegis.otp.SteamInfo;
 import com.beemdevelopment.aegis.otp.TotpInfo;
+import com.beemdevelopment.aegis.otp.YandexInfo;
 import com.beemdevelopment.aegis.ui.glide.IconLoader;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.bumptech.glide.Glide;
@@ -238,7 +239,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         OtpInfo info = _entry.getInfo();
 
         String otp = info.getOtp();
-        if (!(info instanceof SteamInfo)) {
+        if (!(info instanceof SteamInfo || info instanceof YandexInfo)) {
             otp = formatCode(otp);
         }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/util/YandexUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/util/YandexUtils.java
@@ -1,0 +1,89 @@
+package com.beemdevelopment.aegis.util;
+
+import com.beemdevelopment.aegis.otp.OtpInfoException;
+import com.beemdevelopment.aegis.otp.YandexInfo;
+
+public class YandexUtils {
+    private static final char CHECKSUM_POLY = 0b1_1000_1111_0011;
+    public static final int APPROVED_SECRET_LENGTH = 16;
+
+    private YandexUtils() {
+    }
+
+    private static int getNumberOfLeadingZeros(char value) {
+        if (value == 0) return 16;
+
+        int n = 0;
+        if ((value & 0xFF00) == 0) {
+            n += 8;
+            value <<= 8;
+        }
+        if ((value & 0xF000) == 0) {
+            n += 4;
+            value <<= 4;
+        }
+        if ((value & 0xC000) == 0) {
+            n += 2;
+            value <<= 2;
+        }
+        if ((value & 0x8000) == 0) {
+            n++;
+        }
+
+        return n;
+    }
+
+    /**
+     * Java implementation of ChecksumIsValid
+     * from https://github.com/norblik/KeeYaOtp/blob/dev/KeeYaOtp/Core/Secret.cs
+     */
+    public static void validateSecret(byte[] secret) throws OtpInfoException {
+        /*
+            When secret comes from QR code - we can't test it,
+            cause it's only 16 byte long.
+         */
+        if (secret.length == APPROVED_SECRET_LENGTH) return;
+
+        if (secret.length != YandexInfo.SECRET_LENGTH)
+            throw new OtpInfoException("Wrong secret size");
+
+        char originalChecksum = (char) ((secret[secret.length - 2] & 0x0F) << 8 | secret[secret.length - 1] & 0xff);
+
+        char accum = 0;
+        int accumBits = 0;
+
+        int inputTotalBitsAvailable = secret.length * 8 - 12;
+        int inputIndex = 0;
+        int inputBitsAvailable = 8;
+
+        while (inputTotalBitsAvailable > 0) {
+            int requiredBits = 13 - accumBits;
+            if (inputTotalBitsAvailable < requiredBits) requiredBits = inputTotalBitsAvailable;
+
+            while (requiredBits > 0) {
+                int curInput = (secret[inputIndex] & (1 << inputBitsAvailable) - 1) & 0xff;
+                int bitsToRead = Math.min(requiredBits, inputBitsAvailable);
+
+                curInput >>= inputBitsAvailable - bitsToRead;
+                accum = (char) (accum << bitsToRead | curInput);
+
+                inputTotalBitsAvailable -= bitsToRead;
+                requiredBits -= bitsToRead;
+                inputBitsAvailable -= bitsToRead;
+                accumBits += bitsToRead;
+
+                if (inputBitsAvailable == 0) {
+                    inputIndex += 1;
+                    inputBitsAvailable = 8;
+                }
+            }
+
+            if (accumBits == 13) accum ^= CHECKSUM_POLY;
+            accumBits = 16 - getNumberOfLeadingZeros(accum);
+        }
+
+        if (accum != originalChecksum) {
+            throw new OtpInfoException("Secret is corrupted. Checksum is not valid");
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_baseline_fiber_pin_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_fiber_pin_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M5.5,10.5h2v1h-2zM20,4L4,4c-1.11,0 -1.99,0.89 -1.99,2L2,18c0,1.11 0.89,2 2,2h16c1.11,0 2,-0.89 2,-2L22,6c0,-1.11 -0.89,-2 -2,-2zM9,11.5c0,0.85 -0.65,1.5 -1.5,1.5h-2v2L4,15L4,9h3.5c0.85,0 1.5,0.65 1.5,1.5v1zM12.5,15L11,15L11,9h1.5v6zM20,15h-1.2l-2.55,-3.5L16.25,15L15,15L15,9h1.25l2.5,3.5L18.75,9L20,9v6z"/>
+</vector>

--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -45,13 +45,12 @@
                     android:id="@+id/krop_view"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_centerHorizontal="true"
-                    android:layout_centerVertical="true"
+                    android:layout_centerInParent="true"
                     android:visibility="invisible"
                     app:krop_aspectX="1"
                     app:krop_aspectY="1"
                     app:krop_offset="70dp"
-                    app:krop_overlayColor="#aadddddd" >
+                    app:krop_overlayColor="#aadddddd">
 
                     <ImageView
                         android:id="@+id/iv_saveImage"
@@ -184,6 +183,39 @@
                             android:layout_height="wrap_content"
                             android:hint="@string/secret"
                             android:inputType="textPassword"/>
+                    </com.google.android.material.textfield.TextInputLayout>
+                </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/layout_yandex_pin"
+                    android:visibility="gone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:orientation="horizontal"
+                    tools:visibility="visible">
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_fiber_pin_24"
+                        app:tint="?attr/iconColorPrimary"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginEnd="15dp"
+                        android:layout_gravity="center_vertical"/>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/yandex_pin"
+                        android:layout_weight="1"
+                        app:passwordToggleTint="#949494"
+                        app:passwordToggleEnabled="true">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/text_yandex_pin"
+                            android:maxLength="16"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="numberPassword"/>
                     </com.google.android.material.textfield.TextInputLayout>
                 </LinearLayout>
             </LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -10,6 +10,7 @@
         <item>TOTP</item>
         <item>HOTP</item>
         <item>Steam</item>
+        <item>Yandex</item>
     </string-array>
 
     <string-array name="otp_algo_array">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="discard">Discard</string>
     <string name="save">Save</string>
     <string name="issuer">Issuer</string>
+    <string name="yandex_pin">PIN (4–16 digits)</string>
     <string name="suggested">Suggested</string>
     <string name="usage_count">Usage count</string>
 

--- a/app/src/test/java/com/beemdevelopment/aegis/crypto/otp/YAOTPTest.java
+++ b/app/src/test/java/com/beemdevelopment/aegis/crypto/otp/YAOTPTest.java
@@ -1,0 +1,53 @@
+package com.beemdevelopment.aegis.crypto.otp;
+
+import static org.junit.Assert.assertEquals;
+
+import com.beemdevelopment.aegis.crypto.CryptoUtils;
+import com.beemdevelopment.aegis.encoding.Base32;
+import com.beemdevelopment.aegis.encoding.EncodingException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public class YAOTPTest {
+
+    private static final Vector[] TEST_CASES = new Vector[]{
+            new Vector("5239", "6SB2IKNM6OBZPAVBVTOHDKS4FAAAAAAADFUTQMBTRY", 1641559648L, "umozdicq"),
+            new Vector("7586", "LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI", 1581064020L, "oactmacq"),
+            new Vector("7586", "LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI", 1581090810L, "wemdwrix"),
+            new Vector("5210481216086702", "JBGSAU4G7IEZG6OY4UAXX62JU4AAAAAAHTSG4HXU3M", 1581091469L, "dfrpywob"),
+            new Vector("5210481216086702", "JBGSAU4G7IEZG6OY4UAXX62JU4AAAAAAHTSG4HXU3M", 1581093059L, "vunyprpd"),
+    };
+
+    @Test
+    public void validateYaOtp() throws InvalidKeyException, NoSuchAlgorithmException, IOException {
+        for (Vector testCase : TEST_CASES) {
+            YAOTP otp = YAOTP.generateOTP(
+                    Base32.decode(testCase.secret.substring(0, 26)),
+                    CryptoUtils.toBytes(testCase.pin.toCharArray()),
+                    8,
+                    "HmacSHA256",
+                    testCase.timestamp,
+                    30
+            );
+            assertEquals(testCase.expected, otp.toString());
+        }
+    }
+
+    public static class Vector {
+        public String pin;
+        public String secret;
+        public long timestamp;
+        public String expected;
+
+        public Vector(String pin, String secret, long timestamp, String expected) {
+            this.pin = pin;
+            this.secret = secret;
+            this.timestamp = timestamp;
+            this.expected = expected;
+        }
+    }
+}

--- a/app/src/test/java/com/beemdevelopment/aegis/util/YandexUtilsTest.java
+++ b/app/src/test/java/com/beemdevelopment/aegis/util/YandexUtilsTest.java
@@ -1,0 +1,35 @@
+package com.beemdevelopment.aegis.util;
+
+import static org.junit.Assert.assertThrows;
+
+import com.beemdevelopment.aegis.encoding.Base32;
+import com.beemdevelopment.aegis.encoding.EncodingException;
+import com.beemdevelopment.aegis.otp.OtpInfoException;
+
+import org.junit.Test;
+
+public class YandexUtilsTest {
+
+    private static final String[] vectors = new String[]{
+            "LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI", // correct
+            "LA2V6KMCGYMWWVEW64RNP3JA3I",                 // secret from QR - no validation
+            "AA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI", // first letter is different
+            "AA2V6KMCGJA3IAAAAAAHTSG4HRZPI"               // size is wrong
+    };
+
+    @Test(expected = Test.None.class)
+    public void testValidationOk() throws EncodingException, OtpInfoException {
+        YandexUtils.validateSecret(getBase32Vector(0));
+        YandexUtils.validateSecret(getBase32Vector(1));
+    }
+
+    @Test
+    public void testYandexSecretValidation() {
+        assertThrows(OtpInfoException.class, () -> YandexUtils.validateSecret(getBase32Vector(2)));
+        assertThrows(OtpInfoException.class, () -> YandexUtils.validateSecret(getBase32Vector(3)));
+    }
+
+    private byte[] getBase32Vector(int vectorIndex) throws EncodingException {
+        return Base32.decode(vectors[vectorIndex]);
+    }
+}


### PR DESCRIPTION
**Issue**: #617
**Based on**: https://github.com/norblik/KeeYaOtp 

This PR adds support for **Yandex.OTP** and some simple tests. Implementation does not require connection to Yandex servers to work. Made this, because original Yandex.Key app is kinda messy and has an extremely user-unfriendly UI.

The RFC of the protocol has not yet been published, but someone (the original solution) has made an implementation of it.
Soo, it's our time to shine and make most progressive Android OTP app ;)

**Important:** 
Yandex OTP protocol requires not only **secret**, but also **PIN** to work properly. That's why I had to put an additional field to `EntryEditActivity`. 

<details>
  <summary>Screenshots</summary>
<img src="https://user-images.githubusercontent.com/15111821/148558515-afbc9554-b188-47ba-acbd-1a64eadf965e.png" width="324" height="702" />
<img src="https://user-images.githubusercontent.com/15111821/148558513-53c3e255-4771-4b19-8bbc-588bef43e0e2.png" width="402" height="276" />
</details>

<details>
  <summary>Compare to original Yandex.Key</summary>

![Screenshot_20220107-180742_Aegis](https://user-images.githubusercontent.com/15111821/148565699-be90ac60-fe34-4fa4-b13d-f8b306ae643c.png)

</details>

<details>
  <summary>Test account details</summary>
<br>
<strong>Just scan it, add to Aegis and try to login at:</strong> <a href="https://passport.yandex.com/">https://passport.yandex.com</a>
<br><br>
<u>Username</u>: <code>test-aegis</code>
<br>
<u>Pin code</u>: <code>1234567890</code>

![qrsecret (1)](https://user-images.githubusercontent.com/15111821/148564262-8b95df05-2709-41ef-a4bb-06574d038b63.png)

</details>