### PR TITLE
Add ability to disable backup reminder

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -278,6 +278,14 @@ public class Preferences {
         setBuiltInBackupResult(null);
     }
 
+    public boolean isBackupReminderEnabled() {
+        return _prefs.getBoolean("pref_backup_reminder", true);
+    }
+
+    public void setIsBackupReminderEnabled(boolean enabled) {
+        _prefs.edit().putBoolean("pref_backup_reminder", enabled).apply();
+    }
+
     public Uri getBackupsLocation() {
         String str = _prefs.getString("pref_backups_location", null);
         if (str != null) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -825,14 +825,23 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                 });
             });
             _btnErrorBar.setVisibility(View.VISIBLE);
-        } else if (_prefs.isBackupsReminderNeeded()) {
+        } else if (_prefs.isBackupsReminderNeeded() && _prefs.isBackupReminderEnabled()) {
             Date date = _prefs.getLatestBackupOrExportTime();
             if (date != null) {
                 _textErrorBar.setText(getString(R.string.backup_reminder_bar_message_with_latest, TimeUtils.getElapsedSince(this, date)));
             } else {
                 _textErrorBar.setText(R.string.backup_reminder_bar_message);
             }
-            _btnErrorBar.setOnClickListener(view -> startPreferencesActivity());
+            _btnErrorBar.setOnClickListener(view -> {
+                Dialogs.showSecureDialog(new AlertDialog.Builder(this)
+                        .setTitle(R.string.backup_reminder_bar_dialog_title)
+                        .setMessage(R.string.backup_reminder_bar_dialog_summary)
+                        .setPositiveButton(R.string.backup_reminder_bar_dialog_accept, (dialog, whichButton) -> {
+                            startPreferencesActivity(BackupsPreferencesFragment.class, "pref_backups");
+                        })
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .create());
+            });
             _btnErrorBar.setVisibility(View.VISIBLE);
         } else if (_prefs.isPlaintextBackupWarningNeeded()) {
             _textErrorBar.setText(R.string.backup_plaintext_export_warning);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BackupsPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BackupsPreferencesFragment.java
@@ -23,6 +23,7 @@ import com.beemdevelopment.aegis.vault.VaultRepositoryException;
 public class BackupsPreferencesFragment extends PreferencesFragment {
     private SwitchPreferenceCompat _androidBackupsPreference;
     private SwitchPreferenceCompat _backupsPreference;
+    private SwitchPreferenceCompat _backupReminderPreference;
     private Preference _backupsLocationPreference;
     private Preference _backupsTriggerPreference;
     private Preference _backupsVersionsPreference;
@@ -72,6 +73,22 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
             return false;
         });
 
+        _backupReminderPreference = requirePreference("pref_backup_reminder");
+        _backupReminderPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!(boolean)newValue) {
+                Dialogs.showCheckboxDialog(getContext(), R.string.pref_backups_reminder_dialog_title,
+                        R.string.pref_backups_reminder_dialog_summary,
+                        R.string.understand_risk_accept,
+                        this::saveAndDisableBackupReminder
+                );
+            } else {
+                _prefs.setIsBackupReminderEnabled(true);
+                return true;
+            }
+
+            return false;
+        });
+
         _androidBackupsPreference = requirePreference("pref_android_backups");
         _androidBackupsPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             _prefs.setIsAndroidBackupsEnabled((boolean) newValue);
@@ -113,6 +130,13 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
         });
     }
 
