### PR TITLE
Add ability to hide account name in tiles mode

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
@@ -116,7 +116,7 @@ public class AppearancePreferencesFragment extends PreferencesFragment {
                         int i = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
                         _prefs.setCurrentViewMode(ViewMode.fromInteger(i));
                         viewModePreference.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.view_mode_titles)[i]));
-                        overrideAccountNamePosition(ViewMode.fromInteger(i) == ViewMode.TILES);
+                        refreshAccountNamePositionText();
                         dialog.dismiss();
                     })
                     .setNegativeButton(android.R.string.cancel, null)
@@ -156,6 +156,7 @@ public class AppearancePreferencesFragment extends PreferencesFragment {
                         int i = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
                         _prefs.setAccountNamePosition(AccountNamePosition.fromInteger(i));
                         _currentAccountNamePositionPreference.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.account_name_position_titles)[i]));
+                        refreshAccountNamePositionText();
                         dialog.dismiss();
                     })
                     .setNegativeButton(android.R.string.cancel, null)
@@ -164,15 +165,15 @@ public class AppearancePreferencesFragment extends PreferencesFragment {
             return true;
         });
 
-        overrideAccountNamePosition(_prefs.getCurrentViewMode() == ViewMode.TILES);
+        refreshAccountNamePositionText();
     }
 
-    private void overrideAccountNamePosition(boolean override) {
+    private void refreshAccountNamePositionText() {
+        boolean override = (_prefs.getCurrentViewMode() == ViewMode.TILES && _prefs.getAccountNamePosition() == AccountNamePosition.END);
+
         if (override) {
-            _currentAccountNamePositionPreference.setEnabled(false);
-            _currentAccountNamePositionPreference.setSummary(getString(R.string.pref_account_name_position_summary_override));
+            _currentAccountNamePositionPreference.setSummary(String.format("%s: %s. %s", getString(R.string.selected), getResources().getStringArray(R.array.account_name_position_titles)[_prefs.getAccountNamePosition().ordinal()], getString(R.string.pref_account_name_position_summary_override)));
         } else {
-            _currentAccountNamePositionPreference.setEnabled(true);
             _currentAccountNamePositionPreference.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.account_name_position_titles)[_prefs.getAccountNamePosition().ordinal()]));
         }
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -550,7 +550,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                             case SINGLETAP:
                                 if (!handled) {
                                     _view.onEntryCopy(entry);
-                                    entryHolder.animateCopyText(_viewMode != ViewMode.TILES);
+                                    entryHolder.animateCopyText();
                                     _clickedEntry = null;
                                 }
                                 break;
@@ -559,7 +559,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
                                 if(entry == _clickedEntry) {
                                     _view.onEntryCopy(entry);
-                                    entryHolder.animateCopyText(_viewMode != ViewMode.TILES);
+                                    entryHolder.animateCopyText();
                                     _clickedEntry = null;
                                 } else {
                                     _clickedEntry = entry;

--- a/app/src/main/res/layout/card_entry_tile.xml
+++ b/app/src/main/res/layout/card_entry_tile.xml
@@ -66,9 +66,9 @@
 
             <RelativeLayout
                 android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="24dp"
                 android:id="@+id/description"
-                android:layout_toEndOf="@+id/layoutImage">
+                android:layout_toEndOf="@id/layoutImage">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -80,19 +80,16 @@
                     android:textSize="11sp"
                     android:ellipsize="end"
                     android:maxLines="1"/>
-
-
                 <TextView
                     android:id="@+id/profile_copied"
                     android:layout_width="wrap_content"
-                    android:layout_below="@id/profile_issuer"
                     android:layout_height="wrap_content"
+                    android:layout_below="@id/profile_issuer"
                     android:maxLines="1"
                     android:includeFontPadding="false"
                     android:visibility="invisible"
                     android:text="@string/copied"
                     android:textSize="9sp" />
-
                 <TextView
                     android:id="@+id/profile_account_name"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_account_name_position_title">Show the account name</string>
     <string name="pref_shared_issuer_account_name_title">Only show account name when necessary</string>
     <string name="pref_shared_issuer_account_name_summary">Only show account names whenever they share the same issuer. Other account names will be hidden.</string>
-    <string name="pref_account_name_position_summary_override">This setting is overridden by the tiles view mode. Account name will always be shown below the issuer.</string>
+    <string name="pref_account_name_position_summary_override">This setting is overridden by the tiles view mode. Account name will be shown below the issuer.</string>
     <string name="pref_import_file_title">Import from file</string>
     <string name="pref_import_file_summary">Import tokens from a file</string>
     <string name="pref_android_backups_title">Android cloud backups</string>


### PR DESCRIPTION
This PR removes the limitation to refrain the user from setting the account name to hidden whenever the Tiles mode is being used. We still override the account name position preference it's set to "Next to issuer" since that will make a mess in Tiles mode.

<img src="https://github.com/user-attachments/assets/78e3f735-d27c-4076-b5a0-b70007b5b50f" width=250/>
<img src="https://github.com/user-attachments/assets/3e68f868-063e-48a1-8494-4ade812abd84" width=250/>

We would have to think about a nice way to handle all the different customization options between the different viewmodes though.


Fixes #1285

