### PR TITLE
Fix progress bar colors when using dynamic

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/ThemeHelper.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/ThemeHelper.java
@@ -33,7 +33,10 @@ public class ThemeHelper {
             DynamicColorsOptions.Builder optsBuilder = new DynamicColorsOptions.Builder();
             if (getConfiguredTheme().equals(Theme.AMOLED)) {
                 optsBuilder.setThemeOverlay(R.style.ThemeOverlay_Aegis_Dynamic_Amoled);
+            } else if (getConfiguredTheme().equals(Theme.DARK)) {
+                optsBuilder.setThemeOverlay(R.style.ThemeOverlay_Aegis_Dynamic_Dark);
             }
+
             DynamicColors.applyToActivityIfAvailable(_activity, optsBuilder.build());
         }
     }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -159,9 +159,14 @@
         <item name="colorCode">@android:color/white</item>
     </style>
 
+    <style name="ThemeOverlay.Aegis.Dynamic.Dark" parent="ThemeOverlay.Material3.DynamicColors.Dark">
+        <item name="colorPrimaryAlternative">?attr/colorPrimary</item>
+    </style>
+
     <style name="ThemeOverlay.Aegis.Dynamic.Amoled" parent="ThemeOverlay.Material3.DynamicColors.Dark">
         <!-- Setting android:colorBackground to #000000 on API 28 and below causes smearing -->
         <item name="android:colorBackground">@android:color/black</item>
+        <item name="colorPrimaryAlternative">@android:color/white</item>
         <item name="colorSurface">#000000</item>
         <item name="colorSurfaceVariant">#000000</item>
         <item name="colorSurfaceContainerHighest">#000000</item>


### PR DESCRIPTION
This PR fixes the visibility of the progressbar when using 'dynamic colors' in combination with dark and amoled themes. With this PR the progressbar will have the same color as the profile codes and thus will never be too dark.

Fixes #1350 