### PR TITLE
Apply window insets to accommodate system UI.

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/ViewHelper.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/ViewHelper.java
@@ -1,0 +1,26 @@
+package com.beemdevelopment.aegis.helpers;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.google.android.material.appbar.AppBarLayout;
+
+public class ViewHelper {
+    private ViewHelper() {
+
+    }
+
+    public static void setupAppBarInsets(AppBarLayout appBar) {
+        ViewCompat.setOnApplyWindowInsetsListener(appBar, (targetView, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            targetView.setPadding(
+                    insets.left,
+                    insets.top,
+                    insets.right,
+                    0
+            );
+            return WindowInsetsCompat.CONSUMED;
+        });
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AboutActivity.java
@@ -13,11 +13,15 @@ import android.widget.Toast;
 
 import androidx.annotation.AttrRes;
 import androidx.annotation.StringRes;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.beemdevelopment.aegis.BuildConfig;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.ui.dialogs.ChangelogDialog;
 import com.beemdevelopment.aegis.ui.dialogs.LicenseDialog;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.google.android.material.color.MaterialColors;
 
 public class AboutActivity extends AegisActivity {
@@ -39,6 +43,7 @@ public class AboutActivity extends AegisActivity {
 
         setContentView(R.layout.activity_about);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
 
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -89,6 +94,17 @@ public class AboutActivity extends AegisActivity {
             ChangelogDialog.create()
                     .setTheme(_themeHelper.getConfiguredTheme())
                     .show(getSupportFragmentManager(), null);
+        });
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.about_scroll_view), (targetView, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            targetView.setPadding(
+                    0,
+                    0,
+                    0,
+                    insets.bottom
+            );
+            return WindowInsetsCompat.CONSUMED;
         });
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AssignIconsActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AssignIconsActivity.java
@@ -25,6 +25,7 @@ import com.beemdevelopment.aegis.ui.models.AssignIconEntry;
 import com.beemdevelopment.aegis.ui.views.AssignIconAdapter;
 import com.beemdevelopment.aegis.ui.views.IconAdapter;
 import com.beemdevelopment.aegis.util.IOUtils;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultEntryIcon;
 import com.bumptech.glide.Glide;
@@ -61,6 +62,7 @@ public class AssignIconsActivity extends AegisActivity implements AssignIconAdap
 
         setContentView(R.layout.activity_assign_icons);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             getSupportActionBar().setDisplayShowHomeEnabled(true);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -59,6 +59,7 @@ import com.beemdevelopment.aegis.ui.tasks.ImportFileTask;
 import com.beemdevelopment.aegis.ui.views.IconAdapter;
 import com.beemdevelopment.aegis.util.Cloner;
 import com.beemdevelopment.aegis.util.IOUtils;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultEntryIcon;
 import com.beemdevelopment.aegis.vault.VaultGroup;
@@ -164,6 +165,7 @@ public class EditEntryActivity extends AegisActivity {
         }
         setContentView(R.layout.activity_edit_entry);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
 
         _groups = _vaultManager.getVault().getGroups();
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/GroupManagerActivity.java
@@ -15,6 +15,7 @@ import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
 import com.beemdevelopment.aegis.ui.views.GroupAdapter;
 import com.beemdevelopment.aegis.util.Cloner;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.beemdevelopment.aegis.vault.VaultGroup;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -39,6 +40,7 @@ public class GroupManagerActivity extends AegisActivity implements GroupAdapter.
         }
         setContentView(R.layout.activity_groups);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             getSupportActionBar().setDisplayShowHomeEnabled(true);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/ImportEntriesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/ImportEntriesActivity.java
@@ -24,6 +24,7 @@ import com.beemdevelopment.aegis.ui.models.ImportEntry;
 import com.beemdevelopment.aegis.ui.tasks.RootShellTask;
 import com.beemdevelopment.aegis.ui.views.ImportEntriesAdapter;
 import com.beemdevelopment.aegis.util.UUIDMap;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultGroup;
 import com.beemdevelopment.aegis.vault.VaultRepository;
