### PR TITLE
Added checks for animations accessibility

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -762,13 +762,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         if (!_loaded) {
             _entryListView.setUsageCounts(_prefs.getUsageCounts());
             _entryListView.addEntries(_vaultManager.getVault().getEntries());
-            try {
-                if (!(Settings.Global.getFloat(getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE) == 0f)) {
-                    _entryListView.runEntriesAnimation();
-                }
-            } catch (Exception e) {
-                _entryListView.runEntriesAnimation();
-            }
+            _entryListView.runEntriesAnimation();
 
             _loaded = true;
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -90,6 +90,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     private EntryListView _entryListView;
     private LinearLayout _btnErrorBar;
     private TextView _textErrorBar;
+    private Context context;
 
     private FabScrollHelper _fabScrollHelper;
 
@@ -761,7 +762,14 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         if (!_loaded) {
             _entryListView.setUsageCounts(_prefs.getUsageCounts());
             _entryListView.addEntries(_vaultManager.getVault().getEntries());
-            _entryListView.runEntriesAnimation();
+            try {
+                if (!(Settings.Global.getFloat(getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE) == 0f)) {
+                    _entryListView.runEntriesAnimation();
+                }
+            } catch (Exception e) {
+                _entryListView.runEntriesAnimation();
+            }
+
             _loaded = true;
         }
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -1,6 +1,7 @@
 package com.beemdevelopment.aegis.ui;
 
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.MenuItem;
 
 import androidx.fragment.app.Fragment;
@@ -97,11 +98,18 @@ public class PreferencesActivity extends AegisActivity implements
     }
 
     private void showFragment(Fragment fragment) {
-        getSupportFragmentManager().beginTransaction()
-                .setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left, R.anim.slide_in_left, R.anim.slide_out_right)
-                .replace(R.id.content, fragment)
-                .addToBackStack(null)
-                .commit();
+        if (Settings.Global.getFloat(getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f) {
+            getSupportFragmentManager().beginTransaction()
+                    .setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left, R.anim.slide_in_left, R.anim.slide_out_right)
+                    .replace(R.id.content, fragment)
+                    .addToBackStack(null)
+                    .commit();
+        } else {
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.content, fragment)
+                    .addToBackStack(null)
+                    .commit();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -406,7 +406,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                     if (_selectedEntries.isEmpty()) {
                         if (_copyOnTap) {
                             _view.onEntryCopy(entry);
-                            entryHolder.animateCopyText();
+                            entryHolder.animateCopyText(v.getContext());
                         }
 
                         if (_highlightEntry || _tempHighlightEntry || _tapToReveal) {
@@ -423,9 +423,9 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         if (_selectedEntries.contains(entry)) {
                             _view.onDeselect(entry);
                             removeSelectedEntry(entry);
-                            entryHolder.setFocusedAndAnimate(false);
+                            entryHolder.setFocusedAndAnimate(v.getContext(), false);
                         } else {
-                            entryHolder.setFocusedAndAnimate(true);
+                            entryHolder.setFocusedAndAnimate(v.getContext(),true);
                             addSelectedEntry(entry);
                             _view.onSelect(entry);
                         }
@@ -441,7 +441,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                 public boolean onLongClick(View v) {
                     int position = holder.getAdapterPosition();
                     if (_selectedEntries.isEmpty()) {
-                        entryHolder.setFocusedAndAnimate(true);
+                        entryHolder.setFocusedAndAnimate(v.getContext(),true);
                     }
 
                     boolean returnVal = _view.onLongEntryClick(_shownEntries.get(position));
@@ -643,7 +643,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         for (VaultEntry entry: _selectedEntries) {
             for (EntryHolder holder : _holders) {
                 if (holder.getEntry() == entry) {
-                    holder.setFocusedAndAnimate(false);
+                    holder.setFocusedAndAnimate(_view.getContext(), false);
                     break;
                 }
             }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -1,7 +1,9 @@
 package com.beemdevelopment.aegis.ui.views;
 
+import android.content.Context;
 import android.graphics.PorterDuff;
 import android.os.Handler;
+import android.provider.Settings;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
@@ -200,13 +202,18 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         _view.setSelected(focused);
     }
 
-    public void setFocusedAndAnimate(boolean focused) {
+    public void setFocusedAndAnimate(Context context, boolean focused) {
         setFocused(focused);
 
+
         if (focused) {
-            _selected.startAnimation(_scaleIn);
+            if (Settings.Global.getFloat(context.getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f) {
+                _selected.startAnimation(_scaleIn);
+            }
         } else {
-            _selected.startAnimation(_scaleOut);
+            if (Settings.Global.getFloat(context.getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f) {
+                _selected.startAnimation(_scaleOut);
+            }
             _selectedHandler.postDelayed(() -> _selected.setVisibility(View.GONE), 150);
         }
     }
@@ -297,7 +304,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         animateAlphaTo(DEFAULT_ALPHA);
     }
 
-    public void animateCopyText() {
+    public void animateCopyText(Context context) {
         _animationHandler.removeCallbacksAndMessages(null);
 
         Animation slideDownFadeIn = AnimationUtils.loadAnimation(itemView.getContext(), R.anim.slide_down_fade_in);
@@ -305,13 +312,15 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         Animation fadeOut = AnimationUtils.loadAnimation(itemView.getContext(), R.anim.fade_out);
         Animation fadeIn = AnimationUtils.loadAnimation(itemView.getContext(), R.anim.fade_in);
 
-        _profileCopied.startAnimation(slideDownFadeIn);
-        _description.startAnimation(slideDownFadeOut);
+        if (Settings.Global.getFloat(context.getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f) {
+            _profileCopied.startAnimation(slideDownFadeIn);
+            _description.startAnimation(slideDownFadeOut);
 
-        _animationHandler.postDelayed(() -> {
-            _profileCopied.startAnimation(fadeOut);
-            _description.startAnimation(fadeIn);
-        }, 3000);
+            _animationHandler.postDelayed(() -> {
+                _profileCopied.startAnimation(fadeOut);
+                _description.startAnimation(fadeIn);
+            }, 3000);
+        }
     }
 
     private void animateAlphaTo(float alpha) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -380,11 +381,13 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
     }
 
     public void runEntriesAnimation() {
-        final LayoutAnimationController controller =
-                AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.layout_animation_fall_down);
+        if (Settings.Global.getFloat(requireContext().getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f) {
+            final LayoutAnimationController controller =
+                    AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.layout_animation_fall_down);
 
-        _recyclerView.setLayoutAnimation(controller);
-        _recyclerView.scheduleLayoutAnimation();
+            _recyclerView.setLayoutAnimation(controller);
+            _recyclerView.scheduleLayoutAnimation();
+        }
     }
 
     private void addChipTo(ChipGroup chipGroup, String group) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -381,13 +381,11 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
     }
 
     public void runEntriesAnimation() {
-        if (Settings.Global.getFloat(requireContext().getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f) {
-            final LayoutAnimationController controller =
-                    AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.layout_animation_fall_down);
+        final LayoutAnimationController controller =
+                AnimationUtils.loadLayoutAnimation(requireContext(), R.anim.layout_animation_fall_down);
 
-            _recyclerView.setLayoutAnimation(controller);
-            _recyclerView.scheduleLayoutAnimation();
-        }
+        _recyclerView.setLayoutAnimation(controller);
+        _recyclerView.scheduleLayoutAnimation();
     }
 
     private void addChipTo(ChipGroup chipGroup, String group) {


### PR DESCRIPTION
Per issue from lucy, added checks for Remove Animations in accessibility settings for a bug fix.

This PR will add compatibility with the Remove Animations accessibility option. Currently, the list of OTPs will still fade in from the top. My change adds a conditional to check for "Remove Animations" before deciding to animate or just pop the list right in.

Please review and provide any feedback.