### PR TITLE
Fix various minor inconsistencies in entry list item offsets

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ViewMode.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ViewMode.java
@@ -35,11 +35,11 @@ public enum ViewMode {
     }
 
     /**
-     * Retrieves the height (in dp) that the divider between entries should have in this view mode.
+     * Retrieves the offset (in dp) that should exist between entries in this view mode.
      */
-    public float getDividerHeight() {
+    public float getItemOffset() {
         if (this == ViewMode.COMPACT) {
-            return 0;
+            return 1;
         } else if (this == ViewMode.TILES) {
             return 4;
         }
@@ -47,20 +47,12 @@ public enum ViewMode {
         return 8;
     }
 
-    public int getColumnSpan() {
+    public int getSpanCount() {
         if (this == ViewMode.TILES) {
             return 2;
         }
 
         return 1;
-    }
-
-    public float getDividerWidth() {
-        if (this == ViewMode.TILES) {
-            return 4;
-        }
-
-        return 0;
     }
 
     public String getFormattedAccountName(String accountName) {


### PR DESCRIPTION
This patch addresses the following:
- More consistent offsets between entries in the list, especially in relation to the action bar and the error card.
- Consistent correct application of card shapes when switching between favoriting and unfavoriting entries.
- Removal of CompactDividerDecoration. We no longer uses dividers, so this is no longer needed.

Example before and after:

<img width="300" src="https://github.com/beemdevelopment/Aegis/assets/2387841/6b90da11-892b-4b92-8691-402c7a0cd7a5" />
<img width="300" src="https://github.com/beemdevelopment/Aegis/assets/2387841/79366ebd-55a1-4293-8710-04d246bd2805" />

