### PR TITLE
When the text is empty, the generated TextDrawable uses a grey bgcolor

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/TextDrawableHelper.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/TextDrawableHelper.java
@@ -39,12 +39,14 @@ public class TextDrawableHelper {
     public static TextDrawable generate(String text, String fallback, View view) {
         if (text == null || text.isEmpty()) {
             if (fallback == null || fallback.isEmpty()) {
-                return null;
+                text = "";
+            }else{
+                text = fallback;
             }
-            text = fallback;
         }
 
-        int color = _generator.getColor(text);
+        //When the text is empty, the generated TextDrawable uses a grey background (level 300).
+        int color = text.isEmpty()? 0xFFE0E0E0:_generator.getColor(text);
         return TextDrawable.builder().beginConfig()
                 .width(view.getLayoutParams().width)
                 .height(view.getLayoutParams().height)


### PR DESCRIPTION
When the text is empty, the generated TextDrawable uses a grey bgcolor.
This will help remind customers that this is where an icon is selected.
I wanted to use arrays.xml/colors.xml to manage the colors at first, but after looking at the source code(The color generator is also hardcoded, so I followed), I used a hardcoded way. Because the current TextDrawableHelper.java does not have a Context to load resources.

This is a suggested change, please evaluate.

Effect:
![image](https://user-images.githubusercontent.com/6801952/183229634-12c74850-1738-4cf4-9d95-bdad6ff667e4.png)
