### PR TITLE
Clarify FreeOTP+ import needs JSON, not URI-format

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/importers/DatabaseImporter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/importers/DatabaseImporter.java
@@ -40,7 +40,7 @@ public abstract class DatabaseImporter {
         _importers.add(new Definition("Bitwarden", BitwardenImporter.class, R.string.importer_help_bitwarden, false));
         _importers.add(new Definition("Duo", DuoImporter.class, R.string.importer_help_duo, true));
         _importers.add(new Definition("FreeOTP (1.x)", FreeOtpImporter.class, R.string.importer_help_freeotp, true));
-        _importers.add(new Definition("FreeOTP+", FreeOtpPlusImporter.class, R.string.importer_help_freeotp_plus, true));
+        _importers.add(new Definition("FreeOTP+ (JSON)", FreeOtpPlusImporter.class, R.string.importer_help_freeotp_plus, true));
         _importers.add(new Definition("Google Authenticator", GoogleAuthImporter.class, R.string.importer_help_google_authenticator, true));
         _importers.add(new Definition("Microsoft Authenticator", MicrosoftAuthImporter.class, R.string.importer_help_microsoft_authenticator, true));
         _importers.add(new Definition("Plain text", GoogleAuthUriImporter.class, R.string.importer_help_plain_text, false));


### PR DESCRIPTION
Hi again! After the mini-fix in #1408, I've been toying with FreeOTP+, and syncing it with Aegis.
(Confirming that the FreeOTP+ backup works, after being burned by FreeOTP, never again!)

FreeOTP+ offers two export formats: JSON and URI.
Aegis imports only the JSON, and gives a "cryptic" (for non-developers) "couldn't deserialise java.lang.String to JsonObject" error if you try to import the URI-format.

This PR makes the JSON-format explicit in the importer dropdown, and updates the few translations of the additional-hint-text that I'm personally comfortable with.
I hope your translation community will step up for the rest, but since the dropdown is untranslated, everybody should benefit even without the hint-texts.

I'm not sure if URI-import support is something that is desired. I don't know how generic that format is, or if it is FreeOTP+-specific.
Regardless, I don't have capacity to work on that, but I could open a tracking issue for it, if desired.