### PR TITLE
Make progressbar rounded on the right side

### DIFF
--- a/app/src/main/res/drawable/progress_horizontal.xml
+++ b/app/src/main/res/drawable/progress_horizontal.xml
@@ -1,9 +1,14 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@android:id/progress">
-        <clip>
+        <scale android:scaleWidth="100%">
             <shape>
                 <solid android:color="?attr/colorPrimaryAlternative"/>
+                <corners
+                    android:topLeftRadius="0dp"
+                    android:topRightRadius="2dp"
+                    android:bottomLeftRadius="0dp"
+                    android:bottomRightRadius="2dp" />
             </shape>
-        </clip>
+        </scale>
     </item>
 </layer-list>


### PR DESCRIPTION
Very minor PR, but I think a rounded progressbar fits Material 3 better:

![image](https://github.com/user-attachments/assets/a312aba2-e639-4357-b2f0-f5a80830d9be)