### PR TITLE
Set the searchview to occupy all Toolbar widths when it expands

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -559,6 +559,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         MenuItem searchViewMenuItem = menu.findItem(R.id.mi_search);
 
         _searchView = (SearchView) searchViewMenuItem.getActionView();
+        _searchView.setMaxWidth(Integer.MAX_VALUE);
 
         _searchView.setQueryHint(getString(R.string.search));
         if (_prefs.getFocusSearchEnabled() && !_isRecreated) {


### PR DESCRIPTION
Modify reason:
When the search box is expanded, part of the menu space on the right side is occupied. It is suggested that when the search box is expanded, the entire width of the toolbar is occupied (the search box has been opened by the customer, so just focus on the search task).

Another thinking solution: determine the width of the toolbar, if the width of the toolbar is less than a certain value, then expand the search box to all. This may be beneficial for large-screen devices.

Current:
![image](https://user-images.githubusercontent.com/6801952/182104980-a5a14032-5219-46e6-99e2-ca7d76f8ff81.png)

After modification:
![image](https://user-images.githubusercontent.com/6801952/182105249-72ea9a62-3575-4840-a38f-6c71af696e61.png)
