### PR TITLE
Add dialog when password reminder is active

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -162,7 +162,16 @@ public class AuthActivity extends AegisActivity {
         });
 
         biometricsButton.setOnClickListener(v -> {
-            showBiometricPrompt();
+            if (_prefs.isPasswordReminderNeeded()) {
+                Dialogs.showSecureDialog(new AlertDialog.Builder(this)
+                        .setTitle(getString(R.string.password_reminder_dialog_title))
+                        .setMessage(getString(R.string.password_reminder_dialog_message))
+                        .setCancelable(false)
+                        .setPositiveButton(android.R.string.ok, (dialog1, which) -> {
+                            showBiometricPrompt();
+                        })
+                        .create());
+            }
         });
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,7 +138,9 @@
     <string name="set_password_confirm">Please confirm the password</string>
     <string name="invalid_password">The password is incorrect</string>
     <string name="invalidated_biometrics">A change in your device\'s security settings has been detected. Please go to \"Aegis -> Settings -> Security -> Biometric unlock\" to disable and re-enable biometric unlock.</string>
-    <string name="password_reminder">Please enter your password. We occasionally ask you to do this so that don\'t forget it.</string>
+    <string name="password_reminder">Please enter your password. We occasionally ask you to do this so that you don\'t forget it.</string>
+    <string name="password_reminder_dialog_title">Biometric unlock by default</string>
+    <string name="password_reminder_dialog_message">We occasionally prompt you to enter your password instead to ensure you haven\'t forgotten it and won\'t get locked out of your vault. After entering your password once, Aegis will default back to biometric unlock until it\'s time for another password reminder.</string>
     <string name="password_reminder_freq_never">Never</string>
     <string name="password_reminder_freq_weekly">Weekly</string>
     <string name="password_reminder_freq_biweekly">Biweekly</string>


### PR DESCRIPTION
We are receiving **a lot** of reports from people thinking that Aegis doesn't open biometrics unlock by default (ie #1159, #1155, #1151 and lots more). These users are unaware that this is caused by our password reminder encouraging them to enter their password. The password reminder doesn't tell the users that Aegis defaults back to biometrics unlock after entering their password once which is why we made #989.

This pull requests adds an additional dialog whenever a user clicks on the "biometrics" button below the password field when the password reminder is active as shown below:

![image](https://github.com/beemdevelopment/Aegis/assets/7524012/9d8fe86b-37ed-4b40-be26-77153a3d1f86)

The screenshot above shows old text. The new text is:

> **_Biometric unlock by default_**
> _We occasionally prompt you to enter your password instead to ensure you haven\'t forgotten it and won\'t get locked out of your vault. After entering your password once, Aegis will default back to biometric unlock until it\'s time for another password reminder._
> 

Please share your suggestions if you believe the text can be made clearer.


Closes #989