### PR TITLE
Use DayNight as the default theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:icon="@mipmap/${iconName}"
         android:label="Aegis"
         android:supportsRtl="true"
+        android:theme="@style/Theme.Aegis.Launch"
         tools:targetApi="tiramisu">
         <activity android:name=".ui.TransferEntriesActivity"
             android:label="@string/title_activity_transfer" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,11 @@
 <resources>
+    <style name="Theme.Aegis.Launch" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- colorPrimary in the root theme sets the task description color (seen in task switcher) -->
+        <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+
     <style name="Base.Theme.Aegis.Light" parent="Theme.Material3.Light">
         <!-- Material colors -->
         <item name="colorPrimary">@color/md_theme_light_primary</item>


### PR DESCRIPTION
This reduces the chance that we flashbang the user when they launch the app. The issue remains on older Android versions that don't natively support dark mode, but I don't think that's fixable.

Activities override the theme based on the user's settings, so this change only has effect while the app is launching.

Fixes #1330.