### PR TITLE
Improve search feature for better UX

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -930,6 +930,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _searchView.setOnCloseListener(() -> {
             boolean enabled = _submittedSearchQuery != null;
             _searchViewBackPressHandler.setEnabled(enabled);
+            _groupChip.setVisibility(_groups.isEmpty() ? View.GONE : View.VISIBLE);
             return false;
         });
 
@@ -963,6 +964,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         });
         _searchView.setOnSearchClickListener(v -> {
             String query = _submittedSearchQuery != null ? _submittedSearchQuery : _pendingSearchQuery;
+            _groupChip.setVisibility(View.GONE);
             _searchView.setQuery(query, false);
         });
 
@@ -1028,6 +1030,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     }
 
     private void collapseSearchView() {
+        _groupChip.setVisibility(_groups.isEmpty() ? View.GONE : View.VISIBLE);
         _searchView.setQuery(null, false);
         _searchView.setIconified(true);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -37,6 +37,7 @@ import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultGroup;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -196,6 +197,19 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         String name = entry.getName().toLowerCase();
         String note = entry.getNote().toLowerCase();
 
+        if (_searchFilter != null) {
+            String[] tokens = _searchFilter.toLowerCase().split("\\s+");
+
+            // Return true if not all tokens match at least one of the relevant fields
+            return !Arrays.stream(tokens)
+                    .allMatch(token ->
+                            ((_searchBehaviorMask & Preferences.SEARCH_IN_ISSUER) != 0 && issuer.contains(token)) ||
+                                    ((_searchBehaviorMask & Preferences.SEARCH_IN_NAME) != 0 && name.contains(token)) ||
+                                    ((_searchBehaviorMask & Preferences.SEARCH_IN_NOTE) != 0 && note.contains(token)) ||
+                                    ((_searchBehaviorMask & Preferences.SEARCH_IN_GROUPS) != 0 && doesAnyGroupMatchSearchFilter(groups, token))
+                    );
+        }
+
         if (!_groupFilter.isEmpty()) {
             if (groups.isEmpty() && !_groupFilter.contains(null)) {
                 return true;
@@ -205,14 +219,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             }
         }
 
-        if (_searchFilter == null) {
-            return false;
-        }
-
-        return ((_searchBehaviorMask & Preferences.SEARCH_IN_ISSUER) == 0 || !issuer.contains(_searchFilter))
-                && ((_searchBehaviorMask & Preferences.SEARCH_IN_NAME) == 0 || !name.contains(_searchFilter))
-                && ((_searchBehaviorMask & Preferences.SEARCH_IN_NOTE) == 0 || !note.contains(_searchFilter))
-                && ((_searchBehaviorMask & Preferences.SEARCH_IN_GROUPS) == 0 || !doesAnyGroupMatchSearchFilter(entry.getGroups(), _searchFilter));
+        return false;
     }
 
     private boolean doesAnyGroupMatchSearchFilter(Set<UUID> entryGroupUUIDs, String searchFilter) {


### PR DESCRIPTION
This PR improves the search feature as requested in #1527 and #1536. After this gets merged Aegis will:

1. Hide the group chips when user starts searching
2. Ignore the current active group filter
3. Matches now in all fields that are enabled to search in

Example: 

| Search Filter     | Issuer   | Name   | Match? |
|--------------------|----------|--------|--------|
| `GitHub michaelschattgen`     | GitHub   | michaelschattgen   | ✅ Yes  |
| `GitHub`          | GitHub   | michaelschattgen   | ✅ Yes  |
| `michaelschattgen`            | GitHub   | michaelschattgen   | ✅ Yes  |
| `hub michaelschattgen`        | GitHub   | michaelschattgen   | ✅ Yes   |
| `michaelschattgen Git`     | GitHub   | michaelschattgen   | ✅ Yes  |
| `Github e`         | GitHub   | michaelschattgen   | ✅ Yes    |
| `GitHub michaelschattgen 1`| GitHub   | michaelschattgen   | ❌ No   |
| `hub z`             | GitHub   | michaelschattgen   | ❌ No   |

Closes #1527, closes #1536 