### PR TITLE
Minor improvements to the entry sharing activity

### DIFF
--- a/app/src/main/res/layout/activity_share_entry.xml
+++ b/app/src/main/res/layout/activity_share_entry.xml
@@ -22,46 +22,40 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layoutShareEntry"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <ImageView
-            android:id="@+id/ivQrCode"
-            android:layout_width="250dp"
-            android:layout_height="250dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tvTransfer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/transfer_entry"
-            android:textSize="22sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="5dp"
-            app:layout_constraintBottom_toTopOf="@+id/tvDescription"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+        android:layout_height="match_parent"
+        android:paddingHorizontal="30dp"
+        android:layout_marginTop="?attr/actionBarSize">
 
         <TextView
             android:id="@+id/tvDescription"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:padding="10dp"
             android:text="@string/transfer_entry_description"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@+id/ivQrCode"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/ivQrCode"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Aegis.ImageView.Rounded"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintVertical_bias="0.3"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
         <TextView
             android:id="@+id/tvIssuer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="20dp"
             tools:text="Issuer"
             android:textSize="18sp"
             android:textStyle="bold"
@@ -95,7 +89,6 @@
             android:id="@+id/btnNext"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="4dp"
             android:layout_marginBottom="4dp"
             style="@style/Widget.Material3.Button.TextButton"
             android:text="@string/next"
@@ -123,7 +116,6 @@
             android:layout_marginBottom="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@+id/btnNext"
-            app:layout_constraintHorizontal_bias="0.506"
             app:layout_constraintStart_toStartOf="@+id/btnPrevious" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -465,7 +465,6 @@
     <string name="copy_uri">نسخ URI</string>
     <string name="unable_to_copy_uri_to_clipboard">تعذر نسخ URI إلى الحافظة</string>
     <string name="uri_copied_to_clipboard">نُسخ URI إلى الحافظة</string>
-    <string name="transfer_entry">نقل المدخل</string>
     <string name="transfer_entry_description">امسح كود QR هذا بتطبيق المصادقة الذي ترغب بنقل ذلك المدخل إليه</string>
     <string name="google_auth_compatible_transfer_description">امسح رموز ال QR هذه بواسطة Aegis أو Google Authenticator.\n\nبسبب القيود في تطبيق Google Authenticator، فقط رموز TOTP &amp; HOTP التي تستعمل SHA1 وتنتِج كود من 6 خانات هي من سيتم إدراجها</string>
     <string name="password_strength_very_weak">ضعيف جدًا</string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -357,7 +357,6 @@
     <string name="previous">Anterior</string>
     <string name="unable_to_copy_uri_to_clipboard">Nun ye posible copiar la URI al cartafueyu</string>
     <string name="uri_copied_to_clipboard">La URI copióse al cartafueyu</string>
-    <string name="transfer_entry">Tresferencia d\'una entrada</string>
     <string name="transfer_entry_description">Escania esti códígu QR cola aplicación autenticadora a la que quies tresferir esta entrada</string>
     <string name="google_auth_compatible_transfer_description">Escania estos códigos QR con Aegis o con Google Authenticator.\n\nPola mor de les llendes de l\'aplicación Google Authenticator, namás s\'inclúin pases TOTP ya HOTP qu\'usen el hash SHA1 ya produzan códigos de 6 díxitos</string>
     <string name="password_strength_very_weak">Perpoco segura</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">Копиране на адреса</string>
     <string name="unable_to_copy_uri_to_clipboard">Грешка при копиране на адреса</string>
     <string name="uri_copied_to_clipboard">Адресът е копиран</string>
-    <string name="transfer_entry">Прехвърляне на запис</string>
     <string name="transfer_entry_description">Сканирайте QR кода с приложението за удостоверяване, в което искате да прехвърлите този запис</string>
     <string name="google_auth_compatible_transfer_description">Сканирайте тези кодове в Aegis или Google Authenticator.\n\nПоради ограничения в приложението на Google Authenticator са включени само кодовете, които използват SHA1 и извеждат 6 цифри</string>
     <string name="password_strength_very_weak">Много слаба</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -432,7 +432,6 @@
     <string name="copy_uri">Copiar URI</string>
     <string name="unable_to_copy_uri_to_clipboard">No s\'ha pogut copiar la URI</string>
     <string name="uri_copied_to_clipboard">URI copiada al porta-retalls</string>
