### PR TITLE
Add an extra check before showing the password reminder popup

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -241,7 +241,7 @@ public class AuthActivity extends AegisActivity {
         popup.setFocusable(false);
         popup.setOutsideTouchable(true);
         _textPassword.post(() -> {
-            if (isFinishing()) {
+            if (isFinishing() || !_textPassword.isAttachedToWindow()) {
                 return;
             }
 


### PR DESCRIPTION
This is another attempt to fix a rare crash we're seeing in the developer console:

```
Exception android.view.WindowManager$BadTokenException: Unable to add window -- token null is not valid; is your activity running?
  at android.view.ViewRootImpl.setView (ViewRootImpl.java:1423)
  at android.view.WindowManagerGlobal.addView (WindowManagerGlobal.java:408)
  at android.view.WindowManagerImpl.addView (WindowManagerImpl.java:148)
  at android.widget.PopupWindow.invokePopup (PopupWindow.java:1583)
  at android.widget.PopupWindow.showAsDropDown (PopupWindow.java:1430)
  at android.widget.PopupWindow.showAsDropDown (PopupWindow.java:1386)
  at com.beemdevelopment.aegis.ui.AuthActivity.lambda$showPasswordReminder$5 (AuthActivity.java:253)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8294)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:580)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1028)
```