### PR TITLE
Fix a couple UI inconsistencies

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -375,6 +375,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
 
         sortShownEntries();
+        checkPeriodUniformity();
         _view.onListChange();
         notifyDataSetChanged();
     }
@@ -667,6 +668,10 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
         if (infos.isEmpty()) {
             return -1;
+        }
+
+        if (infos.size() == 1) {
+            return infos.get(0).getPeriod();
         }
 
         Map<Integer, Integer> occurrences = new HashMap<>();

--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -98,7 +98,7 @@
                 </LinearLayout>
                 <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     android:orientation="horizontal"
                     android:layout_marginTop="10dp"
                     android:layout_marginStart="44.5dp">
@@ -110,8 +110,9 @@
                         android:layout_weight="1">
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/text_issuer"
+                            android:maxLines="1"
                             android:layout_width="match_parent"
-                            android:layout_height="match_parent"
+                            android:layout_height="wrap_content"
                             android:inputType="text"/>
                     </com.google.android.material.textfield.TextInputLayout>
                     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
This pull request fixes the progressbar uniformity and the weird spacing around the Group field in the Edit Entry view.

I've added the uniformity check to the search filter. And from now on whenever there's only 1 shown entry, the perioduniformity check will now return the period of that single entry.

Fixes #1306 