-    <string name="transfer_entry">Transferir entrada</string>
     <string name="transfer_entry_description">Escaneja aquest codi QR amb l\'aplicació d\'autenticació a la que vols transferir aquesta entrada</string>
     <string name="google_auth_compatible_transfer_description">Escanegeu aquests codis QR amb Aegis o Google Authenticator.\n\n A causa de les limitacions de l\'aplicació Google Authenticator, només s\'inclouen tokens TOTP &amp; HOTP que utilitzen SHA1 i produeixen codis de 6 dígits</string>
     <string name="password_strength_very_weak">Molt feble</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -454,7 +454,6 @@
     <string name="copy_uri">Kopírovat URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Nepodařilo se zkopírovat URI do schránky</string>
     <string name="uri_copied_to_clipboard">URI zkopírována do schránky</string>
-    <string name="transfer_entry">Přenést položku</string>
     <string name="transfer_entry_description">Naskenujte tento QR kód ověřovací aplikací, do které chcete položku přenést</string>
     <string name="google_auth_compatible_transfer_description">Naskenujte tyto QR kódy s aplikací Aegis nebo Google Authenticator.\n\nKvůli limitacím aplikace Google Authenticator jsou zahrnuty pouze 6-místné tokeny TOTP a HOTP využívající SHA1</string>
     <string name="password_strength_very_weak">Velmi slabé</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">Kopiér URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Kunne ikke kopiere URI til udklipsholder</string>
     <string name="uri_copied_to_clipboard">URI kopieret til udklipsholder</string>
-    <string name="transfer_entry">Overfør post</string>
     <string name="transfer_entry_description">Scan denne QR-kode med den autentificerings-app, du gerne vil overføre denne post til</string>
     <string name="google_auth_compatible_transfer_description">Skan disse QR-koder med Aegis eller Google Authenticator.\n\nGrundet begrænsninger i Google Authenticator-appen inkluderes kun TOTP- og HOTP-tokener, som bruger SHA1 og genererer 6-cifrede koder</string>
     <string name="password_strength_very_weak">Meget svag</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">URI kopieren</string>
     <string name="unable_to_copy_uri_to_clipboard">URI konnte nicht in die Zwischenablage kopiert werden</string>
     <string name="uri_copied_to_clipboard">URI in die Zwischenablage kopiert</string>
-    <string name="transfer_entry">Eintrag übertragen</string>
     <string name="transfer_entry_description">Scanne diesen QR-Code mit der Authentifizierungs-App, zu der du diesen Eintrag übertragen möchtest</string>
     <string name="google_auth_compatible_transfer_description">Scanne diese QR-Codes mit Aegis oder Google Authenticator.\n\nAufgrund der Einschränkungen der Google Authenticator-App sind nur TOTP- und HOTP-Token enthalten, die SHA1 verwenden und 6-stellige Codes erzeugen</string>
     <string name="password_strength_very_weak">Sehr schwach</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -433,7 +433,6 @@
     <string name="copy_uri">Αντιγραφή URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Αδυναμία αντιγραφής του URI στο πρόχειρο</string>
     <string name="uri_copied_to_clipboard">Το URI αντιγράφηκε στο πρόχειρο</string>
-    <string name="transfer_entry">Μεταφορά καταχώρησης</string>
     <string name="transfer_entry_description">Σαρώστε αυτόν τον κωδικό QR με την εφαρμογή ελέγχου ταυτότητας στην οποία θέλετε να μεταφέρετε αυτήν την καταχώριση</string>
     <string name="google_auth_compatible_transfer_description">Σαρώστε αυτούς τους κωδικούς QR με το Aegis ή το Google Authenticator.\n\nΛόγω περιορισμών της εφαρμογής Google Authenticator, περιλαμβάνονται μόνο αναγνωριστικά TOTP &amp; HOTP που χρησιμοποιούν SHA1 και παράγουν 6ψήφιους κωδικούς</string>
     <string name="password_strength_very_weak">Πολύ αδύναμος</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">Copiar URI</string>
     <string name="unable_to_copy_uri_to_clipboard">No se puede copiar el URI al portapapeles</string>
     <string name="uri_copied_to_clipboard">Se ha copiado el URI al portapapeles</string>