@@ -58,6 +59,7 @@ public class ImportEntriesActivity extends AegisActivity {
         }
         setContentView(R.layout.activity_import_entries);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
 
         _view = findViewById(R.id.importEntriesRootView);
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -59,6 +59,7 @@ import com.beemdevelopment.aegis.ui.tasks.QrDecodeTask;
 import com.beemdevelopment.aegis.ui.views.EntryListView;
 import com.beemdevelopment.aegis.util.TimeUtils;
 import com.beemdevelopment.aegis.util.UUIDMap;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.beemdevelopment.aegis.vault.VaultFile;
 import com.beemdevelopment.aegis.vault.VaultGroup;
@@ -183,6 +184,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
         _loaded = false;
         _isDPadPressed = false;
         _isDoingIntro = false;

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -13,6 +13,7 @@ import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.ui.fragments.preferences.AppearancePreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.MainPreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.PreferencesFragment;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 
 public class PreferencesActivity extends AegisActivity implements
         PreferenceFragmentCompat.OnPreferenceStartFragmentCallback {
@@ -27,6 +28,7 @@ public class PreferencesActivity extends AegisActivity implements
         }
         setContentView(R.layout.activity_preferences);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
         getSupportFragmentManager()
                 .registerFragmentLifecycleCallbacks(new FragmentResumeListener(), true);
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/ScannerActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/ScannerActivity.java
@@ -22,6 +22,7 @@ import com.beemdevelopment.aegis.helpers.QrCodeAnalyzer;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfo;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfoException;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.beemdevelopment.aegis.vault.VaultEntry;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.zxing.Result;
@@ -56,6 +57,7 @@ public class ScannerActivity extends AegisActivity implements QrCodeAnalyzer.Lis
         }
         setContentView(R.layout.activity_scanner);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
 
         _entries = new ArrayList<>();
         _lenses = new ArrayList<>();

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/TransferEntriesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/TransferEntriesActivity.java
@@ -28,6 +28,7 @@ import com.beemdevelopment.aegis.otp.GoogleAuthInfo;
 import com.beemdevelopment.aegis.otp.GoogleAuthInfoException;
 import com.beemdevelopment.aegis.otp.Transferable;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
+import com.beemdevelopment.aegis.helpers.ViewHelper;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.imageview.ShapeableImageView;
 import com.google.zxing.WriterException;
@@ -55,6 +56,7 @@ public class TransferEntriesActivity extends AegisActivity {
         }
         setContentView(R.layout.activity_share_entry);
         setSupportActionBar(findViewById(R.id.toolbar));
+        ViewHelper.setupAppBarInsets(findViewById(R.id.app_bar_layout));
 
         _qrImage = findViewById(R.id.ivQrCode);
         _description = findViewById(R.id.tvDescription);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AuditLogPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/AuditLogPreferencesFragment.java
