### PR TITLE
Use Android color reference for android:colorBackground in AMOLED theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -138,7 +138,8 @@
     </style>
 
     <style name="Base.Theme.Aegis.Amoled" parent="Base.Theme.Aegis.Dark">
-        <item name="android:colorBackground">#000000</item>
+        <!-- Setting android:colorBackground to #000000 on API 28 and below causes smearing -->
+        <item name="android:colorBackground">@android:color/black</item>
         <item name="colorSurface">#000000</item>
         <item name="colorSurfaceVariant">#000000</item>
         <item name="colorSurfaceContainerHighest">#000000</item>
@@ -152,7 +153,8 @@
     </style>
 
     <style name="ThemeOverlay.Aegis.Dynamic.Amoled" parent="ThemeOverlay.Material3.DynamicColors.Dark">
-        <item name="android:colorBackground">#000000</item>
+        <!-- Setting android:colorBackground to #000000 on API 28 and below causes smearing -->
+        <item name="android:colorBackground">@android:color/black</item>
         <item name="colorSurface">#000000</item>
         <item name="colorSurfaceVariant">#000000</item>
         <item name="colorSurfaceContainerHighest">#000000</item>


### PR DESCRIPTION
My best guess is that API 28 and below somehow interpret ``#000000`` to mean either ``@null`` or transparent for ``android:colorBackground``.

Fixes #1325.