-    <string name="transfer_entry">Transferir clave</string>
     <string name="transfer_entry_description">Escanea este código QR con la aplicación de autenticación a la que vayas a importar esta clave</string>
     <string name="google_auth_compatible_transfer_description">Escanea estos códigos QR con Aegis o Google Authenticator.\n\nDebido a limitaciones técnicas de Google Authenticator solo se incluirán claves de tipo TOTP y HOTP que usen SHA1 y produzcan códigos de 6 dígitos</string>
     <string name="password_strength_very_weak">Muy débil</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -426,7 +426,6 @@
     <string name="copy_uri">Kopiatu URIa</string>
     <string name="unable_to_copy_uri_to_clipboard">Ezin da URIa arbelean kopiatu</string>
     <string name="uri_copied_to_clipboard">URIa arbelean kopiatu da</string>
-    <string name="transfer_entry">Transferitu sarrera</string>
     <string name="transfer_entry_description">Eskaneatu QR kode hau sarrera transferitu nahi diozun aitentifikazio-aplikazioarekin</string>
     <string name="google_auth_compatible_transfer_description">Eskaneatu QR kode hauek Aegis edo Google Authenticator erabiliz.\n\nGoogle Authenticator aplikazioaren mugak direla eta, SHA1 darabilten eta 6 zenbakiko kodeak erabiltzen dituzten TOTP &amp; HOTP tokenak bakarrik sartzen dira</string>
     <string name="password_strength_very_weak">Oso ahula</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -259,7 +259,6 @@
     <string name="done">انجام شد</string>
     <string name="next">بعدی</string>
     <string name="previous">قبلی</string>
-    <string name="transfer_entry">انتقال آیتم‌ها</string>
     <string name="transfer_entry_description">این بارکد دوبعدی را توسط برنامه ای که علاقه دارید توکن منتقل شود اسکن کنید.</string>
     <string name="password_strength_very_weak">خیلی ضعیف</string>
     <string name="password_strength_weak">ضعیف</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -427,7 +427,6 @@
     <string name="copy_uri">Kopioi URI</string>
     <string name="unable_to_copy_uri_to_clipboard">URI:a ei voitu kopioida leikepöydälle</string>
     <string name="uri_copied_to_clipboard">URI kopioitiin leikepöydälle</string>
-    <string name="transfer_entry">Siirrä kohde</string>
     <string name="transfer_entry_description">Skannaa tämä QR-koodi todennussovelluksella, johon haluat siirtää tämän kohteen</string>
     <string name="google_auth_compatible_transfer_description">Skannaa nämä QR-koodit Aegisilla tai Google Authenticatorilla.\n\nGoogle Authenticator -sovelluksen rajoitusten vuoksi, vain SHA1-suojausta ja 6-numeroisia koodeja tuottavat TOTP- ja HOTP-todennuskoodit sisällytetään</string>
     <string name="password_strength_very_weak">Erittäin heikko</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">Copier l\'URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Impossible de copier l\'URI dans le presse-papier</string>
     <string name="uri_copied_to_clipboard">URI copiée dans le presse-papier</string>
-    <string name="transfer_entry">Transférer une entrée</string>
     <string name="transfer_entry_description">Scannez ce code QR avec l\'application d\'authentification vers laquelle vous souhaitez transférer cette entrée</string>
     <string name="google_auth_compatible_transfer_description">Scannez ces codes QR avec Aegis ou Google Authenticator.\n\nEn raison des limitations de l\'application Google Authenticator, seuls les jetons TOTP &amp; HOTP qui utilisent SHA1 et produisent des codes à 6 chiffres sont inclus</string>
     <string name="password_strength_very_weak">Très faible</string>

