### PR TITLE
Apply dark background colors when combining AMOLED and dynamic colors

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AegisActivity.java
@@ -26,6 +26,7 @@ import com.beemdevelopment.aegis.icons.IconPackManager;
 import com.beemdevelopment.aegis.vault.VaultManager;
 import com.beemdevelopment.aegis.vault.VaultRepositoryException;
 import com.google.android.material.color.DynamicColors;
+import com.google.android.material.color.DynamicColorsOptions;
 import com.google.android.material.color.MaterialColors;
 
 import java.lang.reflect.Field;
@@ -122,7 +123,11 @@ public abstract class AegisActivity extends AppCompatActivity implements VaultMa
         setTheme(theme);
 
         if (_prefs.isDynamicColorsEnabled()) {
-            DynamicColors.applyToActivityIfAvailable(this);
+            DynamicColorsOptions.Builder optsBuilder = new DynamicColorsOptions.Builder();
+            if (getConfiguredTheme().equals(Theme.AMOLED)) {
+                optsBuilder.setThemeOverlay(R.style.ThemeOverlay_Aegis_Dynamic_Amoled);
+            }
+            DynamicColors.applyToActivityIfAvailable(this, optsBuilder.build());
         }
     }
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -148,6 +148,19 @@
         <item name="colorSurfaceBright">#000000</item>
     </style>
 
+    <style name="ThemeOverlay.Aegis.Dynamic.Amoled" parent="ThemeOverlay.Material3.DynamicColors.Dark">
+        <item name="android:colorBackground">#000000</item>
+        <item name="colorSurface">#000000</item>
+        <item name="colorSurfaceVariant">#000000</item>
+        <item name="colorSurfaceContainerHighest">#000000</item>
+        <item name="colorSurfaceContainerHigh">#000000</item>
+        <item name="colorSurfaceContainer">#000000</item>
+        <item name="colorSurfaceContainerLow">#000000</item>
+        <item name="colorSurfaceContainerLowest">#000000</item>
+        <item name="colorSurfaceDim">#000000</item>
+        <item name="colorSurfaceBright">#000000</item>
+    </style>
+
     <style name="Theme.Aegis.Light" parent="Base.Theme.Aegis.Light">
     </style>
     <style name="Theme.Aegis.Light.Fullscreen" parent="Theme.Aegis.Light">


### PR DESCRIPTION
Previously, the dark background colors would not be applied for this combination of settings.

Unfortunately, I couldn't find a way to avoid some duplication in themes.xml.