### PR TITLE
Fix showing duplicate time sync dialogs

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -520,7 +520,6 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
 
     private void onIntroResult() {
         loadEntries();
-        checkTimeSyncSetting();
     }
 
     private void checkTimeSyncSetting() {
@@ -537,7 +536,6 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _auditLogRepository.addVaultUnlockedEvent();
 
         loadEntries();
-        checkTimeSyncSetting();
     }
 
     private void startScanActivity() {


### PR DESCRIPTION
This fixes an issue introduced by 46e1421c28857034c135f3c3facbe8b9b5c6483d where the automatic time sync dialog would be shown multiple times. After decrypting the vault, completing the setup wizard and right before loading the entries in the onStart. I removed the dialog from both the IntroResult and DecryptResult. 

Fixes #1436