--- a/app/src/main/res/values-fy-rNL/strings.xml
+++ b/app/src/main/res/values-fy-rNL/strings.xml
@@ -427,7 +427,6 @@
     <string name="copy_uri">URI kopiearje</string>
     <string name="unable_to_copy_uri_to_clipboard">Kin URI net nei klamboerd kopiearje</string>
     <string name="uri_copied_to_clipboard">URI nei klamboerd kopiearre</string>
-    <string name="transfer_entry">Item oerbringe</string>
     <string name="transfer_entry_description">Scan dizze QR-koade mei de autentikator-app wêr’tsto dit item nei oerbringe wolst</string>
     <string name="google_auth_compatible_transfer_description">Scan dizze QR-koaden mei Aegis of Google Authenticator.\n\nFanwegen beheiningen fan de Google Authenticator-app, binne allinnich TOTP- &amp; HOTP-tokens dy’t SHA1 brûke en 6-siferige koaden produsearje opnommen</string>
     <string name="password_strength_very_weak">Hiel swak</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -425,7 +425,6 @@
     <string name="copy_uri">Copiar URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Non se puido copiar a URI no portapapeis</string>
     <string name="uri_copied_to_clipboard">URI copiada no portapapeis</string>
-    <string name="transfer_entry">Transferir entrada</string>
     <string name="transfer_entry_description">Escanea este código QR coa aplicación de autenticación á que queiras transferirlle esta entrada</string>
     <string name="google_auth_compatible_transfer_description">Escanea estes códigos QR con Aegis ou con Google Authenticator.\n\nDebido ás limitacións de Google Authenticator, só se inclúen os tokens TOTP e HOTP que usen SHA1 e produzan códigos de 6 cifras</string>
     <string name="password_strength_very_weak">Moi feble</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -374,7 +374,6 @@
     <string name="copy_uri">URI को कॉपी करें</string>
     <string name="unable_to_copy_uri_to_clipboard">क्लिपबोर्ड पर कॉपी करने में असमर्थ</string>
     <string name="uri_copied_to_clipboard">क्लिपबोर्ड में कॉपी हो गया</string>
-    <string name="transfer_entry">प्रविष्टि स्थानांतरित करें</string>
     <string name="transfer_entry_description">इस क्यूआर कोड को उस ऑथेंटिकेटर ऐप के साथ स्कैन करें जिसमें आप इस प्रविष्टि को स्थानांतरित करना चाहते हैं</string>
     <string name="google_auth_compatible_transfer_description">इन क्यूआर कोड को एजिस या गूगल ऑथेंटिकेटर से स्कैन करें।\n\n गूगल ऑथेंटिकेटर ऐप की सीमाओं के कारण, केवल TOTP &amp; HOTP टोकन जो SHA1 का उपयोग करते हैं और 6-अंकीय कोड उत्पन्न करते हैं, शामिल हैं</string>
     <string name="password_strength_very_weak">बहुत कमज़ोर</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -427,7 +427,6 @@
     <string name="copy_uri">URI másolása</string>
     <string name="unable_to_copy_uri_to_clipboard">Nem lehet az URI-t a vágólapra másolni</string>
     <string name="uri_copied_to_clipboard">Az URI a vágólapra másolva</string>
-    <string name="transfer_entry">Bejegyzés átvitele</string>
     <string name="transfer_entry_description">Olvassa le ezt a QR-kódot azzal hitelesítő alkalmazással, amelybe át akarja vinni</string>
     <string name="google_auth_compatible_transfer_description">Olvassa le ezeket a QR-kódokat az Aegisszel vagy a Google Hitelesítővel.\n\nA Google Hitelesítő korlátozásai miatt csak az SHA1-et használó és 6 számjegyű kódot előállító TOTP és HOTP tokenek szerepelnek itt.</string>
     <string name="password_strength_very_weak">Nagyon gyenge</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -416,7 +416,6 @@
     <string name="copy_uri">Salin URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Tidak dapat menyalin URI ke clipboard</string>
     <string name="uri_copied_to_clipboard">URI disalin ke papan klip</string>