+    private void saveAndDisableBackupReminder(boolean understand) {
+        if (understand) {
+            _prefs.setIsBackupReminderEnabled(false);
+            updateBackupPreference();
+        }
+    }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (data != null && requestCode == CODE_BACKUPS) {
@@ -140,11 +164,13 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
         boolean encrypted = _vaultManager.getVault().isEncryptionEnabled();
         boolean androidBackupEnabled = _prefs.isAndroidBackupsEnabled() && encrypted;
         boolean backupEnabled = _prefs.isBackupsEnabled() && encrypted;
+        boolean backupReminderEnabled = _prefs.isBackupReminderEnabled();
         _backupsPasswordWarningPreference.setVisible(_vaultManager.getVault().isBackupPasswordSet());
         _androidBackupsPreference.setChecked(androidBackupEnabled);
         _androidBackupsPreference.setEnabled(encrypted);
         _backupsPreference.setChecked(backupEnabled);
         _backupsPreference.setEnabled(encrypted);
+        _backupReminderPreference.setChecked(backupReminderEnabled);
         _backupsLocationPreference.setVisible(backupEnabled);
         _backupsTriggerPreference.setVisible(backupEnabled);
         _backupsVersionsPreference.setVisible(backupEnabled);

--- a/app/src/main/res/layout/dialog_export.xml
+++ b/app/src/main/res/layout/dialog_export.xml
@@ -61,7 +61,7 @@
         android:layout_marginStart="20dp"
         android:layout_marginEnd="20dp"
         android:layout_marginTop="5dp"
-        android:text="@string/export_warning_accept"
+        android:text="@string/understand_risk_accept"
         android:checked="false"
         android:visibility="gone" />
 

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -94,7 +94,7 @@
     <string name="export_encrypted">تشفير المخزن</string>
     <string name="export_help">هذا الإجراء سيصدر المخزن خارج ذاكرة تخزين Aegis الداخلية. حدد الصيغة التي ترغب بأن يكون التصدير عليها:</string>
     <string name="export_warning_unencrypted">أنت على وشك تصدير نسخة غير مشفرة من مخزن Aegis. <b>لا يُنصح بهذا</b>.</string>
-    <string name="export_warning_accept">أنا أتفهم المخاطر</string>
+    <string name="understand_risk_accept">أنا أتفهم المخاطر</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">ملف نصي (.TXT)</string>
     <string name="export_format_hint">تصدير الصيغة</string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Cifrar l\'arca</string>
     <string name="export_help">Esta aición esporta l\'arca fuera del almacenamientu internu d\'Aegis. Seleiciona\'l formatu col que quies esportar:</string>
     <string name="export_warning_unencrypted">Tas a piques d\'esportar una copia ensin cifrar de l\'arca d\'Aegis. <b>Nun s\'aconseya</b>.</string>
-    <string name="export_warning_accept">Entiendo\'l riesgu</string>
+    <string name="understand_risk_accept">Entiendo\'l riesgu</string>
     <string name="export_warning_password">Les esportaciones cífrense con otra contraseña que se configura nos axustes de seguranza.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Ficheru de testu (.TXT)</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -68,7 +68,7 @@
     <string name="export_encrypted">Шифровайте трезора</string>
     <string name="export_help">Това действие ще експортира трезора от вътрешното хранилище на Aegis. Изберете формата, който искате да бъде експорта ви:</string>
     <string name="export_warning_unencrypted">На път сте да експортирате нешифровано копие на своя Aegis трезор. <b>Това не се препоръчва</b>.</string>
-    <string name="export_warning_accept">Разбирам риска</string>
+    <string name="understand_risk_accept">Разбирам риска</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Текстов файл (.TXT)</string>
     <string name="export_format_hint">Експорт формат</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Xifra la volta</string>
     <string name="export_help">Això exportarà la volta fora d\'Aegis. Tria el format en el que s\'ha d\'exportar:</string>
     <string name="export_warning_unencrypted">Això exportarà una còpia sense xifrar de la volta d\'Aegis. <b>No recomanat</b>.</string>
-    <string name="export_warning_accept">Entenc els riscos</string>
+    <string name="understand_risk_accept">Entenc els riscos</string>
     <string name="export_warning_password">Les exportacions es xifren fent servir una contrasenya diferent, configurada a la secció de seguretat.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Fitxers de text (*.txt)</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -101,7 +101,7 @@
     <string name="export_encrypted">Šifrovat trezor</string>
     <string name="export_help">Trezor bude exportován mimo vnitřní úložiště Aegis. Zvolte formát, ve kterém chcete trezor exportovat:</string>
     <string name="export_warning_unencrypted">Chystáte se exportovat nešifrovanou kopii vašeho Aegis trezoru. Toto <b>není doporučeno</b>.</string>
-    <string name="export_warning_accept">Chápu rizika</string>
+    <string name="understand_risk_accept">Chápu rizika</string>
     <string name="export_warning_password">Exporty jsou šifrovány pomocí samostatného hesla nastaveného v nastavení zabezpečení.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Textový soubor (.TXT)</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Kryptér boksen</string>
     <string name="export_help">Denne handling vil eksportere boksen ud af Aegis\' interne lager. Vælg det format, som du gerne vil eksportere i:</string>
     <string name="export_warning_unencrypted">Du er ved at eksportere en ukrypteret kopi af din Aegis-boks. <b>Dette er ikke anbefalet</b>.</string>
-    <string name="export_warning_accept">Jeg forstår risikoen</string>
+    <string name="understand_risk_accept">Jeg forstår risikoen</string>
     <string name="export_warning_password">Eksporter krypteres vha. en separat adgangskode opsat i Sikkerhedsindstillinger.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Tekst fil (.TXT)</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Datenbank verschlüsseln</string>
     <string name="export_help">Mit dieser Aktion wird die Datenbank aus dem internen Speicher von Aegis exportiert. Wähle das Format aus, in dem der Export erfolgen soll:</string>
     <string name="export_warning_unencrypted">Du bist dabei, eine unverschlüsselte Kopie deiner Aegis-Datenbank zu exportieren. <b>Dies wird nicht empfohlen</b>.</string>
-    <string name="export_warning_accept">Mir ist das Risiko bewusst</string>
+    <string name="understand_risk_accept">Mir ist das Risiko bewusst</string>
     <string name="export_warning_password">Exporte werden mit einem separaten Passwort verschlüsselt, das in den Sicherheitseinstellungen konfiguriert wurde.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Textdatei (.TXT)</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Κρυπτογράφηση κρύπτης</string>
     <string name="export_help">Αυτή η ενέργεια θα εξάγει την κρύπτη έξω από τον εσωτερικό χώρο αποθήκευσης του Aegis. Επιλέξτε τη μορφή στην οποία θέλετε να είναι η εξαγωγή σας:</string>
     <string name="export_warning_unencrypted">Πρόκειται να εξαγάγετε ένα μη κρυπτογραφημένο αντίγραφο της Aegis κρύπτης σας. <b> Αυτό δεν συνιστάται </b>.</string>
-    <string name="export_warning_accept">Κατανοώ τους κινδύνους</string>
+    <string name="understand_risk_accept">Κατανοώ τους κινδύνους</string>
     <string name="export_warning_password">Οι εξαγωγές κρυπτογραφούνται χρησιμοποιώντας ένα ξεχωριστό κωδικό πρόσβασης που έχει ρυθμιστεί στις ρυθμίσεις ασφαλείας.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Αρχείο κειμένου (*.TXT)</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Cifrar la bóveda</string>
     <string name="export_help">Esta acción exportará la bóveda fuera del almacenamiento interno de Aegis. Seleccione el formato al que desea exportar:</string>
     <string name="export_warning_unencrypted">Está a punto de exportar una copia sin cifrar de su bóveda de Aegis. <b>Esto no es recomendable</b>.</string>
-    <string name="export_warning_accept">Entiendo el riesgo</string>
+    <string name="understand_risk_accept">Entiendo el riesgo</string>
     <string name="export_warning_password">Las exportaciones se cifran usando una contraseña separada configurada en la configuración de seguridad.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Archivo de texto (.TXT)</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Zifratu biltegia</string>
     <string name="export_help">Akzio honek zure biltegia Aegisen barne-biltegiratzetik kanpo esportatuko du. Aukeratu zein formatutan esportatu nahi duzun:</string>
     <string name="export_warning_unencrypted">Zure Aegis biltegiaren zifratu gabeko kopia esportatzera zoaz. <b>Ez dizugu hau egitea gomendatzen</b>.</string>
-    <string name="export_warning_accept">Arriskua ulertzen dut</string>
+    <string name="understand_risk_accept">Arriskua ulertzen dut</string>
     <string name="export_warning_password">Esportazioak Segurtasun ezarpenetan zehazten den bestelako pasahitz batekin zifratuta daude.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Testu fitxategia (.TXT)</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -80,7 +80,7 @@
     <string name="export_encrypted">رمزگذاری مخزن</string>
     <string name="export_help">این عملیات مخرن را از حافظه داخلی آگیس صادر میکند. فرمت مورد نظر فایل خروجی را انتخاب کنید:</string>
     <string name="export_warning_unencrypted">شما در حال صادر کردن یک کپی محافظت نشده از مخزن آگیس هستید. <b>این روش توصیه نمیشود</b>.</string>
-    <string name="export_warning_accept">بله، این ریسک را می‌دانم</string>
+    <string name="understand_risk_accept">بله، این ریسک را می‌دانم</string>
     <string name="export_format_aegis">فایل جیسون (.json)</string>
     <string name="export_format_google_auth_uri">فایل متنی (.txt)</string>
     <string name="export_format_hint">فرمت خروجی</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -89,7 +89,7 @@
     <string name="export_encrypted">Salaa holvi</string>
     <string name="export_help">Tämä toiminto vie holvin ulos Aegisin sisäisestä tallennustilasta. Valitse viennin tiedostomuoto:</string>
     <string name="export_warning_unencrypted">Olet viemässä salaamattoman kopion Aegis-holvistasi. <b>Tätä ei suositella</b>.</string>
-    <string name="export_warning_accept">Ymmärrän riskin</string>
+    <string name="understand_risk_accept">Ymmärrän riskin</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Tekstitiedosto (.TXT)</string>
     <string name="export_format_hint">Vientimuoto</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Chiffrer le coffre-fort</string>
     <string name="export_help">Cette action exportera le coffre-fort à partir du stockage interne d\'Aegis. Sélectionnez le format vers lequel vous souhaitez faire votre export :</string>
     <string name="export_warning_unencrypted">Vous êtes sur le point d\'exporter une copie non chiffrée de votre coffre-fort Aegis. <b>Ce n\'est pas recommandé</b>.</string>
-    <string name="export_warning_accept">Je comprends le risque</string>
+    <string name="understand_risk_accept">Je comprends le risque</string>
     <string name="export_warning_password">Les exports sont chiffrés à l\'aide d\'un mot de passe séparé configuré dans les paramètres de sécurité.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Fichier texte (.TXT)</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -95,7 +95,7 @@
     <string name="export_encrypted">Cifrar o almacén</string>
     <string name="export_help">Esta acción exportará o almacén fóra do almacenamento interno de Aegis. Escolle o formato no que o queiras exportar:</string>
     <string name="export_warning_unencrypted">Estás a piques de exportar unha copia non cifrada do teu almacén de Aegis. <b>Isto non está recomendado</b>.</string>
-    <string name="export_warning_accept">Entendo os riscos</string>
+    <string name="understand_risk_accept">Entendo os riscos</string>
     <string name="export_warning_password">As exportacións cífranse mediante un contrasinal distinto, definido nos axustes de seguridade.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Ficheiro de texto (.TXT)</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -86,7 +86,7 @@
     <string name="export_encrypted">वॉल्ट एन्क्रिप्ट करें</string>
     <string name="export_help">यह क्रिया एजिस के आंतरिक संग्रहण से तिजोरी को निर्यात करेगी। उस प्रारूप का चयन करें जिसमें आप चाहते हैं कि आपका निर्यात हो:</string>
     <string name="export_warning_unencrypted">आप अपने एजिस वॉल्ट की एक अनएन्क्रिप्टेड कॉपी निर्यात करने वाले हैं। <b>यह अनुशंसित नहीं है</b>।</string>
-    <string name="export_warning_accept">मैं जोखिम को समझता हूं</string>
+    <string name="understand_risk_accept">मैं जोखिम को समझता हूं</string>
     <string name="export_format_aegis">एजिस (.JSON)</string>
     <string name="export_format_google_auth_uri">टेक्स्ट फ़ाइल (.TXT)</string>
     <string name="export_format_hint">निर्यात स्वरूप</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -79,7 +79,7 @@
     <string name="export_encrypted">A széf titkosítása</string>
     <string name="export_help">Ezzel ki tudja exportálni az Aegis belső széf tárolóját. Válassza ki, milyen formátumú legyen az export:</string>
     <string name="export_warning_unencrypted">Arra készül, hogy egy titkosítatlan Aegis széfet exportáljon. <b>Ez nem ajánlott</b>.</string>
-    <string name="export_warning_accept">Megértettem a kockázatot</string>
+    <string name="understand_risk_accept">Megértettem a kockázatot</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Szöveges fájl (.TXT)</string>
     <string name="export_format_hint">Export formátuma</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -86,7 +86,7 @@
     <string name="export_encrypted">Enkripsi brankas</string>
     <string name="export_help">Tindakan ini akan mengekspor brankas dari penyimpanan internal Aegis. Pilih format yang Anda inginkan untuk ekspor:</string>
     <string name="export_warning_unencrypted">Anda akan mengekspor salinan tidak terenkripsi dari brankas Aegis Anda. <b>Ini tidak disarankan</b>.</string>
-    <string name="export_warning_accept">Saya mengerti risikonya</string>
+    <string name="understand_risk_accept">Saya mengerti risikonya</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">File teks (*.txt)</string>
     <string name="export_format_hint">Format ekspor</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Cripta la cassaforte</string>
     <string name="export_help">Questa azione esporterà la cassaforte al di fuori dello spazio di archiviazione interno di Aegis. Seleziona il formato che vorresti utilizzare per l\'esportazione:</string>
     <string name="export_warning_unencrypted">Stai per esportare una copia decriptata della tua cassaforte Aegis. <b>Questo non è raccomandabile</b>.</string>
-    <string name="export_warning_accept">Sono consapevole del rischio</string>
+    <string name="understand_risk_accept">Sono consapevole del rischio</string>
     <string name="export_warning_password">Le esportazioni vengono crittografate utilizzando una password separata configurata nelle impostazioni di sicurezza.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">File di testo (.TXT)</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -79,7 +79,7 @@
     <string name="export_encrypted">保管庫を暗号化</string>
     <string name="export_help">保管庫をAegisの内部ストレージからエクスポートします。エクスポートしたいフォーマットを選択してください:</string>
     <string name="export_warning_unencrypted">暗号化されていないAegis保管庫のコピーをエクスポートしようとしています。 <b>これは推奨されません</b>。</string>
-    <string name="export_warning_accept">リスクを理解しています</string>
+    <string name="understand_risk_accept">リスクを理解しています</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">テキストファイル (.TXT)</string>
     <string name="export_format_hint">エクスポートフォーマット</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -70,7 +70,7 @@
     <string name="export_encrypted">Šifruoti slėptuvę</string>
     <string name="export_help">Šis veiksmas eksportuos slėptuvę iš Aegis vidinės saugyklos. Pasirinkite formatą, kuriuo norėtumėte eksportuoti:</string>
     <string name="export_warning_unencrypted">Jūs ketinate eksportuoti nešifruotą savo Aegis slėptuvės kopiją. <b>Tai nerekomenduojama</b>.</string>
-    <string name="export_warning_accept">Aš suprantu riziką</string>
+    <string name="understand_risk_accept">Aš suprantu riziką</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Tekstinis failas (.TXT)</string>
     <string name="export_format_hint">Eksportavimo formatas</string>

--- a/app/src/main/res/values-lv-rLV/strings.xml
+++ b/app/src/main/res/values-lv-rLV/strings.xml
@@ -99,7 +99,7 @@
     <string name="export_encrypted">Šifrēt glabātavu</string>
     <string name="export_help">Šī darbība izdos glabātavas saturu no Aegis iekšējās krātuves. Atlasīt veidolu, kādā izdot datus:</string>
     <string name="export_warning_unencrypted">Tiks izdots nešifrēts Aegis glabātavas atveidojums. <b>Tas nav ieteicams</b>.</string>
-    <string name="export_warning_accept">Es apzinos bīstamību</string>
+    <string name="understand_risk_accept">Es apzinos bīstamību</string>
     <string name="export_warning_password">Izdodamās datnes ir šifrētas ar paroli, kas ir norādīta drošības iestatījumos.</string>
     <string name="export_format_aegis">Aegis (.json)</string>
     <string name="export_format_google_auth_uri">Teksta datne (.txt)</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Versleutel de kluis</string>
     <string name="export_help">Deze actie zal de kluis exporteren uit de interne opslag van Aegis. Selecteer het formaat waarin je de export wilt:</string>
     <string name="export_warning_unencrypted">Je staat op het punt een onversleutelde kopie van de Aegis-kluis te exporteren. <b>Dit wordt niet aanbevolen</b>.</string>
-    <string name="export_warning_accept">Ik begrijp het risico</string>
+    <string name="understand_risk_accept">Ik begrijp het risico</string>
     <string name="export_warning_password">Exporten worden versleuteld met een apart wachtwoord ingesteld in de beveiligingsinstellingen.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Tekstbestand (.TXT)</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -99,7 +99,7 @@
     <string name="export_encrypted">Zaszyfruj sejf</string>
     <string name="export_help">Ta czynność wyeksportuje sejf z wewnętrznej przestrzeni dyskowej aplikacji Aegis. Wybierz format eksportowanego pliku:</string>
     <string name="export_warning_unencrypted">Wyeksportujesz sejf aplikacji Aegis w niezaszyfrowanym formacie. <b>Ta opcja nie jest zalecana</b>.</string>
-    <string name="export_warning_accept">Rozumiem ryzyko</string>
+    <string name="understand_risk_accept">Rozumiem ryzyko</string>
     <string name="export_warning_password">Eksport jest szyfrowany przy użyciu osobnego hasła skonfigurowanego w ustawieniach bezpieczeństwa.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Plik tekstowy (.TXT)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Criptografar o cofre</string>
     <string name="export_help">Esta ação irá exportar o cofre para fora do armazenamento interno do Aegis. Selecione o formato em que você gostaria que sua exportação esteja:</string>
     <string name="export_warning_unencrypted">Você está prestes a exportar uma cópia não criptografada de seu cofre Aegis. <b>Isso não é recomendado</b>.</string>
-    <string name="export_warning_accept">Eu compreendo o risco</string>
+    <string name="understand_risk_accept">Eu compreendo o risco</string>
     <string name="export_warning_password">As exportações são criptografadas usando uma senha separada, configurada nas configurações de segurança.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Arquivo de texto (.TXT)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -52,7 +52,7 @@
     <string name="export_encrypted">Criptografar o cofre</string>
     <string name="export_help">Esta ação irá exportar o cofre para fora do armazenamento interno do Aegis. Selecione o formato em que você gostaria que sua exportação esteja:</string>
     <string name="export_warning_unencrypted">Você está prestes a exportar uma cópia não criptografada de seu cofre Aegis. <b>Isso não é recomendado</b>.</string>
-    <string name="export_warning_accept">Eu compreendo o risco</string>
+    <string name="understand_risk_accept">Eu compreendo o risco</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Arquivo de texto (.TXT)</string>
     <string name="choose_authentication_method">Segurança</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -99,7 +99,7 @@
     <string name="export_encrypted">Criptează seiful</string>
     <string name="export_help">Această acțiune va exporta seiful din spațiul de stocare al aplicaţiei. Selectează formatul în care dorești exportul:</string>
     <string name="export_warning_unencrypted">Ești pe cale să exportezi o copie necriptată a seifului Aegis. <b>Acest lucru nu este recomandat</b>.</string>
-    <string name="export_warning_accept">Înţeleg riscurile</string>
+    <string name="understand_risk_accept">Înţeleg riscurile</string>
     <string name="export_warning_password">Exporturile sunt criptate folosind o parolă separată configurată în setările de securitate.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Fișier text (.TXT)</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -101,7 +101,7 @@
     <string name="export_encrypted">Шифровать хранилище</string>
     <string name="export_help">Экспорт внутреннего хранилища Aegis. Выберите формат:</string>
     <string name="export_warning_unencrypted">Вы собираетесь экспортировать незашифрованную копию хранилища Aegis. <b>Не рекомендуется</b>.</string>
-    <string name="export_warning_accept">Я понимаю риск</string>
+    <string name="understand_risk_accept">Я понимаю риск</string>
     <string name="export_warning_password">Экспортируемые данные шифруются с использованием отдельного пароля, указанного в разделе настроек «Безопасность».</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Текстовый файл (.TXT)</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -73,7 +73,7 @@
     <string name="export_encrypted">Šifrovať trezor</string>
     <string name="export_help">Touto akciou sa exportuje trezor z interného úložiska Aegis. Vyberte formát, v ktorom chcete mať export:</string>
     <string name="export_warning_unencrypted">Chystáte sa exportovať nezašifrovanú kópiu svojho trezoru Aegis. <b> Toto sa neodporúča </b>.</string>
-    <string name="export_warning_accept">Áno, rozumiem rizikám</string>
+    <string name="understand_risk_accept">Áno, rozumiem rizikám</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Textové súbory (*.txt)</string>
     <string name="export_format_hint">Formát exportu</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -95,7 +95,7 @@
     <string name="export_encrypted">Kryptera valvet</string>
     <string name="export_help">Denna åtgärd kommer att exportera valvet från Aegis interna lagring. Välj det format som du vill att din export ska vara i:</string>
     <string name="export_warning_unencrypted">Du håller på att exportera en okrypterad kopia av ditt Aegis-valv. <b>Detta rekommenderas inte.</b></string>
-    <string name="export_warning_accept">Jag förstår riskerna</string>
+    <string name="understand_risk_accept">Jag förstår riskerna</string>
     <string name="export_warning_password">Exporter krypteras med ett separat lösenord som konfigureras i Säkerhet-inställningarna.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Textfil (.TXT)</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -97,7 +97,7 @@
     <string name="export_encrypted">Kasayı şifrele</string>
     <string name="export_help">Bu işlem kasayı Aegis\'in dahili deposundan dışarı aktaracaktır. Lütfen dışa aktarmak istediğiniz biçimi seçiniz:</string>
     <string name="export_warning_unencrypted">Aegis kasanızın şifrelenmemiş bir kopyasını dışa aktarmak üzeresiniz. <b>Bu işlem tavsiye edilmez</b>.</string>
-    <string name="export_warning_accept">Riskleri göze alıyorum</string>
+    <string name="understand_risk_accept">Riskleri göze alıyorum</string>
     <string name="export_warning_password">Dışa aktarmalar, Güvenlik ayarlarında yapılandırılan ayrı bir parola kullanılarak şifrelenir.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Metin belgesi (.TXT)</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -101,7 +101,7 @@
     <string name="export_encrypted">Зашифрувати сховище</string>
     <string name="export_help">Ця дія експортує внутрішнє сховище додатка Aegis. Виберіть формат:</string>
     <string name="export_warning_unencrypted">Ви збираєтеся експортувати незашифровану копію вашого сховища Aegis. <b>Це не рекомендується</b>.</string>
-    <string name="export_warning_accept">Я знаю, на що йду</string>
+    <string name="understand_risk_accept">Я знаю, на що йду</string>
     <string name="export_warning_password">Експортовані копії зашифровано окремим паролем, що був заданий в налаштуваннях безпеки.</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Текстовий файл (.TXT)</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -92,7 +92,7 @@
     <string name="export_encrypted">Mã hoá kho</string>
     <string name="export_help">Hành động này sẽ xuất kho ra ngoài bộ nhớ trong của Aegis. Hãy chọn định dạng mà bạn muốn bản xuất của bạn có:</string>
     <string name="export_warning_unencrypted">Bạn sắp xuất một bản sao không được mã khoá của kho Aegis. <b>Việc này không được khuyên dùng</b>.</string>
-    <string name="export_warning_accept">Tôi hiểu rủi ro này</string>
+    <string name="understand_risk_accept">Tôi hiểu rủi ro này</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Tệp văn bản (.TXT)</string>
     <string name="export_format_hint">Định dạng xuất</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -95,7 +95,7 @@
     <string name="export_encrypted">加密数据库</string>
     <string name="export_help">此操作将从 Aegis 的内部存储中导出数据库。选择您想要的导出格式：</string>
     <string name="export_warning_unencrypted">您将导出一个未加密的 Aegis 数据库副本。<b>不建议这么做</b></string>
-    <string name="export_warning_accept">我了解风险</string>
+    <string name="understand_risk_accept">我了解风险</string>
     <string name="export_warning_password">导出使用在安全设置中配置的单独密码进行加密。</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">文本文件 (.TXT)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -88,7 +88,7 @@
     <string name="export_encrypted">加密保險箱</string>
     <string name="export_help">此動作將保險箱從 Aegis 的內部儲存空間裡匯出，請選擇欲匯出的格式：</string>
     <string name="export_warning_unencrypted">即將匯出未加密的 Aegis 保險箱。<b>不建議</b>。</string>
-    <string name="export_warning_accept">我瞭解相關風險</string>
+    <string name="understand_risk_accept">我瞭解相關風險</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">純文字檔案 (.TXT)</string>
     <string name="export_format_hint">匯出格式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,10 @@
     <string name="pref_android_backups_hint"><i>Device-to-device (D2D) backups are always allowed, regardless of the setting above</i></string>
     <string name="pref_backups_title">Automatically back up the vault</string>
     <string name="pref_backups_summary">Automatically create backups of the vault on external storage when changes are made. This is only supported for encrypted vaults.</string>
+    <string name="pref_backups_reminder_title">Backup reminder</string>
+    <string name="pref_backups_reminder_summary">Show a reminder to backup your vault in case you haven\'t backed up your latest changes.</string>
+    <string name="pref_backups_reminder_dialog_title">Disable backup reminder</string>
+    <string name="pref_backups_reminder_dialog_summary">Disabling this reminder means Aegis won\'t tell you whether or not you have changes that are not backed up yet. This puts you at risk of losing access to your tokens. Are you sure you want to disable the reminder?</string>
     <string name="pref_backups_location_title">Directory for backup files</string>
     <string name="pref_backups_location_summary">Backups will be stored at</string>
     <string name="pref_backups_trigger_title">Trigger backup</string>
@@ -101,8 +105,8 @@
     <string name="export_encrypted">Encrypt the vault</string>
     <string name="export_help">This action will export the vault out of Aegis\' internal storage. Select the format you\'d like your export to be in:</string>
     <string name="export_warning_unencrypted">You are about to export an unencrypted copy of your Aegis vault. <b>This is not recommended</b>.</string>
-    <string name="export_warning_accept">I understand the risk</string>
     <string name="export_warning_password">Exports are encrypted using a separate password configured in Security settings.</string>
+    <string name="understand_risk_accept">I understand the risk</string>
     <string name="export_format_aegis">Aegis (.JSON)</string>
     <string name="export_format_google_auth_uri">Text file (.TXT)</string>
     <string name="export_format_html">Web page (.HTML)</string>
@@ -386,6 +390,11 @@
     <string name="backup_reminder_bar_message">
         Changes are not backed up
     </string>
+    <string name="backup_reminder_bar_dialog_title">Changes are not backed up</string>
+    <string name="backup_reminder_bar_dialog_summary">
+        Recent changes to the vault have not been backed up yet. It\'s important to take regular backups to prevent losing access to your accounts. Please consider setting up automatic backups in the settings menu.
+    </string>
+    <string name="backup_reminder_bar_dialog_accept">Set up backups</string>
     <string name="backup_plaintext_export_warning"><b>The vault was recently exported in plain text</b></string>
     <string name="pref_show_plaintext_warning_hint">Don\'t show this warning again</string>
     <string name="backup_plaintext_warning_explanation">This warning is shown because you recently exported an unencrypted copy of the vault. To maintain security of your tokens, we recommend deleting this file once it\'s no longer needed.</string>

--- a/app/src/main/res/xml/preferences_backups.xml
+++ b/app/src/main/res/xml/preferences_backups.xml
@@ -17,6 +17,12 @@
             android:title="@string/pref_backups_title"
             android:summary="@string/pref_backups_summary"
             app:icon="@drawable/ic_cloud_upload_outline_black_24dp" />
+
+        <androidx.preference.SwitchPreferenceCompat
+            android:key="pref_backup_reminder"
+            android:title="@string/pref_backups_reminder_title"
+            android:summary="@string/pref_backups_reminder_summary" />
+
         <Preference
             android:key="pref_backups_location"
             android:title="@string/pref_backups_location_title"


### PR DESCRIPTION
This PR adds the ability to disable the red warning about outdated backups. Tapping the red bar at the top will trigger this dialog which brings you to the backups settings screen. In the backups preferences fragment you will be presented with a new switch to disable these backup reminders. 

![image](https://user-images.githubusercontent.com/7524012/216835678-1752ed6d-4ab5-4479-8e5e-2f1196750f71.png)

![image](https://user-images.githubusercontent.com/7524012/216835758-3e111017-43b1-4470-923e-2dadcc292842.png)

Closes #1072 