### PR TITLE
DatabaseImporter: add overlooked FreeOTP "1.x" hint

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/importers/DatabaseImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/DatabaseImporter.java
@@ -39,7 +39,7 @@ public abstract class DatabaseImporter {
         _importers.add(new Definition("Battle.net Authenticator", BattleNetImporter.class, R.string.importer_help_battle_net_authenticator, true));
         _importers.add(new Definition("Bitwarden", BitwardenImporter.class, R.string.importer_help_bitwarden, false));
         _importers.add(new Definition("Duo", DuoImporter.class, R.string.importer_help_duo, true));
-        _importers.add(new Definition("FreeOTP", FreeOtpImporter.class, R.string.importer_help_freeotp, true));
+        _importers.add(new Definition("FreeOTP (1.x)", FreeOtpImporter.class, R.string.importer_help_freeotp, true));
         _importers.add(new Definition("FreeOTP+", FreeOtpPlusImporter.class, R.string.importer_help_freeotp_plus, true));
         _importers.add(new Definition("Google Authenticator", GoogleAuthImporter.class, R.string.importer_help_google_authenticator, true));
         _importers.add(new Definition("Microsoft Authenticator", MicrosoftAuthImporter.class, R.string.importer_help_microsoft_authenticator, true));


### PR DESCRIPTION
Thanks for making a nice 2FA app!

I tried Aegis while being frustrated by FreeOTP (backup won't import on new phone).
I was briefly excited about Aegis listing "FreeOTP" in the import-dropdown, but later disappointed to learn it is only for the old 1.x format.
To spare others the same emotional rollercoaster, I'm suggesting that the dropdown _itself_ should already mention "FreeOTP **(1.x)**"

This passes local unit tests, and looks correct in the device emulator:
![image](https://github.com/beemdevelopment/Aegis/assets/7068025/92e05f97-38ac-46f0-85f4-e02e347c9661)





See also:
- #1204, where the 1.x-hint was introduced
- #1084: tracking issue for 2.x support
- https://github.com/freeotp/freeotp-android/issues/381 FreeOTP-issue to reconsider the brittle serialised java format used by 2.x