### PR TITLE
Fix state updates for the lock and sort menu items

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -920,6 +920,9 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _menu = menu;
         getMenuInflater().inflate(R.menu.menu_main, menu);
 
+        updateLockIcon();
+        updateSortCategoryMenu();
+
         MenuItem searchViewMenuItem = menu.findItem(R.id.mi_search);
         _searchView = (SearchView) searchViewMenuItem.getActionView();
         _searchView.setMaxWidth(Integer.MAX_VALUE);


### PR DESCRIPTION
Turns out I was a little too enthusiastically removing things in 9d383b85d8c5581f12a1a22407ce4615c4d499f3. The menu may not necessarily have been created yet in all cases.