### PR TITLE
Prioritize normal icon issuer matches over inverse matches

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/IconAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/IconAdapter.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class IconAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private final Context _context;
@@ -96,11 +95,7 @@ public class IconAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         if (_query == null) {
             loadIcons(_pack, false);
         } else {
-            _icons = _pack.getIcons().stream()
-                    .filter(i -> i.isSuggestedFor(query))
-                    .collect(Collectors.toList());
-
-            Collections.sort(_icons, Comparator.comparing(IconPack.Icon::getName));
+            _icons = _pack.getSuggestedIcons(query);
             notifyDataSetChanged();
         }
     }


### PR DESCRIPTION
Icon packs may have very generic issuers for their icons (like [aegis-simple-icons](https://github.com/alexbakker/aegis-simple-icons)). For example, this causes the icon assigning view to suggest the "C" icon for every entry that contains a "c".

This patch addresses that by giving inverse matches (where the entry issuer contains the icon issuer) a lower position in the suggested icons list.