### PR TITLE
Account for audit log entries that reference deleted entries

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AuditLogPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AuditLogPreferencesFragment.java
@@ -6,10 +6,8 @@ import android.view.View;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.Observer;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -64,10 +62,12 @@ public class AuditLogPreferencesFragment extends Fragment {
             _noAuditLogsView.setVisibility(entries1.isEmpty() ? View.VISIBLE : View.GONE);
 
             for (AuditLogEntry entry : entries1) {
-
                 VaultEntry referencedEntry = null;
                 if (entry.getReference() != null) {
-                     referencedEntry = _vaultManager.getVault().getEntryByUUID(UUID.fromString(entry.getReference()));
+                    UUID referencedEntryUUID = UUID.fromString(entry.getReference());
+                    if (_vaultManager.getVault().hasEntryByUUID(referencedEntryUUID)) {
+                        referencedEntry = _vaultManager.getVault().getEntryByUUID(referencedEntryUUID);
+                    }
                 }
 
                 AuditLogEntryModel auditLogEntryModel = new AuditLogEntryModel(entry, referencedEntry);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/AuditLogHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/AuditLogHolder.java
@@ -61,6 +61,10 @@ public class AuditLogHolder extends RecyclerView.ViewHolder {
         if (auditLogEntryModel.getReferencedVaultEntry() != null) {
             VaultEntry referencedVaultEntry = auditLogEntryModel.getReferencedVaultEntry();
             _auditLogEntryReference.setText(String.format("%s (%s)", referencedVaultEntry.getIssuer(), referencedVaultEntry.getName()));
+            _auditLogEntryReference.setVisibility(View.VISIBLE);
+        } else if (auditLogEntryModel.getAuditLogEntry().getReference() != null) {
+            _auditLogEntryReference.setText(R.string.audit_log_entry_deleted);
+            _auditLogEntryReference.setVisibility(View.VISIBLE);
         } else {
             _auditLogEntryReference.setVisibility(View.GONE);
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultRepository.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultRepository.java
@@ -225,6 +225,10 @@ public class VaultRepository {
         _vault.getEntries().add(entry);
     }
 
+    public boolean hasEntryByUUID(UUID uuid) {
+        return _vault.getEntries().has(uuid);
+    }
+
     public VaultEntry getEntryByUUID(UUID uuid) {
         return _vault.getEntries().getByUUID(uuid);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="event_title_vault_unlock_failed_biometrics">Vault unlock failed (biometrics)</string>
     <string name="event_description_vault_unlock_failed_biometrics">An attempt to unlock the vault with biometrics failed</string>
     <string name="event_unknown">Unknown event type</string>
+    <string name="audit_log_entry_deleted">(deleted)</string>
 
     <string name="today_at_time">Today at %1$s</string>
     <string name="day_of_week_at_time">%1$s at %2$s</string>


### PR DESCRIPTION
This fixes the following crash I noticed in the developer console:

```
Exception java.lang.AssertionError:
  at com.beemdevelopment.aegis.util.UUIDMap.getByUUID (UUIDMap.java:127)
  at com.beemdevelopment.aegis.vault.VaultRepository.getEntryByUUID (VaultRepository.java:229)
  at com.beemdevelopment.aegis.ui.fragments.preferences.AuditLogPreferencesFragment.lambda$onViewCreated$0 (AuditLogPreferencesFragment.java:70)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:133)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:151)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:309)
  at androidx.lifecycle.LiveData$1.run (LiveData.java:93)
  at android.os.Handler.handleCallback (Handler.java:959)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loopOnce (Looper.java:232)
  at android.os.Looper.loop (Looper.java:317)
  at android.app.ActivityThread.main (ActivityThread.java:8592)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:580)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:878)
```