### PR TITLE
Add ability to reorder groups

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/GroupAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/GroupAdapter.java
@@ -7,12 +7,14 @@ import android.view.ViewGroup;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.helpers.ItemTouchHelperAdapter;
+import com.beemdevelopment.aegis.util.CollectionUtils;
 import com.beemdevelopment.aegis.vault.VaultGroup;
 
 import java.util.ArrayList;
 import java.util.UUID;
 
-public class GroupAdapter extends RecyclerView.Adapter<GroupHolder> {
+public class GroupAdapter extends RecyclerView.Adapter<GroupHolder> implements ItemTouchHelperAdapter {
     private GroupAdapter.Listener _listener;
     private ArrayList<VaultGroup> _groups;
 
@@ -30,6 +32,10 @@ public class GroupAdapter extends RecyclerView.Adapter<GroupHolder> {
         } else {
             notifyItemInserted(position);
         }
+    }
+
+    public ArrayList<VaultGroup> getGroups() {
+        return _groups;
     }
 
     public void replaceGroup(UUID uuid, VaultGroup newGroup) {
@@ -63,6 +69,18 @@ public class GroupAdapter extends RecyclerView.Adapter<GroupHolder> {
             _listener.onRemoveGroup(_groups.get(position12));
         });
     }
+
+    @Override
+    public void onItemMove(int firstPosition, int secondPosition) {
+        CollectionUtils.move(_groups, firstPosition, secondPosition);
+        notifyItemMoved(firstPosition, secondPosition);
+    }
+
+    @Override
+    public void onItemDismiss(int position) { }
+
+    @Override
+    public void onItemDrop(int position) { }
 
     private VaultGroup getGroupByUUID(UUID uuid) {
         for (VaultGroup group : _groups) {

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultRepository.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultRepository.java
@@ -291,8 +291,11 @@ public class VaultRepository {
         removeGroup(group);
     }
 
-    public void renameGroup(VaultGroup renamedGroup) {
-        _vault.getGroups().replace(renamedGroup);
+    public void replaceGroups(Collection<VaultGroup> groups) {
+        _vault.getGroups().wipe();
+        for (VaultGroup group : groups) {
+            _vault.getGroups().add(group);
+        }
     }
 
     public void removeGroup(VaultGroup group) {

--- a/app/src/main/res/layout/card_group.xml
+++ b/app/src/main/res/layout/card_group.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/colorBackground"
     android:orientation="horizontal">
 
     <LinearLayout


### PR DESCRIPTION
After I built #1479 it only made more sense to me to add the ability to reorder groups through the GroupManagerActivity via drag and drop. This allows the user to change the order in which the groups will show up in the action bar.

This PR also removes the need to keep a list of renamed groups since this feature replaces all the groups with the updated collection.