### PR TITLE
Add ability to only show names when necessary

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -130,6 +130,8 @@ public class Preferences {
         setPasswordReminderTimestamp(new Date().getTime());
     }
 
+    public boolean onlyShowNecessaryAccountNames() { return _prefs.getBoolean("pref_shared_issuer_account_name", false); }
+
     public boolean isIconVisible() {
         return _prefs.getBoolean("pref_show_icons", true);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -135,6 +135,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _entryListView.setCodeGroupSize(_prefs.getCodeGroupSize());
         _entryListView.setAccountNamePosition(_prefs.getAccountNamePosition());
         _entryListView.setShowIcon(_prefs.isIconVisible());
+        _entryListView.setOnlyShowNecessaryAccountNames(_prefs.onlyShowNecessaryAccountNames());
         _entryListView.setHighlightEntry(_prefs.isEntryHighlightEnabled());
         _entryListView.setPauseFocused(_prefs.isPauseFocusedEnabled());
         _entryListView.setTapToReveal(_prefs.isTapToRevealEnabled());
@@ -273,6 +274,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             } else if (data.getBooleanExtra("needsRefresh", false)) {
                 AccountNamePosition accountNamePosition = _prefs.getAccountNamePosition();
                 boolean showIcons = _prefs.isIconVisible();
+                boolean onlyShowNecessaryAccountNames = _prefs.onlyShowNecessaryAccountNames();
                 Preferences.CodeGrouping codeGroupSize = _prefs.getCodeGroupSize();
                 boolean highlightEntry = _prefs.isEntryHighlightEnabled();
                 boolean pauseFocused = _prefs.isPauseFocusedEnabled();
@@ -281,6 +283,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                 ViewMode viewMode = _prefs.getCurrentViewMode();
                 CopyBehavior copyBehavior = _prefs.getCopyBehavior();
                 _entryListView.setAccountNamePosition(accountNamePosition);
+                _entryListView.setOnlyShowNecessaryAccountNames(onlyShowNecessaryAccountNames);
                 _entryListView.setShowIcon(showIcons);
                 _entryListView.setCodeGroupSize(codeGroupSize);
                 _entryListView.setHighlightEntry(highlightEntry);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
@@ -103,6 +103,12 @@ public class AppearancePreferencesFragment extends PreferencesFragment {
             return true;
         });
 
+        Preference onlyShowNecessaryAccountNames = requirePreference("pref_shared_issuer_account_name");
+        onlyShowNecessaryAccountNames.setOnPreferenceChangeListener((preference, newValue) -> {
+            getResult().putExtra("needsRefresh", true);
+            return true;
+        });
+
         int currentAccountNamePosition = _prefs.getAccountNamePosition().ordinal();
         Preference currentAccountNamePositionPreference = requirePreference("pref_account_name_position");
         currentAccountNamePositionPreference.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.account_name_position_titles)[currentAccountNamePosition]));

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -52,6 +52,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private Preferences.CodeGrouping _codeGroupSize;
     private AccountNamePosition _accountNamePosition;
     private boolean _showIcon;
+    private boolean _onlyShowNecessaryAccountNames;
     private boolean _highlightEntry;
     private boolean _tempHighlightEntry;
     private boolean _tapToReveal;
@@ -94,6 +95,10 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     public void setAccountNamePosition(AccountNamePosition accountNamePosition) {
         _accountNamePosition = accountNamePosition;
+    }
+
+    public void setOnlyShowNecessaryAccountNames(boolean onlyShowNecessaryAccountNames) {
+        _onlyShowNecessaryAccountNames = onlyShowNecessaryAccountNames;
     }
 
     public void setShowIcon(boolean showIcon) {
@@ -424,7 +429,16 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             boolean paused = _pauseFocused && entry == _focusedEntry;
             boolean dimmed = (_highlightEntry || _tempHighlightEntry) && _focusedEntry != null && _focusedEntry != entry;
             boolean showProgress = entry.getInfo() instanceof TotpInfo && ((TotpInfo) entry.getInfo()).getPeriod() != getMostFrequentPeriod();
-            entryHolder.setData(entry, _codeGroupSize, _accountNamePosition, _showIcon, showProgress, hidden, paused, dimmed);
+            boolean showAccountName = true;
+            if (_onlyShowNecessaryAccountNames) {
+                // Only show account name when there's multiple entries found with the same issuer.
+                showAccountName = _entries.stream()
+                        .filter(x -> x.getIssuer().equals(entry.getIssuer()))
+                        .count() > 1;
+            }
+
+            AccountNamePosition accountNamePosition = showAccountName ? _accountNamePosition : AccountNamePosition.HIDDEN;
+            entryHolder.setData(entry, _codeGroupSize, accountNamePosition, _showIcon, showProgress, hidden, paused, dimmed);
             entryHolder.setFocused(_selectedEntries.contains(entry));
             entryHolder.setShowDragHandle(isEntryDraggable(entry));
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -330,6 +330,10 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         _adapter.setAccountNamePosition(accountNamePosition);
     }
 
+    public void setOnlyShowNecessaryAccountNames(boolean onlyShowNecessaryAccountNames) {
+        _adapter.setOnlyShowNecessaryAccountNames(onlyShowNecessaryAccountNames);
+    }
+
     public void setShowIcon(boolean showIcon) {
         _adapter.setShowIcon(showIcon);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="pref_code_group_size_title">Code digit grouping</string>
     <string name="pref_code_group_size_summary">Select number of digits to group codes by</string>
     <string name="pref_account_name_position_title">Show the account name</string>
+    <string name="pref_shared_issuer_account_name_title">Only show account name when necessary</string>
+    <string name="pref_shared_issuer_account_name_summary">Only show account names whenever they share the same issuer. Other account names will be hidden.</string>
     <string name="pref_import_file_title">Import from file</string>
     <string name="pref_import_file_summary">Import tokens from a file</string>
     <string name="pref_android_backups_title">Android cloud backups</string>

--- a/app/src/main/res/xml/preferences_appearance.xml
+++ b/app/src/main/res/xml/preferences_appearance.xml
@@ -51,6 +51,13 @@
             android:title="@string/pref_account_name_position_title"
             app:iconSpaceReserved="false"/>
 
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_shared_issuer_account_name"
+            android:title="@string/pref_shared_issuer_account_name_title"
+            android:summary="@string/pref_shared_issuer_account_name_summary"
+            app:iconSpaceReserved="false"/>
+
         <Preference
             android:key="pref_groups"
             android:title="@string/preference_manage_groups"


### PR DESCRIPTION
This pull requests adds the ability to only show account names when they share the same issuer (considered "necessary").

[<img width=350 alt="Screenshot 5"
src="https://github.com/beemdevelopment/Aegis/assets/7524012/c16226b8-49ee-4432-b8cf-9139d32769d8">](https://github.com/beemdevelopment/Aegis/assets/7524012/c16226b8-49ee-4432-b8cf-9139d32769d8) [<img width=350 alt="Screenshot 5"
src="https://github.com/beemdevelopment/Aegis/assets/7524012/3d7eff8f-59ac-4a1e-835d-f407250fc76b">](https://github.com/beemdevelopment/Aegis/assets/7524012/3d7eff8f-59ac-4a1e-835d-f407250fc76b)

I used "onlyShowNecessaryAccountNames" as name for the boolean; I'm not too happy with it but I also couldn't find a better name. Feel free to suggest better alternatives.

This fixes #1117. 