### PR TITLE
Increase version support to `4` for 2FAS backup import

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/importers/TwoFASImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/TwoFASImporter.java
@@ -61,7 +61,7 @@ public class TwoFASImporter extends DatabaseImporter {
             String json = new String(IOUtils.readAll(stream), StandardCharsets.UTF_8);
             JSONObject obj = new JSONObject(json);
             int version = obj.getInt("schemaVersion");
-            if (version > 4) {
+            if (version > 5) {
                 throw new DatabaseImporterException(String.format("Unsupported schema version: %d", version));
             }
 


### PR DESCRIPTION
Version 4 import of 2FAS backup was tested and successful with and without encryption without any code change

RESOLVE #1304