### PR TITLE
Make subclasses of TotpInfo override only getOtp(long time)

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/otp/YAOTP.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/otp/YAOTP.java
@@ -25,10 +25,10 @@ public class YAOTP {
     public static YAOTP generateOTP(byte[] secret, String pin, int digits, String otpAlgo, long period)
             throws NoSuchAlgorithmException, InvalidKeyException, IOException {
         long seconds = System.currentTimeMillis() / 1000;
-        return generateOTP(secret, pin, digits, otpAlgo, seconds, period);
+        return generateOTP(secret, pin, digits, otpAlgo, period, seconds);
     }
 
-    public static YAOTP generateOTP(byte[] secret, String pin, int digits, String otpAlgo, long seconds, long period)
+    public static YAOTP generateOTP(byte[] secret, String pin, int digits, String otpAlgo, long period, long seconds)
             throws NoSuchAlgorithmException, InvalidKeyException, IOException {
         byte[] pinWithHash;
         byte[] pinBytes = pin.getBytes(StandardCharsets.UTF_8);

--- a/app/src/main/java/com/beemdevelopment/aegis/otp/MotpInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/MotpInfo.java
@@ -31,20 +31,6 @@ public class MotpInfo extends TotpInfo {
     }
 
     @Override
-    public String getOtp() {
-        if (_pin == null) {
-            throw new IllegalStateException("PIN must be set before generating an OTP");
-        }
-
-        try {
-            MOTP otp = MOTP.generateOTP(getSecret(), getAlgorithm(false), getDigits(), getPeriod(), getPin());
-            return otp.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
     public String getOtp(long time) {
         if (_pin == null) {
             throw new IllegalStateException("PIN must be set before generating an OTP");

--- a/app/src/main/java/com/beemdevelopment/aegis/otp/SteamInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/SteamInfo.java
@@ -20,11 +20,11 @@ public class SteamInfo extends TotpInfo {
     }
 
     @Override
-    public String getOtp() throws OtpInfoException {
+    public String getOtp(long time) throws OtpInfoException {
         checkSecret();
 
         try {
-            OTP otp = TOTP.generateOTP(getSecret(), getAlgorithm(true), getDigits(), getPeriod());
+            OTP otp = TOTP.generateOTP(getSecret(), getAlgorithm(true), getDigits(), getPeriod(), time);
             return otp.toSteamString();
         } catch (InvalidKeyException | NoSuchAlgorithmException e) {
             throw new RuntimeException(e);

--- a/app/src/main/java/com/beemdevelopment/aegis/otp/TotpInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/TotpInfo.java
@@ -27,14 +27,7 @@ public class TotpInfo extends OtpInfo {
 
     @Override
     public String getOtp() throws OtpInfoException {
-        checkSecret();
-
-        try {
-            OTP otp = TOTP.generateOTP(getSecret(), getAlgorithm(true), getDigits(), getPeriod());
-            return otp.toString();
-        } catch (InvalidKeyException | NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        return getOtp(System.currentTimeMillis() / 1000);
     }
 
     public String getOtp(long time) throws OtpInfoException {

--- a/app/src/main/java/com/beemdevelopment/aegis/otp/YandexInfo.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/otp/YandexInfo.java
@@ -38,13 +38,13 @@ public class YandexInfo extends TotpInfo {
     }
 
     @Override
-    public String getOtp() {
+    public String getOtp(long time) {
         if (_pin == null) {
             throw new IllegalStateException("PIN must be set before generating an OTP");
         }
 
         try {
-            YAOTP otp = YAOTP.generateOTP(getSecret(), getPin(), getDigits(), getAlgorithm(true), getPeriod());
+            YAOTP otp = YAOTP.generateOTP(getSecret(), getPin(), getDigits(), getAlgorithm(true), getPeriod(), time);
             return otp.toString();
         } catch (InvalidKeyException | NoSuchAlgorithmException | IOException e) {
             throw new RuntimeException(e);

--- a/app/src/test/java/com/beemdevelopment/aegis/crypto/otp/YAOTPTest.java
+++ b/app/src/test/java/com/beemdevelopment/aegis/crypto/otp/YAOTPTest.java
@@ -32,8 +32,8 @@ public class YAOTPTest {
                     testCase.pin,
                     8,
                     "HmacSHA256",
-                    testCase.timestamp,
-                    30
+                    30,
+                    testCase.timestamp
             );
             assertEquals(testCase.expected, otp.toString());
         }


### PR DESCRIPTION
This fixes an issue where Steam OTP's were displayed in the wrong format. The underlying issue has been present for a while, but it first became apparent in e4c9a584f48da402291608ec1db0983dcdee2fde.

Fixes #1537.