### PR TITLE
Add ability to skip duplicates during import

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/ImportEntriesAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/ImportEntriesAdapter.java
@@ -12,6 +12,7 @@ import com.beemdevelopment.aegis.ui.models.ImportEntry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class ImportEntriesAdapter extends RecyclerView.Adapter<ImportEntryHolder> {
     private List<ImportEntry> _entries;
@@ -65,6 +66,14 @@ public class ImportEntriesAdapter extends RecyclerView.Adapter<ImportEntryHolder
         }
 
         return entries;
+    }
+
+    public void setCheckboxStates(List<UUID> uuids, boolean state) {
+        for (ImportEntry entry : _entries) {
+            if(uuids.contains(entry.getEntry().getUUID())) {
+                entry.setIsChecked(state);
+            }
+        }
     }
 
     public void toggleCheckboxes() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="share">Share</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="undo">Undo</string>
     <string name="unlock">Unlock</string>
     <string name="advanced">Advanced</string>
     <string name="counter">Counter</string>
@@ -469,6 +470,10 @@
     <string name="pref_panic_trigger_summary">Delete vault when a panic trigger is received from Ripple</string>
 
     <string name="import_vault">Import vault</string>
+    <plurals name="import_duplicate_toast">
+        <item quantity="one">Unchecked %d potential duplicate. Please review the list of entries.</item>
+        <item quantity="other">Unchecked %d potential duplicates. Please review the list of entries.</item>
+    </plurals>
     <string name="importer_help_2fas">Supply a 2FAS Authenticator backup file.</string>
     <string name="importer_help_aegis">Supply an Aegis export/backup file.</string>
     <string name="importer_help_authenticator_plus">Supply an Authenticator Plus export file obtained through <b>Settings -> Backup &amp; Restore -> Export as Text and HTML</b>.</string>


### PR DESCRIPTION
This pull request adds the ability to automatically skip **potential** duplicates whenever Aegis detects import entries that share the same issuer and secret with a token that's already in the vault. The goal of this feature is to simplify the import process as requested in #453 and #1150.


[<img width=350 alt="Screenshot"
src="https://github.com/beemdevelopment/Aegis/assets/7524012/76f3dfc8-7539-4321-a734-1663fc88b8c6">](https://github.com/beemdevelopment/Aegis/assets/7524012/76f3dfc8-7539-4321-a734-1663fc88b8c6)

Closes #453. Closes #1150.