### PR TITLE
Initialize the group chip properly after unlocking Aegis

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -857,6 +857,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
 
     private void loadEntries() {
         if (!_loaded) {
+            _entryListView.setGroups(_vaultManager.getVault().getUsedGroups());
             _entryListView.setUsageCounts(_prefs.getUsageCounts());
             _entryListView.setLastUsedTimestamps(_prefs.getLastUsedTimestamps());
             _entryListView.addEntries(_vaultManager.getVault().getEntries());


### PR DESCRIPTION
This fixes an issue introduced by 46e1421c28857034c135f3c3facbe8b9b5c6483d where the group chip would not show after unlocking Aegis. This happened because the activity result is received *after* ``onStart``. When we were using ``onResume``, it was the other way around.