### PR TITLE
Fix Language of Appearance Title

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -10,6 +10,7 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.ui.fragments.preferences.AppearancePreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.MainPreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.PreferencesFragment;
 
@@ -128,6 +129,9 @@ public class PreferencesActivity extends AegisActivity implements
         public void onFragmentStarted(@NonNull FragmentManager fm, @NonNull Fragment f) {
             if (f instanceof MainPreferencesFragment) {
                 setTitle(R.string.action_settings);
+            } else if (f instanceof AppearancePreferencesFragment) {
+                _prefTitle = getString(R.string.pref_section_appearance_title);
+                setTitle(_prefTitle);
             }
         }
     }


### PR DESCRIPTION
Fixes #1346

### Root cause:
`_prefTitle` is saved in the bundle as `CharSequence`

### Solution:
we only able to store `CharSequence` since `Preference.getTitleRes` is removed in AndroidX. 

As a workaround, we update the title again on Fragment.onStart()

### Demo

https://github.com/beemdevelopment/Aegis/assets/11408319/b929ddf9-b8fb-4ce2-89cf-25ac2b433491

