### PR TITLE
Improve contrast of next code color

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -101,8 +101,8 @@
     <color name="aegis_theme_all_favorite">#F9A825</color>
     <color name="aegis_theme_light_success">#518242</color>
     <color name="aegis_theme_dark_success">#d9e7cb</color>
-    <color name="aegis_theme_light_onSurfaceDim">#FFB0B1B5</color>
-    <color name="aegis_theme_dark_onSurfaceDim">#44464f</color>
+    <color name="aegis_theme_light_onSurfaceDim">#9D9EA2</color>
+    <color name="aegis_theme_dark_onSurfaceDim">#616371</color>
     <!-- Hacks to force the status bar to the correct color during action mode.
          These colors are used by AppCompatDelegateImpl.updateStatusGuardColor -->
     <color name="abc_decor_view_status_guard_light" tools:override="true">@android:color/transparent</color>


### PR DESCRIPTION
This PR fixes the contrast of the next code color. I've made some minor tweaks to contrast while also (try to) not making it too prominent.

Left is before, right is after this PR is merged:
![image](https://github.com/user-attachments/assets/1252ac6f-8fe4-4406-b7eb-e21da01aaf2b)
![image](https://github.com/user-attachments/assets/811d06eb-cb0e-4429-a263-a365f578d5c5)


Fixes #1556 