### PR TITLE
Avoid crash when double clicking on "Copy" button

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -828,6 +828,10 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
 
             @Override
             public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                if(_selectedEntries.size() == 0) {
+                    mode.finish();
+                    return true;
+                }
                 switch (item.getItemId()) {
                     case R.id.action_copy:
                         copyEntryCode(_selectedEntries.get(0));


### PR DESCRIPTION
Fix #921

Another possible approach is to check if there are any selected elements before the switch instruction:
```
@Override  
public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
    if(_selectedEntries.size() == 0) {
        mode.finish();
        return true;
    }
    switch (item.getItemId()) {
        ...
```