### PR TITLE
Introduce a separate menu for AssignIconsActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,7 +82,7 @@
         <activity
             android:name=".ui.GroupManagerActivity"
             android:label="@string/title_activity_manage_groups" />
-        <activity android:name=".AssignIconsActivity"
+        <activity android:name=".ui.AssignIconsActivity"
             android:label="@string/title_activity_assign_icons"/>
         <activity
             android:name=".ui.PanicResponderActivity"

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AssignIconsActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AssignIconsActivity.java
@@ -1,4 +1,4 @@
-package com.beemdevelopment.aegis;
+package com.beemdevelopment.aegis.ui;
 
 import android.content.Intent;
 import android.graphics.Rect;
@@ -13,9 +13,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.helpers.MetricsHelper;
 import com.beemdevelopment.aegis.icons.IconPack;
-import com.beemdevelopment.aegis.ui.AegisActivity;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
 import com.beemdevelopment.aegis.ui.dialogs.IconPickerDialog;
 import com.beemdevelopment.aegis.ui.glide.IconLoader;
@@ -156,7 +157,7 @@ public class AssignIconsActivity extends AegisActivity implements AssignIconAdap
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_groups, menu);
+        getMenuInflater().inflate(R.menu.menu_assign_icons, menu);
         return true;
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/ImportEntriesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/ImportEntriesActivity.java
@@ -15,14 +15,12 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.beemdevelopment.aegis.AssignIconsActivity;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.helpers.FabScrollHelper;
 import com.beemdevelopment.aegis.importers.DatabaseImporter;
 import com.beemdevelopment.aegis.importers.DatabaseImporterEntryException;
 import com.beemdevelopment.aegis.importers.DatabaseImporterException;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
-import com.beemdevelopment.aegis.ui.models.AssignIconEntry;
 import com.beemdevelopment.aegis.ui.models.ImportEntry;
 import com.beemdevelopment.aegis.ui.tasks.RootShellTask;
 import com.beemdevelopment.aegis.ui.views.ImportEntriesAdapter;

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -35,7 +35,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.SearchView;
 
-import com.beemdevelopment.aegis.AssignIconsActivity;
 import com.beemdevelopment.aegis.CopyBehavior;
 import com.beemdevelopment.aegis.AccountNamePosition;
 import com.beemdevelopment.aegis.Preferences;

--- a/app/src/main/res/layout/activity_assign_icons.xml
+++ b/app/src/main/res/layout/activity_assign_icons.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/background"
-    tools:context="com.beemdevelopment.aegis.AssignIconsActivity">
+    tools:context="com.beemdevelopment.aegis.ui.AssignIconsActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/menu/menu_assign_icons.xml
+++ b/app/src/main/res/menu/menu_assign_icons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="com.beemdevelopment.aegis.ui.AssignIconsActivity">
+    <item
+        android:id="@+id/action_save"
+        app:showAsAction="always"
+        android:title="@string/save"/>
+</menu>


### PR DESCRIPTION
Apparently this was using ``menu_groups``, probably a copy-paste error.

This also moves ``AssignIconsActivity`` to the right package.