### PR TITLE
Introduce optional 'name' field for iconpack icons

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/icons/IconPack.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/icons/IconPack.java
@@ -3,6 +3,7 @@ package com.beemdevelopment.aegis.icons;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.beemdevelopment.aegis.util.JsonUtils;
 import com.google.common.base.Objects;
 import com.google.common.io.Files;
 
@@ -120,13 +121,15 @@ public class IconPack {
 
     public static class Icon implements Serializable {
         private final String _relFilename;
+        private final String _name;
         private final String _category;
         private final List<String> _issuers;
 
         private File _file;
 
-        protected Icon(String filename, String category, List<String> issuers) {
+        protected Icon(String filename, String name, String category, List<String> issuers) {
             _relFilename = filename;
+            _name = name;
             _category = category;
             _issuers = issuers;
         }
@@ -149,6 +152,9 @@ public class IconPack {
         }
 
         public String getName() {
+            if (_name != null) {
+                return _name;
+            }
             return Files.getNameWithoutExtension(new File(_relFilename).getName());
         }
 
@@ -169,6 +175,7 @@ public class IconPack {
 
         public static Icon fromJson(JSONObject obj) throws JSONException {
             String filename = obj.getString("filename");
+            String name = JsonUtils.optString(obj, "name");
             String category = obj.isNull("category") ? null : obj.getString("category");
             JSONArray array = obj.getJSONArray("issuer");
 
@@ -178,7 +185,7 @@ public class IconPack {
                 issuers.add(issuer);
             }
 
-            return new Icon(filename, category, issuers);
+            return new Icon(filename, name, category, issuers);
         }
     }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -852,11 +852,12 @@ public class EditEntryActivity extends AegisActivity {
         private final File _file;
 
         protected CustomSvgIcon(File file) {
-            super(file.getAbsolutePath(), null, null);
+            super(file.getAbsolutePath(), null, null, null);
             _file = file;
         }
 
         @Nullable
+        @Override
         public File getFile() {
             return _file;
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/IconAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/IconAdapter.java
@@ -232,16 +232,8 @@ public class IconAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     }
 
     public static class DummyIcon extends IconPack.Icon {
-        private final String _name;
-
         protected DummyIcon(String name) {
-            super(null, null, null);
-            _name = name;
-        }
-
-        @Override
-        public String getName() {
-            return _name;
+            super(name, null, null, null);
         }
 
         @Override

--- a/docs/iconpacks.md
+++ b/docs/iconpacks.md
@@ -15,11 +15,13 @@ is randomly generated once and stays the same across different versions.
     "version": 1,
     "icons": [
         {
+            "name": "Google",
             "filename": "services/Google.png",
             "category": "Services",
             "issuer": [ "google" ]
         },
         {
+            "name": "Blizzard",
             "filename": "services/Blizzard.png",
             "category": "Gaming",
             "issuer": [ "blizzard", "battle.net" ]
@@ -32,7 +34,7 @@ Every icon definition contains the filename of the icon file, relative to the
 root of the .ZIP archive. Icon definitions also have a list of strings that the
 Issuer field in Aegis is matched against for automatic selection of an icon for
 new entries. Matching is done in a case-insensitive manner. There's also a
-category field.
+category field. Optionally, icons can also have a name.
 
 The following image formats are supported, in order of preference:
 


### PR DESCRIPTION
This introduces a new (optional) 'name' field for iconpack icons. It will be used to describe the icon in the icon selection dialog. If it is not present, the name of the icon will be derived from the filename, like before. Using this new field allows usage of more exotic characters in the icon name that are not allowed in a filename.

Related: https://github.com/aegis-icons/aegis-icons/pull/796