### PR TITLE
Set largeHeap to true in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:icon="@mipmap/${iconName}"
         android:label="Aegis"
         android:supportsRtl="true"
+        android:largeHeap="true"
         android:theme="@style/Theme.Aegis.Launch"
         tools:targetApi="tiramisu">
         <activity android:name=".ui.TransferEntriesActivity"


### PR DESCRIPTION
This is a temporary measure to help users who are stuck in a situation where they run into OOM conditions due to large icons in their vault file.

Relates to #1298.