### PR TITLE
Fix visibility of locale setting on Marshmallow

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AppearancePreferencesFragment.java
@@ -77,7 +77,7 @@ public class AppearancePreferencesFragment extends PreferencesFragment {
         });
 
         Preference langPreference = requirePreference("pref_lang");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
             String[] langs = getResources().getStringArray(R.array.pref_lang_values);
             String[] langNames = getResources().getStringArray(R.array.pref_lang_entries);
             List<String> langList = Arrays.asList(langs);


### PR DESCRIPTION
Closes #1015 as this setting never worked on Marshmallow or below and never should've been visible on these versions in the first place. This was a bug that has been introduced in #288 🙃 