### PR TITLE
Change group filter to a single selection

### DIFF
--- a/app/src/androidTest/java/com/beemdevelopment/aegis/OverallTest.java
+++ b/app/src/androidTest/java/com/beemdevelopment/aegis/OverallTest.java
@@ -178,7 +178,7 @@ public class OverallTest extends AegisTest {
 
     private void changeGroupFilter(String text) {
         if (text == null) {
-            onView(allOf(withText(R.string.all), isDescendantOfA(withId(R.id.groupChipGroup)))).perform(click());
+            onView(allOf(withText(R.string.no_group), isDescendantOfA(withId(R.id.groupChipGroup)))).perform(click());
         } else {
             onView(allOf(withText(text), isDescendantOfA(withId(R.id.groupChipGroup)))).perform(click());
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/GroupPlaceholderType.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/GroupPlaceholderType.java
@@ -1,0 +1,17 @@
+package com.beemdevelopment.aegis;
+
+public enum GroupPlaceholderType {
+    ALL,
+    NO_GROUP;
+
+    public int getStringRes() {
+        switch (this) {
+            case ALL:
+                return R.string.all;
+            case NO_GROUP:
+                return R.string.no_group;
+            default:
+                throw new IllegalArgumentException("Unexpected placeholder type: " + this);
+        }
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -39,6 +39,7 @@ import androidx.appcompat.widget.SearchView;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
+import com.beemdevelopment.aegis.GroupPlaceholderType;
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
@@ -265,12 +266,12 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     private void initializeGroups() {
         _groupChip.removeAllViews();
 
-        addChipTo(_groupChip, new VaultGroupModel(getString(R.string.all)));
-
         for (VaultGroup group : _groups) {
             addChipTo(_groupChip, new VaultGroupModel(group));
         }
 
+        GroupPlaceholderType placeholderType = GroupPlaceholderType.NO_GROUP;
+        addChipTo(_groupChip, new VaultGroupModel(this, placeholderType));
         addSaveChip(_groupChip);
     }
 
@@ -290,51 +291,40 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         chip.setChecked(_groupFilter != null && _groupFilter.contains(group.getUUID()));
 
         if (group.isPlaceholder()) {
-            chip.setId(0);
-            chip.setTag(null);
-            chip.setChecked(_groupFilter == null);
-            chip.setOnClickListener(v -> {
-                setSaveChipVisibility(true);
+            GroupPlaceholderType groupPlaceholderType = group.getPlaceholderType();
+            chip.setTag(groupPlaceholderType);
 
-                Chip checkedChip = (Chip) chipGroup.getChildAt(0);
-                boolean checkedState = checkedChip.isChecked();
-                chipGroup.clearCheck();
-
-                Set<UUID> groupFilter = getGroupFilter(chipGroup);
-                if (!checkedState) {
-                    groupFilter = new HashSet<>();
-                    groupFilter.add(null);
-
-                    checkedChip.setChecked(false);
-                } else {
-                    checkedChip.setChecked(true);
-                }
-
-                _groupFilter = groupFilter;
-                _entryListView.setGroupFilter(groupFilter, true);
-            });
-
-            chipGroup.addView(chip);
-            return;
+            if (groupPlaceholderType == GroupPlaceholderType.ALL) {
+                chip.setChecked(_groupFilter == null);
+            } else if (groupPlaceholderType == GroupPlaceholderType.NO_GROUP) {
+                chip.setChecked(_groupFilter != null && _groupFilter.contains(null));
+            }
+        } else {
+            chip.setTag(group);
         }
 
-
-        chip.setOnCheckedChangeListener((group1, checkedId) -> {
+        chip.setOnCheckedChangeListener((group1, isChecked) -> {
+            Set<UUID> groupFilter = new HashSet<>();
             setSaveChipVisibility(true);
-            Set<UUID> groupFilter = getGroupFilter(chipGroup);
 
-            if (groupFilter.isEmpty()) {
+            if (!isChecked) {
+                group1.setChecked(false);
+                _groupFilter = groupFilter;
+                _entryListView.setGroupFilter(groupFilter, false);
+                return;
+            }
+
+            Object chipTag = group1.getTag();
+            if (chipTag == GroupPlaceholderType.NO_GROUP) {
                 groupFilter.add(null);
             } else {
-                Chip allGroupsChip = (Chip) chipGroup.getChildAt(0);
-                allGroupsChip.setChecked(false);
+                groupFilter = getGroupFilter(chipGroup);
             }
 
             _groupFilter = groupFilter;
-            _entryListView.setGroupFilter(groupFilter, true);
+            _entryListView.setGroupFilter(groupFilter, false);
         });
 
-        chip.setTag(group);
         chipGroup.addView(chip);
     }
 
@@ -367,7 +357,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         return chipGroup.getCheckedChipIds().stream()
                 .map(i -> {
                     Chip chip = chipGroup.findViewById(i);
-                    if (chip.getTag() != null) {
+                    if (chip.getTag() instanceof VaultGroupModel) {
                         VaultGroupModel group = (VaultGroupModel) chip.getTag();
                         return group.getUUID();
                     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/ImportExportPreferencesFragment.java
@@ -22,6 +22,7 @@ import androidx.core.content.FileProvider;
 import androidx.preference.Preference;
 
 import com.beemdevelopment.aegis.BuildConfig;
+import com.beemdevelopment.aegis.GroupPlaceholderType;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.helpers.DropdownHelper;
 import com.beemdevelopment.aegis.importers.DatabaseImporter;
@@ -190,7 +191,7 @@ public class ImportExportPreferencesFragment extends PreferencesFragment {
             checkBoxExportAllGroups.setVisibility(View.VISIBLE);
 
             ArrayList<VaultGroupModel> groupsArray = new ArrayList<>();
-            groupsArray.add(new VaultGroupModel(getString(R.string.no_group)));
+            groupsArray.add(new VaultGroupModel(requireContext(), GroupPlaceholderType.NO_GROUP));
             groupsArray.addAll(groups.stream().map(VaultGroupModel::new).collect(Collectors.toList()));
 
             groupsSelection.setCheckedItemsCountTextRes(R.plurals.export_groups_selected_count);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/models/VaultGroupModel.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/models/VaultGroupModel.java
@@ -1,23 +1,31 @@
 package com.beemdevelopment.aegis.ui.models;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.beemdevelopment.aegis.GroupPlaceholderType;
 import com.beemdevelopment.aegis.vault.VaultGroup;
+
 import java.io.Serializable;
 import java.util.UUID;
 
 public class VaultGroupModel implements Serializable {
     private final VaultGroup _group;
-    private final String _placeholderName;
+    private final GroupPlaceholderType _placeholderType;
+    private final String _placeholderText;
 
     public VaultGroupModel(VaultGroup group) {
         _group = group;
-        _placeholderName = null;
+        _placeholderText = null;
+        _placeholderType = null;
     }
 
-    public VaultGroupModel(String placeholderName) {
+    public VaultGroupModel(Context context, GroupPlaceholderType placeholderType) {
         _group = null;
-        _placeholderName = placeholderName;
+        _placeholderType = placeholderType;
+        _placeholderText = context.getString(placeholderType.getStringRes());
     }
 
     public VaultGroup getGroup() {
@@ -25,11 +33,15 @@ public class VaultGroupModel implements Serializable {
     }
 
     public String getName() {
-        return _group != null ? _group.getName() : _placeholderName;
+        return _group != null ? _group.getName() : _placeholderText;
+    }
+
+    public GroupPlaceholderType getPlaceholderType() {
+        return _placeholderType;
     }
 
     public boolean isPlaceholder() {
-        return _group == null;
+        return _placeholderType != null;
     }
 
     @Nullable

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,7 +38,9 @@
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/groupChipGroup"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"></com.google.android.material.chip.ChipGroup>
+                    android:layout_height="wrap_content"
+                    app:selectionRequired="true"
+                    app:singleSelection="true"/>
             </LinearLayout>
         </HorizontalScrollView>
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
As discussed and mentioned [here](https://github.com/beemdevelopment/Aegis/pull/1479#issuecomment-2354206113) and [here](https://github.com/beemdevelopment/Aegis/issues/914#issuecomment-2354110271) after #1479 was merged we decided to change the group filter to just a single selection as we think more users would prefer that. We might add support for multi-selection in the future but this will do for now.

As a bonus I also removed the animation when switching groups as it was quite obnoxious.

https://github.com/user-attachments/assets/234ddfb4-0e49-47a6-9340-2508ed7f0d38

