### PR TITLE
Improve group filters

### DIFF
--- a/app/src/androidTest/java/com/beemdevelopment/aegis/OverallTest.java
+++ b/app/src/androidTest/java/com/beemdevelopment/aegis/OverallTest.java
@@ -177,12 +177,10 @@ public class OverallTest extends AegisTest {
     }
 
     private void changeGroupFilter(String text) {
-        onView(withId(R.id.chip_group)).perform(click());
         if (text == null) {
-            onView(withId(R.id.btnClear)).perform(click());
+            onView(allOf(withText(R.string.all), isDescendantOfA(withId(R.id.groupChipGroup)))).perform(click());
         } else {
-            onView(withText(text)).perform(click());
-            onView(isRoot()).perform(pressBack());
+            onView(allOf(withText(text), isDescendantOfA(withId(R.id.groupChipGroup)))).perform(click());
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -15,30 +14,47 @@
         android:fitsSystemWindows="true"
         app:liftOnScroll="true"
         app:liftOnScrollTargetViewId="@+id/rvKeyProfiles">
+
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />
+
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp"
+            android:scrollbars="none">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp">
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/groupChipGroup"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"></com.google.android.material.chip.ChipGroup>
+            </LinearLayout>
+        </HorizontalScrollView>
     </com.google.android.material.appbar.AppBarLayout>
+
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        android:orientation="vertical">
-
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/groupChipGroup"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-        </com.google.android.material.chip.ChipGroup>
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <fragment
-            android:name="com.beemdevelopment.aegis.ui.views.EntryListView"
             android:id="@+id/key_profiles"
-            android:layout_height="fill_parent"
+            android:name="com.beemdevelopment.aegis.ui.views.EntryListView"
             android:layout_width="match_parent"
+            android:layout_height="fill_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
     </LinearLayout>
 
@@ -48,6 +64,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_outline_add_24"  />
+        android:src="@drawable/ic_outline_add_24" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_select_groups.xml
+++ b/app/src/main/res/layout/dialog_select_groups.xml
@@ -86,7 +86,6 @@
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/groupChipGroup"
                 android:paddingStart="8dp"
-                android:paddingEnd="8dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             </com.google.android.material.chip.ChipGroup>

--- a/app/src/main/res/layout/fragment_entry_list_view.xml
+++ b/app/src/main/res/layout/fragment_entry_list_view.xml
@@ -14,21 +14,6 @@
         android:visibility="gone"
         android:max="5000"/>
 
-    <com.google.android.material.chip.Chip
-        android:id="@+id/chip_group"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/groups"
-        android:layout_gravity="end"
-        android:layout_marginEnd="8dp"
-        android:visibility="gone"
-        app:chipEndPadding="6dp"
-        app:chipIcon="@drawable/ic_outline_filter_list_24"
-        app:chipIconTint="?attr/colorOnSurface"
-        app:chipIconSize="18dp"
-        app:chipStrokeWidth="1dp"
-        app:iconStartPadding="6dp" />
-
     <androidx.recyclerview.widget.RecyclerView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_default_icon">Restore default icon</string>
     <string name="discard">Discard</string>
     <string name="save">Save</string>
+    <string name="all">All</string>
     <string name="issuer">Issuer</string>
     <string name="yandex_pin">PIN (4–16 digits)</string>
     <string name="motp_pin">PIN (4 digits)</string>


### PR DESCRIPTION
This PR moves the group filters from the EntryListView to the MainActivity as shown in the screenshots below.

![image](https://github.com/user-attachments/assets/898e4e41-a25e-4845-953d-6da7704480a7)
![image](https://github.com/user-attachments/assets/22df163b-ce85-4a73-900e-e58e8d92c93f)

Tapping the "All" placeholder group will uncheck all the groups and set the filter to null.
Changing the filter will make a 'Save' button appear at the end of row to set the selected filter as default.

I'm not entirely sure if the "Save" button at the end of the row is intuitive since it will be quite hidden for our users with less screen estate or with a lot of groups, but I think it does the job for now and we can always look into this in the future.

Fixes #1406
Fixes #914

Closes #628
Closes #1219