### PR TITLE
Restore entry list item animations

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -103,7 +103,6 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
 
         // set up the recycler view
         _recyclerView = view.findViewById(R.id.rvKeyProfiles);
-        _recyclerView.setItemAnimator(null);
         _recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {


### PR DESCRIPTION
This fixes an issue where the entry list items no longer animated upon move, insert, delete, etc.

RecyclerView's DefaultItemAnimator automatically scales the animations according to the user's settings.

Introduced in 9ff8efab69ec43c16cce41553ab3239a6613a050