### PR TITLE
Clarify that only Aegis vaults can be imported during the intro

### DIFF
--- a/app/src/main/res/layout/fragment_welcome_slide.xml
+++ b/app/src/main/res/layout/fragment_welcome_slide.xml
@@ -18,28 +18,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageView
-        android:layout_width="210dp"
-        android:layout_height="210dp"
-        android:layout_marginTop="60dp"
-        android:adjustViewBounds="true"
-        android:src="@drawable/app_icon"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/titleText"/>
-
-    <Button
-        android:id="@+id/btnImport"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="32dp"
-        android:text="@string/import_vault"
-        android:textSize="11sp"
-        style="?attr/outlineButtonStyle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/descriptionText" />
-
     <TextView
         android:id="@+id/descriptionText"
         android:layout_width="match_parent"
@@ -47,8 +25,45 @@
         android:text="@string/app_description"
         android:textAlignment="center"
         android:textSize="16sp"
+        android:layout_marginTop="10dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/titleText" />
+
+    <ImageView
+        android:id="@+id/imgLogo"
+        android:layout_width="210dp"
+        android:layout_height="210dp"
+        android:layout_marginTop="60dp"
+        android:adjustViewBounds="true"
+        android:src="@drawable/app_icon"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/descriptionText"/>
+
+    <Button
+        android:id="@+id/btnImport"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="5dp"
+        android:text="@string/import_vault"
+        android:textSize="11sp"
+        android:layout_marginVertical="10dp"
+        style="?attr/outlineButtonStyle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/txtImportHelp" />
+
+    <TextView
+        android:id="@+id/txtImportHelp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/import_vault_hint"
+        android:textSize="11sp"
+        android:textAlignment="center"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintWidth_percent="0.9" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,7 +469,8 @@
     <string name="pref_panic_trigger_title">Delete vault on panic trigger</string>
     <string name="pref_panic_trigger_summary">Delete vault when a panic trigger is received from Ripple</string>
 
-    <string name="import_vault">Import vault</string>
+    <string name="import_vault">Import Aegis vault</string>
+    <string name="import_vault_hint">Want to import from a different 2FA app? Complete the setup first and then head over to the settings menu.</string>
     <plurals name="import_duplicate_toast">
         <item quantity="one">Unchecked %d potential duplicate. Please review the list of entries.</item>
         <item quantity="other">Unchecked %d potential duplicates. Please review the list of entries.</item>


### PR DESCRIPTION
Some users understandably get confused when they try to import a backup file from a different 2FA app during the intro and then get greeted with an error dialog.

This changes the button text to "Import Aegis vault" and adds a small hint text in the hope that this makes the limitations of the intro more clear to the user.

<img width="200" src="https://alexbakker.me/u/jzhh3bk30w.png" />