-    <string name="transfer_entry">Pindahkan entri</string>
     <string name="transfer_entry_description">Pindai kode QR ini dengan aplikasi autentikasi yang ingin Anda pindahkan ke sana entri ini</string>
     <string name="google_auth_compatible_transfer_description">Pindai kode QR ini dengan Aegis atau Google Authenticator.\n\nKarena keterbatasan aplikasi Google Authenticator, hanya token TOTP &amp; HOTP yang menggunakan SHA1 dan menghasilkan kode 6 digit yang disertakan</string>
     <string name="password_strength_very_weak">Sangat lemah</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -400,7 +400,6 @@
     <string name="copy_uri">Copia URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Impossibile copiare l\'URI negli appunti</string>
     <string name="uri_copied_to_clipboard">URI copiato negli appunti</string>
-    <string name="transfer_entry">Trasferisci voce</string>
     <string name="transfer_entry_description">Scansiona questo codice QR con l\'app di autenticazione a cui vuoi trasferire questa voce</string>
     <string name="google_auth_compatible_transfer_description">Scansiona questi codici QR con Aegis o Google Authenticator.\n\nA causa delle limitazioni dell\'app Google Authenticator, sono inclusi solo i token TOTP e HOTP che utilizzano SHA1 e producono codici a 6 cifre</string>
     <string name="password_strength_very_weak">Molto debole</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -364,7 +364,6 @@
     <string name="copy_uri">העתק שורת כתובת</string>
     <string name="unable_to_copy_uri_to_clipboard">לא ניתן להעתיק URI ללוח</string>
     <string name="uri_copied_to_clipboard">URI שהועתק ללוח</string>
-    <string name="transfer_entry">העברת ערך</string>
     <string name="transfer_entry_description">סרוק קוד QR זה באמצעות אפליקציית המאמת שאליה ברצונך להעביר ערך זה</string>
     <string name="google_auth_compatible_transfer_description">סרוק קודי QR אלה באמצעות Aegis אוGoogle Authenticator.\n\n בשל מגבלות אפליקציית מאמת Google, רק אסימוני TOTP &amp; HOTP המשתמשים ב- SHA1 ומייצרים קודים בני 6 ספרות כלולים</string>
     <string name="password_strength_very_weak">חלש מאוד</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -386,7 +386,6 @@
     <string name="copy_uri">URIをコピー</string>
     <string name="unable_to_copy_uri_to_clipboard">URIをクリップボードにコピーできません</string>
     <string name="uri_copied_to_clipboard">URI をクリップボードにコピーしました</string>
-    <string name="transfer_entry">エントリーを転送</string>
     <string name="transfer_entry_description">このエントリーを別の認証アプリに転送するには、このQRコードをスキャンしてください</string>
     <string name="google_auth_compatible_transfer_description">QRコードを Aegis または Google Authenticator でスキャンしてください。\n\nGoogle Authenticator アプリの制限のため、SHA1 を使用し6桁のコードを生成する TOTP と HOTP トークンのみが含まれます。</string>
     <string name="password_strength_very_weak">非常に弱い</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -260,7 +260,6 @@
     <string name="copy_uri">Kopijuoti URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Nepavyko nukopijuoti URI į iškarpinę</string>
     <string name="uri_copied_to_clipboard">URI nukopijuotas į iškarpinę</string>
-    <string name="transfer_entry">Perkelti įrašą</string>
     <string name="transfer_entry_description">Nuskenuokite šį QR kodą naudodami tapatybės nustatymo programėlę, į kurią norite perkelti šį įrašą</string>
     <string name="password_strength_very_weak">Labai silpnas</string>
     <string name="password_strength_weak">Silpnas</string>

--- a/app/src/main/res/values-lv-rLV/strings.xml
+++ b/app/src/main/res/values-lv-rLV/strings.xml
@@ -444,7 +444,6 @@
     <string name="copy_uri">Ievietot URI starpliktuvē</string>
     <string name="unable_to_copy_uri_to_clipboard">Nebija iespējams ievietot URI starpliktuvē</string>
     <string name="uri_copied_to_clipboard">URI tika ievietots starpliktuvē</string>
