### PR TITLE
The entryList emptyView adjustment to the center.

### DIFF
--- a/app/src/main/res/layout/fragment_entry_list_view.xml
+++ b/app/src/main/res/layout/fragment_entry_list_view.xml
@@ -52,10 +52,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:gravity="center"
-            android:orientation="vertical"
-            android:paddingBottom="150dp">
+            android:orientation="vertical">
 
             <ImageView
                 android:id="@+id/imageView"


### PR DESCRIPTION
Modify the empty view of the list to be centered, it will be more beautiful when displayed in landscape, and it should be more obvious on some small screen devices.
On small screens, it's easier to squeeze empty view offscreen due to the bottom padding.
`android:paddingBottom="150dp"`
This is a suggested change, please evaluate.

Landscape effect:
Current:
![image](https://user-images.githubusercontent.com/6801952/183228372-a670fc00-3066-4342-acde-fa509561c764.png)

After:
![image](https://user-images.githubusercontent.com/6801952/183228388-e56ab0f4-0266-4eb4-9ca1-f9ef5072d64e.png)
