### PR TITLE
Load vault file on demand instead of juggling it around in-memory

### DIFF
--- a/app/src/androidTest/java/com/beemdevelopment/aegis/PanicTriggerTest.java
+++ b/app/src/androidTest/java/com/beemdevelopment/aegis/PanicTriggerTest.java
@@ -1,7 +1,6 @@
 package com.beemdevelopment.aegis;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -32,11 +31,10 @@ public class PanicTriggerTest extends AegisTest {
     @Test
     public void testPanicTriggerDisabled() {
         assertFalse(_prefs.isPanicTriggerEnabled());
+        assertTrue(_vaultManager.isVaultLoaded());
         launchPanic();
         assertTrue(_vaultManager.isVaultLoaded());
         _vaultManager.getVault();
-        assertFalse(_vaultManager.isVaultFileLoaded());
-        assertNull(_vaultManager.getVaultFileError());
         assertTrue(VaultRepository.fileExists(getApp()));
     }
 
@@ -44,11 +42,10 @@ public class PanicTriggerTest extends AegisTest {
     public void testPanicTriggerEnabled() {
         _prefs.setIsPanicTriggerEnabled(true);
         assertTrue(_prefs.isPanicTriggerEnabled());
+        assertTrue(_vaultManager.isVaultLoaded());
         launchPanic();
         assertFalse(_vaultManager.isVaultLoaded());
         assertThrows(IllegalStateException.class, () -> _vaultManager.getVault());
-        assertFalse(_vaultManager.isVaultFileLoaded());
-        assertNull(_vaultManager.getVaultFileError());
         assertFalse(VaultRepository.fileExists(getApp()));
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -36,6 +36,7 @@ import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
 import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
 import com.beemdevelopment.aegis.vault.VaultFile;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
+import com.beemdevelopment.aegis.vault.VaultRepository;
 import com.beemdevelopment.aegis.vault.VaultRepositoryException;
 import com.beemdevelopment.aegis.vault.slots.BiometricSlot;
 import com.beemdevelopment.aegis.vault.slots.PasswordSlot;
@@ -55,7 +56,9 @@ public class AuthActivity extends AegisActivity {
 
     private EditText _textPassword;
 
+    private VaultFile _vaultFile;
     private SlotList _slots;
+
     private SecretKey _bioKey;
     private BiometricSlot _bioSlot;
     private BiometricPrompt _bioPrompt;
@@ -104,17 +107,17 @@ public class AuthActivity extends AegisActivity {
             _inhibitBioPrompt = savedInstanceState.getBoolean("inhibitBioPrompt", false);
         }
 
-        if (_vaultManager.getVaultFileError() != null) {
-            Dialogs.showErrorDialog(this, R.string.vault_load_error, _vaultManager.getVaultFileError(), (dialog, which) -> {
+        try {
+            _vaultFile = VaultRepository.readVaultFile(this);
+        } catch (VaultRepositoryException e) {
+            Dialogs.showErrorDialog(this, R.string.vault_load_error, e, (dialog, which) -> {
                 getOnBackPressedDispatcher().onBackPressed();
             });
             return;
         }
 
-        VaultFile vaultFile = _vaultManager.getVaultFile();
-        _slots = vaultFile.getHeader().getSlots();
-
         // only show the biometric prompt if the api version is new enough, permission is granted, a scanner is found and a biometric slot is found
+        _slots = _vaultFile.getHeader().getSlots();
         if (_slots.has(BiometricSlot.class) && BiometricsHelper.isAvailable(this)) {
             boolean invalidated = false;
 
@@ -287,7 +290,7 @@ public class AuthActivity extends AegisActivity {
         VaultFileCredentials creds = new VaultFileCredentials(key, _slots);
 
         try {
-            _vaultManager.unlock(creds);
+            _vaultManager.loadFrom(_vaultFile, creds);
             if (isSlotRepaired) {
                 saveAndBackupVault();
             }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/IntroActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/IntroActivity.java
@@ -21,7 +21,9 @@ import com.beemdevelopment.aegis.ui.slides.DoneSlide;
 import com.beemdevelopment.aegis.ui.slides.SecurityPickerSlide;
 import com.beemdevelopment.aegis.ui.slides.SecuritySetupSlide;
 import com.beemdevelopment.aegis.ui.slides.WelcomeSlide;
+import com.beemdevelopment.aegis.vault.VaultFile;
 import com.beemdevelopment.aegis.vault.VaultFileCredentials;
+import com.beemdevelopment.aegis.vault.VaultRepository;
 import com.beemdevelopment.aegis.vault.VaultRepositoryException;
 import com.beemdevelopment.aegis.vault.slots.BiometricSlot;
 import com.beemdevelopment.aegis.vault.slots.PasswordSlot;
@@ -108,8 +110,17 @@ public class IntroActivity extends IntroBaseActivity {
                 return;
             }
         } else {
+            VaultFile vaultFile;
             try {
-                _vaultManager.load(creds);
+                vaultFile = VaultRepository.readVaultFile(this);
+            } catch (VaultRepositoryException e) {
+                e.printStackTrace();
+                Dialogs.showErrorDialog(this, R.string.vault_load_error, e);
+                return;
+            }
+
+            try {
+                _vaultManager.loadFrom(vaultFile, creds);
             } catch (VaultRepositoryException e) {
                 e.printStackTrace();
                 Dialogs.showErrorDialog(this, R.string.vault_load_error, e);


### PR DESCRIPTION
This trades performance for making VaultManager a bit easier to reason about.

This also fixes a rare crash that could occur if the user retries to unlock the app after the previous attempt resulted in an error related to parsing the vault. The vault file would no longer be present in memory after the first attempt, causing the second attempt to crash the app.