### PR TITLE
Fix capitalization of multiple text fields

### DIFF
--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -98,7 +98,7 @@
                                 android:id="@+id/text_name"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:inputType="text"/>
+                                android:inputType="textCapSentences"/>
                         </com.google.android.material.textfield.TextInputLayout>
                     </LinearLayout>
                     <LinearLayout
@@ -117,7 +117,7 @@
                                 android:maxLines="1"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:inputType="text"/>
+                                android:inputType="textCapSentences"/>
                         </com.google.android.material.textfield.TextInputLayout>
                     </LinearLayout>
 
@@ -171,7 +171,7 @@
                                 android:id="@+id/text_note"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:inputType="text|textMultiLine"/>
+                                android:inputType="text|textMultiLine|textCapSentences"/>
                         </com.google.android.material.textfield.TextInputLayout>
                     </LinearLayout>
                     <LinearLayout

--- a/app/src/main/res/layout/dialog_text_input.xml
+++ b/app/src/main/res/layout/dialog_text_input.xml
@@ -14,6 +14,6 @@
             android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"/>
+            android:inputType="textCapSentences"/>
     </com.google.android.material.textfield.TextInputLayout>
 </LinearLayout>


### PR DESCRIPTION
One thing that always slightly bothered me in Aegis was the lack of capitalization in our different text fields. Name, Issuer, Note, New Group were always lowercase. This PR capitalizes the first word of every sentence in our generic text fields inside of a dialog or in the aforementioned text fields. The user can always override this by manually pressing the shift key on their keyboard.