### PR TITLE
Update change of Code Digit Grouping

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
@@ -132,9 +132,10 @@ public class AppearancePreferencesFragment extends PreferencesFragment {
 
         String[] codeGroupings = getResources().getStringArray(R.array.pref_code_groupings_values);
         String[] codeGroupingNames = getResources().getStringArray(R.array.pref_code_groupings);
-        int currentCodeGroupingIndex = Arrays.asList(codeGroupings).indexOf(_prefs.getCodeGroupSize().name());
         Preference codeDigitGroupingPreference = requirePreference("pref_code_group_size_string");
         codeDigitGroupingPreference.setOnPreferenceClickListener(preference -> {
+            int currentCodeGroupingIndex = Arrays.asList(codeGroupings).indexOf(_prefs.getCodeGroupSize().name());
+
             Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.pref_code_group_size_title)
                     .setSingleChoiceItems(codeGroupingNames, currentCodeGroupingIndex, (dialog, which) -> {


### PR DESCRIPTION
When I change in the preferences the "Code digit grouping" from x to y and then open the dialog again, the displayed value is still x instead of y. This PR fixed this issue, that is, it displays y when re-opening the dialog