### PR TITLE
Simplify approach for animating advanced entry settings

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -127,7 +127,7 @@ public class EditEntryActivity extends AegisActivity {
     private KropView _kropView;
 
     private RelativeLayout _advancedSettingsHeader;
-    private RelativeLayout _advancedSettings;
+    private LinearLayout _advancedSettingsLayout;
 
     private BackPressHandler _backPressHandler;
     private IconBackPressHandler _iconBackPressHandler;
@@ -241,7 +241,7 @@ public class EditEntryActivity extends AegisActivity {
 
         _advancedSettingsHeader = findViewById(R.id.accordian_header);
         _advancedSettingsHeader.setOnClickListener(v -> openAdvancedSettings());
-        _advancedSettings = findViewById(R.id.expandableLayout);
+        _advancedSettingsLayout = findViewById(R.id.layout_advanced);
 
         // fill the fields with values if possible
         GlideHelper.loadEntryIcon(Glide.with(this), _origEntry, _iconView);
@@ -411,17 +411,13 @@ public class EditEntryActivity extends AegisActivity {
         fadeOut.setDuration((long) (220 * AnimationsHelper.Scale.ANIMATOR.getValue(this)));
         _advancedSettingsHeader.startAnimation(fadeOut);
 
-        Animation fadeIn = new AlphaAnimation(0, 1);
-        fadeIn.setInterpolator(new AccelerateInterpolator());
-        fadeIn.setDuration((long) (250 * AnimationsHelper.Scale.ANIMATOR.getValue(this)));
-
         fadeOut.setAnimationListener(new SimpleAnimationEndListener((a) -> {
             _advancedSettingsHeader.setVisibility(View.GONE);
-            _advancedSettings.startAnimation(fadeIn);
-        }));
-
-        fadeIn.setAnimationListener(new SimpleAnimationEndListener((a) -> {
-            _advancedSettings.setVisibility(View.VISIBLE);
+            _advancedSettingsLayout.setVisibility(View.VISIBLE);
+            _advancedSettingsLayout.animate()
+                    .setInterpolator(new AccelerateInterpolator())
+                    .setDuration((long) (250 * AnimationsHelper.Scale.ANIMATOR.getValue(this)))
+                    .alpha(1);
         }));
     }
 

--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -251,149 +251,143 @@
                         android:textStyle="bold" />
 
                 </RelativeLayout>
-                <RelativeLayout
-                    android:id="@+id/expandableLayout"
+                <LinearLayout
+                    android:id="@+id/layout_advanced"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone">
+                    android:orientation="vertical"
+                    android:visibility="gone"
+                    android:alpha="0"
+                    android:layout_marginHorizontal="10dp">
                     <LinearLayout
-                        android:id="@+id/layout_advanced"
+                        android:id="@+id/layout_type_algo"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:layout_marginHorizontal="10dp">
-                        <LinearLayout
-                            android:id="@+id/layout_type_algo"
-                            android:layout_width="match_parent"
+                        android:layout_marginTop="10dp"
+                        android:orientation="horizontal">
+                        <ImageView
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="10dp"
+                            android:src="@drawable/ic_outline_info_24"
+                            app:tint="?attr/colorOnSurface"
+                            android:layout_marginStart="5dp"
+                            android:layout_marginEnd="15dp"
+                            android:layout_gravity="center_vertical"/>
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
                             android:orientation="horizontal">
-                            <ImageView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:src="@drawable/ic_outline_info_24"
-                                app:tint="?attr/colorOnSurface"
-                                android:layout_marginStart="5dp"
-                                android:layout_marginEnd="15dp"
-                                android:layout_gravity="center_vertical"/>
 
-                            <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:orientation="horizontal">
-
-                                <com.google.android.material.textfield.TextInputLayout
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginEnd="5dp"
-                                    android:layout_weight="2"
-                                    android:hint="@string/type"
-                                    style="?attr/dropdownStyle">
-                                    <AutoCompleteTextView
-                                        android:id="@+id/dropdown_type"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        android:inputType="none"/>
-                                </com.google.android.material.textfield.TextInputLayout>
-                                <com.google.android.material.textfield.TextInputLayout
-                                    android:id="@+id/dropdown_algo_layout"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginStart="5dp"
-                                    android:layout_weight="2"
-                                    android:hint="@string/algorithm_hint"
-                                    style="?attr/dropdownStyle">
-                                    <AutoCompleteTextView
-                                        android:id="@+id/dropdown_algo"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        android:inputType="none" />
-                                </com.google.android.material.textfield.TextInputLayout>
-                            </LinearLayout>
-                        </LinearLayout>
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:layout_marginTop="10dp"
-                            android:layout_marginStart="44.5dp">
                             <com.google.android.material.textfield.TextInputLayout
-                                android:id="@+id/text_period_counter_layout"
-                                android:hint="@string/period_hint"
                                 android:layout_width="0dp"
                                 android:layout_height="wrap_content"
                                 android:layout_marginEnd="5dp"
-                                android:layout_weight="1">
-                                <com.google.android.material.textfield.TextInputEditText
-                                    android:id="@+id/text_period_counter"
+                                android:layout_weight="2"
+                                android:hint="@string/type"
+                                style="?attr/dropdownStyle">
+                                <AutoCompleteTextView
+                                    android:id="@+id/dropdown_type"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
-                                    android:inputType="text"/>
+                                    android:inputType="none"/>
                             </com.google.android.material.textfield.TextInputLayout>
                             <com.google.android.material.textfield.TextInputLayout
-                                android:id="@+id/text_digits_layout"
-                                android:hint="@string/digits"
+                                android:id="@+id/dropdown_algo_layout"
                                 android:layout_width="0dp"
-                                android:layout_height="match_parent"
+                                android:layout_height="wrap_content"
                                 android:layout_marginStart="5dp"
-                                android:layout_weight="1">
-                                <com.google.android.material.textfield.TextInputEditText
-                                    android:id="@+id/text_digits"
+                                android:layout_weight="2"
+                                android:hint="@string/algorithm_hint"
+                                style="?attr/dropdownStyle">
+                                <AutoCompleteTextView
+                                    android:id="@+id/dropdown_algo"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
-                                    android:inputType="text"/>
+                                    android:inputType="none" />
                             </com.google.android.material.textfield.TextInputLayout>
                         </LinearLayout>
-                        <LinearLayout
-                            android:id="@+id/layout_usage_count"
-                            android:layout_width="match_parent"
+                    </LinearLayout>
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginTop="10dp"
+                        android:layout_marginStart="44.5dp">
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/text_period_counter_layout"
+                            android:hint="@string/period_hint"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="10dp"
-                            android:weightSum="2"
-                            android:orientation="horizontal">
-                            <ImageView
-                                android:layout_width="wrap_content"
+                            android:layout_marginEnd="5dp"
+                            android:layout_weight="1">
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/text_period_counter"
+                                android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:src="@drawable/ic_counter_black_24"
-                                app:tint="?attr/colorOnSurface"
-                                android:layout_marginStart="5dp"
-                                android:layout_marginEnd="15dp"
-                                android:layout_gravity="center_vertical"/>
-
-                            <LinearLayout
-                                android:layout_width="0dp"
+                                android:inputType="text"/>
+                        </com.google.android.material.textfield.TextInputLayout>
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/text_digits_layout"
+                            android:hint="@string/digits"
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginStart="5dp"
+                            android:layout_weight="1">
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/text_digits"
+                                android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:orientation="horizontal">
-
-                                <com.google.android.material.textfield.TextInputLayout
-                                    android:hint="@string/usage_count"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginEnd="5dp">
-                                    <com.google.android.material.textfield.TextInputEditText
-                                        android:id="@+id/text_usage_count"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        android:enabled="false"
-                                        android:inputType="number"/>
-                                </com.google.android.material.textfield.TextInputLayout>
-                            </LinearLayout>
-                        </LinearLayout>
-                        <TextView
-                            android:id="@+id/text_last_used"
+                                android:inputType="text"/>
+                        </com.google.android.material.textfield.TextInputLayout>
+                    </LinearLayout>
+                    <LinearLayout
+                        android:id="@+id/layout_usage_count"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:weightSum="2"
+                        android:orientation="horizontal">
+                        <ImageView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:paddingTop="16dp"
-                            android:paddingBottom="16dp"
-                            android:layout_centerInParent="true"
-                            android:layout_gravity="bottom|center"
-                            android:textSize="14sp" />
+                            android:src="@drawable/ic_counter_black_24"
+                            app:tint="?attr/colorOnSurface"
+                            android:layout_marginStart="5dp"
+                            android:layout_marginEnd="15dp"
+                            android:layout_gravity="center_vertical"/>
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="horizontal">
+
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:hint="@string/usage_count"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="5dp">
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/text_usage_count"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:enabled="false"
+                                    android:inputType="number"/>
+                            </com.google.android.material.textfield.TextInputLayout>
+                        </LinearLayout>
                     </LinearLayout>
-
-
-                </RelativeLayout>
+                    <TextView
+                        android:id="@+id/text_last_used"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="16dp"
+                        android:paddingBottom="16dp"
+                        android:layout_centerInParent="true"
+                        android:layout_gravity="bottom|center"
+                        android:textSize="14sp" />
+                </LinearLayout>
 
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
This slightly simplifies the approach we use to animate the advanced entry settings into view, by defaulting its alpha to 0 and setting it to VISIBLE before the animation starts. That way, we're not dependent on "animation ended" callbacks that apparently don't fire in all cases.

The XML diff looks a bit scary, but it basically just removes a wrapping ``RelativeLayout`` that appears to not be necessary.

Fixes #1417.