### PR TITLE
Don't initialize VaultManager after the intro unless saving succeeds

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultManager.java
@@ -55,8 +55,9 @@ public class VaultManager {
             throw new IllegalStateException("Vault manager is already initialized");
         }
 
-        _repo = new VaultRepository(_context, new Vault(), creds);
-        save();
+        VaultRepository repo = new VaultRepository(_context, new Vault(), creds);
+        repo.save();
+        _repo = repo;
 
         if (getVault().isEncryptionEnabled()) {
             startNotificationService();


### PR DESCRIPTION
In rare cases where writing to disk fails after the intro, a crash could occur if the user presses "Done" again. VaultManager would have been initialized, and trying to initialize it again would result in a crash.