### PR TITLE
Never wrap RecyclerView with a NestedScrollView

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 public class GroupManagerActivity extends AegisActivity implements GroupAdapter.Listener {
     private GroupAdapter _adapter;
     private HashSet<String> _removedGroups;
-    private RecyclerView _slotsView;
+    private RecyclerView _groupsView;
     private View _emptyStateView;
     private BackPressHandler _backPressHandler;
 
@@ -51,11 +51,11 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
         }
 
         _adapter = new GroupAdapter(this);
-        _slotsView= findViewById(R.id.list_slots);
+        _groupsView = findViewById(R.id.list_groups);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
-        _slotsView.setLayoutManager(layoutManager);
-        _slotsView.setAdapter(_adapter);
-        _slotsView.setNestedScrollingEnabled(false);
+        _groupsView.setLayoutManager(layoutManager);
+        _groupsView.setAdapter(_adapter);
+        _groupsView.setNestedScrollingEnabled(false);
 
         for (String group : _vaultManager.getVault().getGroups()) {
             _adapter.addGroup(group);
@@ -135,10 +135,10 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
 
     private void updateEmptyState() {
         if (_adapter.getItemCount() > 0) {
-            _slotsView.setVisibility(View.VISIBLE);
+            _groupsView.setVisibility(View.VISIBLE);
             _emptyStateView.setVisibility(View.GONE);
         } else {
-            _slotsView.setVisibility(View.GONE);
+            _groupsView.setVisibility(View.GONE);
             _emptyStateView.setVisibility(View.VISIBLE);
         }
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
@@ -44,7 +44,6 @@ public class IconPacksManagerFragment extends Fragment implements IconPackAdapte
     @Inject
     VaultManager _vaultManager;
 
-    private View _iconPacksView;
     private RecyclerView _iconPacksRecyclerView;
     private IconPackAdapter _adapter;
     private LinearLayout _noIconPacksView;
@@ -62,7 +61,6 @@ public class IconPacksManagerFragment extends Fragment implements IconPackAdapte
 
         _noIconPacksView = view.findViewById(R.id.vEmptyList);
         ((TextView) view.findViewById(R.id.txt_no_icon_packs)).setMovementMethod(LinkMovementMethod.getInstance());
-        _iconPacksView = view.findViewById(R.id.view_icon_packs);
         _adapter = new IconPackAdapter(this);
         _iconPacksRecyclerView = view.findViewById(R.id.list_icon_packs);
         LinearLayoutManager layoutManager = new LinearLayoutManager(requireContext());
@@ -169,10 +167,10 @@ public class IconPacksManagerFragment extends Fragment implements IconPackAdapte
 
     private void updateEmptyState() {
         if (_adapter.getItemCount() > 0) {
-            _iconPacksView.setVisibility(View.VISIBLE);
+            _iconPacksRecyclerView.setVisibility(View.VISIBLE);
             _noIconPacksView.setVisibility(View.GONE);
         } else {
-            _iconPacksView.setVisibility(View.GONE);
+            _iconPacksRecyclerView.setVisibility(View.GONE);
             _noIconPacksView.setVisibility(View.VISIBLE);
         }
     }

--- a/app/src/main/res/layout/activity_groups.xml
+++ b/app/src/main/res/layout/activity_groups.xml
@@ -18,23 +18,11 @@
             android:background="?attr/colorAppBar" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.core.widget.NestedScrollView
-        android:layout_width="match_parent"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list_groups"
         android:layout_height="match_parent"
-        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/list_slots"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:scrollbars="vertical"/>
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+        android:layout_width="match_parent"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_icon_packs.xml
+++ b/app/src/main/res/layout/fragment_icon_packs.xml
@@ -47,26 +47,11 @@
 
     </LinearLayout>
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/view_icon_packs"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list_icon_packs"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/list_icon_packs"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:scrollbars="vertical"/>
-
-        </LinearLayout>
-
-    </androidx.core.widget.NestedScrollView>
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"


### PR DESCRIPTION
Wrapping a ``RecyclerView`` with a ``NestedScrollView`` breaks its recycling functionality because the view height is stretched to fit the full list of entries.

We never noticed performance issues in these two cases because these lists never get very long. Let's fix these cases anyway so that we don't accidentally base a new use of a ``RecyclerView`` on this broken pattern.

Also renamed ``list_slots`` to ``list_groups``. Must have been a copy-paste error.