### PR TITLE
Use DiffUtil for the RecyclerView of the entry list

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/SimpleItemTouchHelperCallback.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/SimpleItemTouchHelperCallback.java
@@ -69,7 +69,7 @@ public class SimpleItemTouchHelperCallback extends ItemTouchHelper.Callback {
         int swipeFlags = 0;
         if (adapter.isPositionFooter(position)
                 || adapter.isPositionErrorCard(position)
-                || adapter.getEntryAtPos(position) != _selectedEntry
+                || adapter.getEntryAtPosition(position) != _selectedEntry
                 || !isLongPressDragEnabled()) {
             return makeMovementFlags(0, swipeFlags);
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/models/ErrorCardInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/models/ErrorCardInfo.java
@@ -2,6 +2,10 @@ package com.beemdevelopment.aegis.ui.models;
 
 import android.view.View;
 
+import com.google.common.hash.HashCode;
+
+import java.util.Objects;
+
 public class ErrorCardInfo {
     private final String _message;
     private final View.OnClickListener _listener;
@@ -17,5 +21,24 @@ public class ErrorCardInfo {
 
     public View.OnClickListener getListener() {
         return _listener;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCode.fromString(_message).asInt();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof ErrorCardInfo)) {
+            return false;
+        }
+
+        // This equality check purposefully ignores the onclick listener
+        ErrorCardInfo info = (ErrorCardInfo) o;
+        return Objects.equals(getMessage(), info.getMessage());
     }
 }

--- a/app/src/main/java/com/beemdevelopment/aegis/vault/VaultRepository.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/vault/VaultRepository.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.AtomicFile;
 
 import com.beemdevelopment.aegis.otp.GoogleAuthInfo;
+import com.beemdevelopment.aegis.util.Cloner;
 import com.beemdevelopment.aegis.util.IOUtils;
 import com.google.zxing.WriterException;
 
@@ -249,6 +250,13 @@ public class VaultRepository {
         return _vault.getEntries().replace(entry);
     }
 
+    public VaultEntry editEntry(VaultEntry entry, EntryEditor editor) {
+        VaultEntry newEntry = Cloner.clone(entry);
+        editor.edit(newEntry);
+        replaceEntry(newEntry);
+        return newEntry;
+    }
+
     /**
      * Moves entry1 to the position of entry2.
      */
@@ -343,5 +351,9 @@ public class VaultRepository {
         }
 
         return getCredentials().getSlots().findBackupPasswordSlots().size() > 0;
+    }
+
+    public interface EntryEditor {
+        void edit(VaultEntry entry);
     }
 }


### PR DESCRIPTION
Gets rid of all of the custom logic we had for notifying the RecyclerView about changes in the entry list. This will allow for more simplifications in the future around non-persisted changes to state in the entry list.

A neat side effect is that any filtering/ordering changes in the entry list are now also animated: https://alexbakker.me/u/4a4ie5yzpj.mp4

This touches the fundamentals of the entry list, so lots of careful testing required.

Closes #1053.