-    <string name="transfer_entry">Pārvietot ierakstu</string>
     <string name="transfer_entry_description">Nolasīt šo kvadrātkodu ar autentificētāja lietotni, uz kuru ir vēlme pārvietot šo ierakstu</string>
     <string name="google_auth_compatible_transfer_description">Nolasīt šos kvadrātkodus ar Aegis vai Google Authenticator.\n\nIerobežojumu dēļ Google Authenticator lietotnē, ir iekļautas tikai TOTP un HOTP pilnvaras, kam ir izmantots SHA1 un kas veido sešciparu kodus</string>
     <string name="password_strength_very_weak">Ļoti vāja</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">URI kopiëren</string>
     <string name="unable_to_copy_uri_to_clipboard">Kan URI niet naar klembord kopiëren</string>
     <string name="uri_copied_to_clipboard">URI naar klembord gekopieerd</string>
-    <string name="transfer_entry">Item overzetten</string>
     <string name="transfer_entry_description">Scan deze QR-code met de authenticator-app waar je dit item naar wilt overzetten</string>
     <string name="google_auth_compatible_transfer_description">Scan deze QR-codes met Aegis of Google Authenticator.\n\nVanwege beperkingen van de Google Authenticator app, zijn alleen TOTP- &amp; HOTP-tokens die SHA1 gebruiken en 6-cijferige codes produceren opgenomen</string>
     <string name="password_strength_very_weak">Zeer zwak</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -443,7 +443,6 @@
     <string name="copy_uri">Kopiuj URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Nie można skopiować URI do schowka</string>
     <string name="uri_copied_to_clipboard">Skopiowano URI do schowka</string>
-    <string name="transfer_entry">Przenieś wpis</string>
     <string name="transfer_entry_description">Zeskanuj kod QR za pomocą aplikacji uwierzytelniającej, do której chcesz przenieść ten wpis</string>
     <string name="google_auth_compatible_transfer_description">Zeskanuj te kody QR za pomocą Aegis lub Google Authenticator.\n\nZ powodu ograniczeń w aplikacji Google Authenticator, tylko tokeny TOTP &amp; HOTP, które używają SHA1 i generują 6 cyfrowe kody są uwzględniane</string>
     <string name="password_strength_very_weak">Bardzo słabe</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -434,7 +434,6 @@
     <string name="copy_uri">Copiar URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Não foi possível copiar URI para área de transferência</string>
     <string name="uri_copied_to_clipboard">URI copiada para a área de transferência</string>
-    <string name="transfer_entry">Transferir entrada</string>
     <string name="transfer_entry_description">Escaneie esse QR code com o app autenticador para o qual você gostaria de transferir essa entrada</string>
     <string name="google_auth_compatible_transfer_description">Escaneie esses QR codes com Aegis ou Google Authenticator.\n\nDevido a limitações do aplicativo Google Authenticator, apenas TOTP &amp; tokens HOTP que usam SHA1 e produzem códigos de 6 dígitos estão incluídos</string>
     <string name="password_strength_very_weak">Muito fraca</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -420,7 +420,6 @@
     <string name="copy_uri">Copiar URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Não é possível copiar o URI para a área de transferência</string>
     <string name="uri_copied_to_clipboard">URI copiado para a área de transferência</string>
-    <string name="transfer_entry">Transferir entrada</string>
     <string name="transfer_entry_description">Digitalize este código QR com a aplicação de autenticação para a qual gostaria de transferir esta entrada</string>
     <string name="google_auth_compatible_transfer_description">Digitalize estes códigos QR com o Aegis ou o Google Authenticator.\n\nDevido às limitações do Google Authenticator, apenas estão incluídos os tokens TOTP e HOTP que utilizam SHA1 e produzem códigos de 6 dígitos</string>
     <string name="password_strength_very_weak">Muito Fraca</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -437,7 +437,6 @@
     <string name="copy_uri">Copiere URL</string>
     <string name="unable_to_copy_uri_to_clipboard">Nu se poate copia în clipboard</string>
     <string name="uri_copied_to_clipboard">URI copiat în clipboard</string>
