### PR TITLE
Add ability to easily assign groups

### DIFF
--- a/app/src/main/res/layout/dialog_select_group.xml
+++ b/app/src/main/res/layout/dialog_select_group.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="10dp"
+        android:paddingTop="10dp">
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:layout_marginEnd="25dp"
+            android:text="@string/assign_groups_dialog_summary" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/group_selection_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:layout_marginEnd="25dp"
+            android:layout_marginTop="15dp"
+            android:hint="@string/assign_groups_dialog_dropdown"
+            style="?attr/dropdownStyle">
+            <AutoCompleteTextView
+                android:id="@+id/group_selection_dropdown"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/text_group_name_layout"
+            android:hint="@string/group_name_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:layout_marginEnd="25dp"
+            android:layout_marginTop="10dp"
+            android:visibility="gone">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/text_group_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textCapSentences"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/menu/menu_action_mode.xml
+++ b/app/src/main/res/menu/menu_action_mode.xml
@@ -34,6 +34,12 @@
         app:showAsAction="never"/>
 
     <item
+        android:id="@+id/action_assign_groups"
+        android:title="@string/assign_groups"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/action_share_qr"
         android:title="@string/action_transfer"
         android:orderInCategory="110"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,9 @@
     <string name="edit">Edit</string>
     <string name="select_all">Select all</string>
     <string name="assign_icons">Assign icons</string>
+    <string name="assign_groups">Assign to group</string>
+    <string name="assign_groups_dialog_summary">Select a group you wish to assign the selected entries to.</string>
+    <string name="assign_groups_dialog_dropdown">Select group</string>
     <string name="favorite" comment="Verb">Favorite</string>
     <string name="unfavorite" comment="Verb">Unfavorite</string>
     <string name="error_all_caps">ERROR</string>
@@ -251,6 +254,7 @@
     <string name="copied">Copied</string>
     <string name="errors_copied">Errors copied to the clipboard</string>
     <string name="version_copied">Version copied to the clipboard</string>
+    <string name="error_required_field">This field is required</string>
     <string name="error_occurred">An error occurred</string>
     <string name="decryption_error">An error occurred while trying to unlock the vault</string>
     <string name="decryption_corrupt_error">An error occurred while trying to unlock the vault. Your vault file might be corrupt.</string>


### PR DESCRIPTION
Since we've heavily improved our group management it would only make sense to also improve the flow in which our users assign groups to their entries. This PR adds the ability to tap 'Assign group' whenever they have entries selected.

Fixes #597

https://github.com/user-attachments/assets/6883f4b2-1e55-4da6-b855-2cc65e454683
