### PR TITLE
Replace deprecated startActivityForResult

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BackupsPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BackupsPreferencesFragment.java
@@ -11,6 +11,8 @@ import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.Nullable;
 import androidx.preference.Preference;
 import androidx.preference.SwitchPreferenceCompat;
@@ -31,6 +33,15 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
 
     private Preference _builtinBackupStatusPreference;
     private Preference _androidBackupStatusPreference;
+
+    private final ActivityResultLauncher<Intent> backupsResultLauncher =
+            registerForActivityResult(new StartActivityForResult(), activityResult -> {
+                Intent data = activityResult.getData();
+                int resultCode = activityResult.getResultCode();
+                if (data != null) {
+                    onSelectBackupsLocationResult(resultCode, data);
+                }
+            });
 
     @Override
     public void onResume() {
@@ -137,13 +148,6 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
         }
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (data != null && requestCode == CODE_BACKUPS) {
-            onSelectBackupsLocationResult(resultCode, data);
-        }
-    }
-
     private void onSelectBackupsLocationResult(int resultCode, Intent data) {
         Uri uri = data.getData();
         if (resultCode != Activity.RESULT_OK || uri == null) {
@@ -226,7 +230,7 @@ public class BackupsPreferencesFragment extends PreferencesFragment {
                 | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
                 | Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
 
-        _vaultManager.startActivityForResult(this, intent, CODE_BACKUPS);
+        _vaultManager.fireIntentLauncher(this, intent, backupsResultLauncher);
     }
 
     private void scheduleBackup() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/PreferencesFragment.java
@@ -25,14 +25,10 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public abstract class PreferencesFragment extends PreferenceFragmentCompat {
     // activity request codes
-    public static final int CODE_IMPORT_SELECT = 0;
-    public static final int CODE_GROUPS = 3;
-    public static final int CODE_IMPORT = 4;
     public static final int CODE_EXPORT = 5;
     public static final int CODE_EXPORT_PLAIN = 6;
     public static final int CODE_EXPORT_GOOGLE_URI = 7;
     public static final int CODE_EXPORT_HTML = 8;
-    public static final int CODE_BACKUPS = 9;
 
     private Intent _result;
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/slides/WelcomeSlide.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/slides/WelcomeSlide.java
@@ -7,6 +7,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 
 import com.beemdevelopment.aegis.R;
@@ -24,10 +26,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 public class WelcomeSlide extends SlideFragment {
-    public static final int CODE_IMPORT_VAULT = 0;
-
     private boolean _imported;
     private VaultFileCredentials _creds;
+
+    private final ActivityResultLauncher<Intent> vaultImportResultLauncher =
+            registerForActivityResult(new StartActivityForResult(), activityResult -> {
+                Intent data = activityResult.getData();
+                if (data != null && data.getData() != null) {
+                    startImportVault(data.getData());
+                }
+            });
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -35,16 +43,9 @@ public class WelcomeSlide extends SlideFragment {
         view.findViewById(R.id.btnImport).setOnClickListener(v -> {
             Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
             intent.setType("*/*");
-            startActivityForResult(intent, CODE_IMPORT_VAULT);
+            vaultImportResultLauncher.launch(intent);
         });
         return view;
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == CODE_IMPORT_VAULT && data != null && data.getData() != null) {
-            startImportVault(data.getData());
-        }
     }
 
     @Override

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -6,6 +6,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -304,11 +305,11 @@ public class VaultManager {
      * Starts an external activity, temporarily blocks automatic lock of Aegis and
      * shows an error dialog if the target activity is not found.
      */
-    public void startActivityForResult(Activity activity, Intent intent, int requestCode) {
+    public void fireIntentLauncher(Activity activity, Intent intent, ActivityResultLauncher<Intent> resultLauncher) {
         setBlockAutoLock(true);
 
         try {
-            activity.startActivityForResult(intent, requestCode, null);
+            resultLauncher.launch(intent);
         } catch (ActivityNotFoundException e) {
             e.printStackTrace();
 
@@ -324,19 +325,11 @@ public class VaultManager {
      * Starts an external activity, temporarily blocks automatic lock of Aegis and
      * shows an error dialog if the target activity is not found.
      */
-    public void startActivity(Fragment fragment, Intent intent) {
-        startActivityForResult(fragment, intent, -1);
-    }
-
-    /**
-     * Starts an external activity, temporarily blocks automatic lock of Aegis and
-     * shows an error dialog if the target activity is not found.
-     */
-    public void startActivityForResult(Fragment fragment, Intent intent, int requestCode) {
+    public void fireIntentLauncher(Fragment fragment, Intent intent, ActivityResultLauncher<Intent> resultLauncher) {
         setBlockAutoLock(true);
 
         try {
-            fragment.startActivityForResult(intent, requestCode, null);
+            resultLauncher.launch(intent);
         } catch (ActivityNotFoundException e) {
             e.printStackTrace();
 


### PR DESCRIPTION
Hi Aegis team,
this PR can hopefully finally close https://github.com/beemdevelopment/Aegis/issues/807.  
As https://github.com/beemdevelopment/Aegis/pull/998 didn't come to a merge, maybe we can tackle that once again.

Things to discuss:
- Do we want to replace the non-deprecated "Activity.startActivityForResult" as well? It is not marked deprecated in the code as we cast some Activities to an "android.app.Activity" instead of using the original "androidx.appcompat.app.AppCompatActivity". But the issue of best-practice still persists.
  Example: https://github.com/cyb3rko/aegis/blob/9ad3a7925f0e8e980b7eb88ca7cdffbd1c8cb85d/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java#L492 which is defined here https://github.com/cyb3rko/aegis/blob/9ad3a7925f0e8e980b7eb88ca7cdffbd1c8cb85d/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java#L308
- Why does the androidTest "testOverall" fail with on error, that does not seem to be connected to intents or something I worked with in this PR? It seems to be connected to group filtering. Stacktrace: https://cdn.cyb3rko.de/Apps/Aegis/testOverall_stacktrace.txt