-    <string name="transfer_entry">Transfer intrare</string>
     <string name="transfer_entry_description">Scanează acest cod QR cu aplicația de autentificare pe care dorești să o transferi</string>
     <string name="google_auth_compatible_transfer_description">Scanați aceste coduri QR cu Aegis sau Google Authenticator.\n\nDatorită limitărilor aplicației Google Authenticator, numai token-urile TOTP &amp; HOTP care folosesc SHA1 și produc coduri de 6 cifre sunt incluse</string>
     <string name="password_strength_very_weak">Foarte slabă</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -454,7 +454,6 @@
     <string name="copy_uri">Копировать URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Невозможно скопировать URI в буфер обмена</string>
     <string name="uri_copied_to_clipboard">URI скопирован в буфер обмена</string>
-    <string name="transfer_entry">Передача записи</string>
     <string name="transfer_entry_description">Отсканируйте QR-код с помощью приложения для аутентификации, в которое вы хотите передать эту запись.</string>
     <string name="google_auth_compatible_transfer_description">Сканируйте эти QR-коды в Aegis или Google Authenticator. Из-за ограничений приложения Google Authenticator, включены только ключи TOTP и HOTP, использующие SHA1 и создающие 6-значные коды.</string>
     <string name="password_strength_very_weak">Очень слабый</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -364,7 +364,6 @@
     <string name="previous">Predchádzajúce</string>
     <string name="copy_uri">Skopírovať URI</string>
     <string name="uri_copied_to_clipboard">URI bola skopírovaná do schránky</string>
-    <string name="transfer_entry">Prenos záznamu</string>
     <string name="transfer_entry_description">Naskenujte tento QR kód pomocou overovacej aplikácie, do ktorej chcete tento záznam preniesť</string>
     <string name="google_auth_compatible_transfer_description">Naskenujte tieto QR kódy s aplikáciou Aegis alebo Google Authenticator.\n\nKvôli limitáciám aplikácie Google Authenticator sú zahrnuté iba TOTP &amp; HOTP tokény, ktoré používajú SHA1 a obsahujú 6 číselné kódy</string>
     <string name="password_strength_very_weak">Veľmi slabé</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -429,7 +429,6 @@
     <string name="copy_uri">Kopiera URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Kunde inte kopiera URI till urklipp</string>
     <string name="uri_copied_to_clipboard">URI kopierad till urklipp</string>
-    <string name="transfer_entry">Överför post</string>
     <string name="transfer_entry_description">Skanna denna rutkod med den autentiseringsapp som du vill överföra denna post till</string>
     <string name="google_auth_compatible_transfer_description">Skanna dessa rutkoder med Aegis eller Google Authenticator.\n\nPå grund av begränsningar i Google Authenticator-appen inkluderas endast TOTP- &amp; HOTP-polletter som använder SHA1 och producerar 6-siffriga koder.</string>
     <string name="password_strength_very_weak">Mycket svagt</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -400,7 +400,6 @@
     <string name="copy_uri">URI\'ı kopyala</string>
     <string name="unable_to_copy_uri_to_clipboard">URI panoya kopyalanamıyor</string>
     <string name="uri_copied_to_clipboard">URI panoya kopyalandı</string>
-    <string name="transfer_entry">Girdiyi aktar</string>
     <string name="transfer_entry_description">Bu kare kodu aktarmak istediğiniz doğrulayıcı uygulamasıyla okutun</string>
     <string name="google_auth_compatible_transfer_description">Bu QR kodlarını Aegis veya Google Authenticator ile tarayın.\in\Google Authenticator uygulamasının sınırlamaları nedeniyle, yalnızca TOTP &amp; SHA1 kullanan ve 6 basamaklı kodlar üreten TOTP belirteçleri dahildir</string>
     <string name="password_strength_very_weak">Çok zayıf</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -385,7 +385,6 @@
     <string name="copy_uri">Копіювати URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Не вдалося скопіювати URI в буфер обміну</string>
     <string name="uri_copied_to_clipboard">URI скопійовано в буфер обміну</string>
