### PR TITLE
Fix biometrics unlock button on AuthActivity

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -171,6 +171,8 @@ public class AuthActivity extends AegisActivity {
                             showBiometricPrompt();
                         })
                         .create());
+            } else {
+                showBiometricPrompt();
             }
         });
     }


### PR DESCRIPTION
This PR fixes a bug that was introduced in #1163 which causes the 'biometrics' button on the unlock screen to be unresponsive.

Closes #1174