### PR TITLE
Fix two issues related to animation duration scale

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -377,12 +377,12 @@ public class EditEntryActivity extends AegisActivity {
     private void openAdvancedSettings() {
         Animation fadeOut = new AlphaAnimation(1, 0);
         fadeOut.setInterpolator(new AccelerateInterpolator());
-        fadeOut.setDuration(220 * (long) AnimationsHelper.Scale.ANIMATOR.getValue(this));
+        fadeOut.setDuration((long) (220 * AnimationsHelper.Scale.ANIMATOR.getValue(this)));
         _advancedSettingsHeader.startAnimation(fadeOut);
 
         Animation fadeIn = new AlphaAnimation(0, 1);
         fadeIn.setInterpolator(new AccelerateInterpolator());
-        fadeIn.setDuration(250 * (long) AnimationsHelper.Scale.ANIMATOR.getValue(this));
+        fadeIn.setDuration((long) (250 * AnimationsHelper.Scale.ANIMATOR.getValue(this)));
 
         fadeOut.setAnimationListener(new SimpleAnimationEndListener((a) -> {
             _advancedSettingsHeader.setVisibility(View.GONE);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -18,6 +18,7 @@ import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.ViewMode;
 import com.beemdevelopment.aegis.helpers.AnimationsHelper;
 import com.beemdevelopment.aegis.helpers.IconViewHelper;
+import com.beemdevelopment.aegis.helpers.SimpleAnimationEndListener;
 import com.beemdevelopment.aegis.helpers.TextDrawableHelper;
 import com.beemdevelopment.aegis.helpers.ThemeHelper;
 import com.beemdevelopment.aegis.helpers.UiRefresher;
@@ -258,7 +259,9 @@ public class EntryHolder extends RecyclerView.ViewHolder {
             _selected.startAnimation(_scaleIn);
         } else {
             _selected.startAnimation(_scaleOut);
-            _selectedHandler.postDelayed(() -> _selected.setVisibility(View.GONE), 150);
+            _scaleOut.setAnimationListener(new SimpleAnimationEndListener(animation -> {
+                _selected.setVisibility(View.GONE);
+            }));
         }
     }
 


### PR DESCRIPTION
This patch addresses two issues:
- The entry selection icon would flicker when a non-1x animator duration scale was set.
- The advanced entry field animation was not shown if the animator duration scale was set to .5x, due to a rounding error.

Introduced in: 9ff8efab69ec43c16cce41553ab3239a6613a050