### PR TITLE
Check for null returned by getQsTile()

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/services/LaunchAppTileService.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/services/LaunchAppTileService.java
@@ -16,8 +16,10 @@ public class LaunchAppTileService extends TileService {
     public void onStartListening() {
         super.onStartListening();
         Tile tile = getQsTile();
-        tile.setState(Tile.STATE_INACTIVE);
-        tile.updateTile();
+        if (tile != null) {
+            tile.setState(Tile.STATE_INACTIVE);
+            tile.updateTile();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/beemdevelopment/aegis/services/LaunchScannerTileService.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/services/LaunchScannerTileService.java
@@ -16,8 +16,10 @@ public class LaunchScannerTileService extends TileService {
     public void onStartListening() {
         super.onStartListening();
         Tile tile = getQsTile();
-        tile.setState(Tile.STATE_INACTIVE);
-        tile.updateTile();
+        if (tile != null) {
+            tile.setState(Tile.STATE_INACTIVE);
+            tile.updateTile();
+        }
     }
 
     @Override


### PR DESCRIPTION
Apparently ``getQsTile()`` can return null, which resulted in a crash. Reported through the Google Play Console:

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void android.service.quicksettings.Tile.setState(int)' on a null object reference
  at com.beemdevelopment.aegis.services.LaunchAppTileService.onStartListening
  at android.service.quicksettings.TileService$H.handleMessage (TileService.java:488)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:205)
  at android.os.Looper.loop (Looper.java:294)
  at android.app.ActivityThread.main (ActivityThread.java:8177)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:552)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:971)
```