### PR TITLE
Fix a crash that could occur when deleting a broken icon pack import

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
@@ -107,15 +107,7 @@ public class IconPacksManagerFragment extends Fragment implements IconPackAdapte
                 .setMessage(R.string.remove_icon_pack_description)
                 .setIconAttribute(android.R.attr.alertDialogIcon)
                 .setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {
-                    try {
-                        _iconPackManager.removeIconPack(pack);
-                    } catch (IconPackException e) {
-                        e.printStackTrace();
-                        Dialogs.showErrorDialog(requireContext(), R.string.icon_pack_delete_error, e);
-                        return;
-                    }
-                    _adapter.removeIconPack(pack);
-                    updateEmptyState();
+                    removeIconPack(pack);
                 })
                 .setNegativeButton(android.R.string.no, null)
                 .create());

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/IconPackAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/IconPackAdapter.java
@@ -35,8 +35,10 @@ public class IconPackAdapter extends RecyclerView.Adapter<IconPackHolder> {
 
     public void removeIconPack(IconPack pack) {
         int position = _iconPacks.indexOf(pack);
-        _iconPacks.remove(position);
-        notifyItemRemoved(position);
+        if (position >= 0) {
+            _iconPacks.remove(position);
+            notifyItemRemoved(position);
+        }
     }
 
     @NonNull


### PR DESCRIPTION
The following crash could occur when trying to import an icon pack for which an empty folder still exists on disk:

```
Exception java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 1
  at jdk.internal.util.Preconditions.outOfBounds (Preconditions.java:64)
  at jdk.internal.util.Preconditions.outOfBoundsCheckIndex (Preconditions.java:70)
  at jdk.internal.util.Preconditions.checkIndex (Preconditions.java:266)
  at java.util.Objects.checkIndex (Objects.java:359)
  at java.util.ArrayList.remove (ArrayList.java:511)
  at com.beemdevelopment.aegis.ui.views.IconPackAdapter.removeIconPack (IconPackAdapter.java:38)
  at com.beemdevelopment.aegis.ui.fragments.preferences.IconPacksManagerFragment.removeIconPack (IconPacksManagerFragment.java:158)
  at com.beemdevelopment.aegis.ui.fragments.preferences.IconPacksManagerFragment.lambda$importIconPack$3 (IconPacksManagerFragment.java:133)
  at androidx.appcompat.app.AlertController$ButtonHandler.handleMessage (AlertController.java:167)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8762)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:604)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
```

To reproduce on a debug build of Aegis with the latest aegis-icons imported into the app, run the following commands and then try to import the same aegis-icons ZIP again:

```
$ adb shell
$ su
# rm -r /data/data/com.beemdevelopment.aegis.debug/files/icons/c1018b93-4e8c-490a-b575-30dde62a833e/20230523/*
```