@@ -6,6 +6,9 @@ import android.view.View;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.LiveData;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -57,6 +60,17 @@ public class AuditLogPreferencesFragment extends Fragment {
         _auditLogRecyclerView.setLayoutManager(layoutManager);
         _auditLogRecyclerView.setAdapter(_adapter);
         _auditLogRecyclerView.setNestedScrollingEnabled(false);
+
+        ViewCompat.setOnApplyWindowInsetsListener(_auditLogRecyclerView, (targetView, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            targetView.setPadding(
+                    0,
+                    0,
+                    0,
+                    insets.bottom
+            );
+            return WindowInsetsCompat.CONSUMED;
+        });
 
         entries.observe(getViewLifecycleOwner(), entries1 -> {
             _noAuditLogsView.setVisibility(entries1.isEmpty() ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
+import android.view.ViewGroup.MarginLayoutParams;
 import android.view.animation.Animation;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -14,6 +15,9 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -66,6 +70,19 @@ public class IconPacksManagerFragment extends Fragment implements IconPackAdapte
         FloatingActionButton fab = view.findViewById(R.id.fab);
         fab.setOnClickListener(v -> startImportIconPack());
         _fabScrollHelper = new FabScrollHelper(fab);
+
+        final MarginLayoutParams fabInitialMargin = (MarginLayoutParams) fab.getLayoutParams();
+        ViewCompat.setOnApplyWindowInsetsListener(fab, (targetView, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+
+            MarginLayoutParams marginParams = (MarginLayoutParams) targetView.getLayoutParams();
+            marginParams.leftMargin = fabInitialMargin.leftMargin + insets.left;
+            marginParams.bottomMargin = fabInitialMargin.bottomMargin + insets.bottom;
+            marginParams.rightMargin = fabInitialMargin.rightMargin + insets.right;
+            targetView.setLayoutParams(marginParams);
+
+            return WindowInsetsCompat.CONSUMED;
+        });
 
         _noIconPacksView = view.findViewById(R.id.vEmptyList);
         ((TextView) view.findViewById(R.id.txt_no_icon_packs)).setMovementMethod(LinkMovementMethod.getInstance());

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/PreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/PreferencesFragment.java
@@ -1,13 +1,20 @@
 package com.beemdevelopment.aegis.ui.fragments.preferences;
 
 import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
 import android.view.animation.Animation;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
@@ -59,6 +66,23 @@ public abstract class PreferencesFragment extends PreferenceFragmentCompat {
         }
 
         return super.onCreateAnimation(transit, enter, nextAnim);
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView onCreateRecyclerView(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent, @Nullable Bundle savedInstanceState) {
+        RecyclerView recyclerView = super.onCreateRecyclerView(inflater, parent, savedInstanceState);
+        ViewCompat.setOnApplyWindowInsetsListener(recyclerView, (targetView, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            targetView.setPadding(
+                    0,
+                    0,
+                    0,
+                    insets.bottom
+            );
+            return WindowInsetsCompat.CONSUMED;
+        });
+        return recyclerView;
     }
 
     protected boolean saveAndBackupVault() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -19,6 +19,9 @@ import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
@@ -147,6 +150,23 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
             public long getMillisTillNextRefresh() {
                 return TotpInfo.getMillisTillNextRotation(_adapter.getMostFrequentPeriod());
             }
+        });
+
+        final int rvInitialPaddingLeft = _recyclerView.getPaddingLeft();
+        final int rvInitialPaddingTop = _recyclerView.getPaddingTop();
+        final int rvInitialPaddingRight = _recyclerView.getPaddingRight();
+        final int rvInitialPaddingBottom = _recyclerView.getPaddingBottom();
+
+        ViewCompat.setOnApplyWindowInsetsListener(_recyclerView, (targetView, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            // left and right padding seems to be handled by fitsSystemWindows="true" on the CoordinatorLayout in activity_main.xml
+            targetView.setPadding(
+                    rvInitialPaddingLeft,
+                    rvInitialPaddingTop,
+                    rvInitialPaddingRight,
+                    rvInitialPaddingBottom + insets.bottom
+            );
+            return WindowInsetsCompat.CONSUMED;
         });
 
         _emptyStateView = view.findViewById(R.id.vEmptyList);

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -17,6 +17,7 @@
             android:layout_height="?attr/actionBarSize" />
     </com.google.android.material.appbar.AppBarLayout>
     <ScrollView
+        android:id="@+id/about_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clipToPadding="false"

--- a/app/src/main/res/layout/fragment_audit_log.xml
+++ b/app/src/main/res/layout/fragment_audit_log.xml
@@ -51,6 +51,7 @@
         android:layout_height="match_parent"
         android:scrollbars="vertical"
         android:scrollbarStyle="outsideOverlay"
+        android:clipToPadding="false"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_entry_list_view.xml
+++ b/app/src/main/res/layout/fragment_entry_list_view.xml
@@ -20,6 +20,7 @@
         android:paddingHorizontal="8dp"
         android:scrollbars="vertical"
         android:scrollbarStyle="outsideOverlay"
+        android:clipToPadding="false"
         android:id="@+id/rvKeyProfiles"
         android:layout_weight="1"/>
 


### PR DESCRIPTION
To not have UI elements obscured by system bars on Android 15, this PR adds bottom padding to lists in the main vault view, preferences and about.

As for the AppBar, `android:fitsSystemWindows="true"` only makes the top insets get applied, so I had to manually apply the left and right ones as well. [Google seems to recommend](https://medium.com/androiddevelopers/insets-handling-tips-for-android-15s-edge-to-edge-enforcement-872774e8839b) using `ViewCompat.setOnApplyWindowInsetsListener` over `android:fitsSystemWindows` for this reason. (Tip 10)

Fixes #1549 