### PR TITLE
#1231 - Fix crash in License and Changelog dialogs on configuration change

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/dialogs/ChangelogDialog.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/dialogs/ChangelogDialog.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import com.beemdevelopment.aegis.R;
 
 public class ChangelogDialog extends SimpleWebViewDialog {
-    private ChangelogDialog() {
+    public ChangelogDialog() {
         super(R.string.changelog);
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/dialogs/LicenseDialog.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/dialogs/LicenseDialog.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import com.beemdevelopment.aegis.R;
 
 public class LicenseDialog extends SimpleWebViewDialog {
-    private LicenseDialog() {
+    public LicenseDialog() {
         super(R.string.license);
     }
 


### PR DESCRIPTION
Hey all - I just made a PR to fix #1231 vs adding a proposal first since it was a very small and straightforward fix. This PR marks `SimpleWebViewDialog` implementers with public constructors instead of private, so that they can be recreated automatically on a configuration change (circumventing and fixing the linked crash). 

Let me know if there's anything else I should be adding here. Thanks!