-    <string name="transfer_entry">Передати запис</string>
     <string name="transfer_entry_description">Відскануйте цей QR-код за допомогою додатка для авторизації, куди ви хочете перенести цей запис</string>
     <string name="google_auth_compatible_transfer_description">Проскануйте ці QR-коди за допомогою Aegis або Google Authenticator.\n\nУ зв\'язку з обмеженнями програми Google Authenticator включаються лише TOTP &amp; HOTP токени з використанням SHA1 і генерацією 6-цифрових кодів</string>
     <string name="password_strength_very_weak">Дуже слабкий</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -425,7 +425,6 @@
     <string name="copy_uri">Sao chép URL</string>
     <string name="unable_to_copy_uri_to_clipboard">Không thể sao chép vào bộ nhớ tạm</string>
     <string name="uri_copied_to_clipboard">Đã sao chép vào bộ nhớ tạm</string>
-    <string name="transfer_entry">Truyền mục</string>
     <string name="transfer_entry_description">Quét mã QR này bằng ứng dụng xác minh mà bạn muốn truyền mục này đến</string>
     <string name="google_auth_compatible_transfer_description">Quét các mã QR này bằng Aegis hoặc Google Authenticator.\n\nDo hạn chế của ứng dụng Google Authenticator, chỉ token TOTP &amp; HOTP sử dụng SHA1 và tạo mã gồm 6 chữ số dùng được</string>
     <string name="password_strength_very_weak">Rất yếu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -423,7 +423,6 @@
     <string name="copy_uri">复制 URI</string>
     <string name="unable_to_copy_uri_to_clipboard">无法复制 URI 到剪贴板</string>
     <string name="uri_copied_to_clipboard">URI 已复制到剪贴板</string>
-    <string name="transfer_entry">迁移条目</string>
     <string name="transfer_entry_description">使用您想将此条目迁移到的其它身份验证器应用扫描此二维码</string>
     <string name="google_auth_compatible_transfer_description">使用 Aegis 或 Google 身份验证器扫描这些二维码。\n\n由于 Google 身份验证器应用的限制， 只包含使用 SHA1 并生成 6 位数字代码的 TOTP &amp; HOTP 令牌</string>
     <string name="password_strength_very_weak">很弱</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -372,7 +372,6 @@
     <string name="copy_uri">複製 URI</string>
     <string name="unable_to_copy_uri_to_clipboard">無法複製 URI 到剪貼簿</string>
     <string name="uri_copied_to_clipboard">URI 已複製到剪貼簿</string>
-    <string name="transfer_entry">轉移條目</string>
     <string name="transfer_entry_description">使用您想轉移至其他驗證器應用程式，請掃描此QR碼</string>
     <string name="google_auth_compatible_transfer_description">請使用 Aegis 或 Google Authenticator 掃描以下 QR Code。\n\n由於 Google Authenticator 程式的限制，將僅包含使用 SHA1 並產生六位數密碼的 TOTP &amp; HOTP 憑證</string>
     <string name="password_strength_very_weak">很弱</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -484,7 +484,6 @@
     <string name="copy_uri">Copy URI</string>
     <string name="unable_to_copy_uri_to_clipboard">Unable to copy URI to clipboard</string>
     <string name="uri_copied_to_clipboard">URI copied to clipboard</string>
-    <string name="transfer_entry">Transfer entry</string>
     <string name="transfer_entry_description">Scan this QR code with the authenticator app you would like to transfer this entry to</string>
     <string name="google_auth_compatible_transfer_description">Scan these QR codes with Aegis or Google Authenticator.\n\nDue to limitations of the Google Authenticator app, only TOTP &amp; HOTP tokens that use SHA1 and produce 6-digit codes are included</string>
 


### PR DESCRIPTION
This patch makes a couple of minor improvements to the entry sharing activity:
- Remove the double "Transfer entries" heading.
- Make the QR codes larger. Especially helpful with Google Authenticator exports.
- Increase screen brightness to 100%.

Before and after:

<img width="200" src="https://alexbakker.me/u/d91cl1x495.png"/> <img width="200" src="https://alexbakker.me/u/ckzhrs5nf5.png"/>

<img width="200" src="https://alexbakker.me/u/6bo0womot0.png"/> <img width="200" src="https://alexbakker.me/u/mw7yskjn7z.png"/>