### PR TITLE
Improve color contrast on hidden codes

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -369,9 +369,11 @@ public class EntryHolder extends RecyclerView.ViewHolder {
     public void hideCode() {
         String code = getOtp();
         String hiddenText = code.replaceAll("\\S", Character.toString(HIDDEN_CHAR));
+        stopExpirationAnimation();
+
         updateTextViewWithDots(_profileCode,  hiddenText, code);
         updateTextViewWithDots(_nextProfileCode,  hiddenText, code);
-        stopExpirationAnimation();
+
         _hidden = true;
     }
 
@@ -384,6 +386,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
         float dotsWidth = paint.measureText(hiddenCode);
         float scaleFactor = codeWidth / dotsWidth;
         scaleFactor = (float)(Math.round(scaleFactor * 10.0) / 10.0);
+        textView.setTextColor(MaterialColors.getColor(textView, R.attr.colorCodeHidden));
 
         // If scale is higher or equal to 0.8, do nothing and proceed with the normal text rendering
         if (scaleFactor >= 0.8) {

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
     <attr name="colorSuccess" />
     <attr name="colorOnSurfaceDim" />
     <attr name="colorCode" />
+    <attr name="colorCodeHidden" />
 
     <declare-styleable name="SlideIndicator">
         <attr name="dot_radius" format="dimension" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -62,6 +62,7 @@
         <item name="colorSuccess">@color/aegis_theme_light_success</item>
         <item name="colorOnSurfaceDim">@color/aegis_theme_light_onSurfaceDim</item>
         <item name="colorCode">?attr/colorPrimary</item>
+        <item name="colorCodeHidden">?attr/colorOutlineVariant</item>
         <!-- Intro colors -->
         <item name="dot_color">?attr/colorSurfaceVariant</item>
         <item name="dot_color_selected">?attr/colorOnSurfaceVariant</item>
@@ -132,6 +133,7 @@
         <item name="colorSuccess">@color/aegis_theme_dark_success</item>
         <item name="colorOnSurfaceDim">@color/aegis_theme_dark_onSurfaceDim</item>
         <item name="colorCode">?attr/colorPrimary</item>
+        <item name="colorCodeHidden">?attr/colorOutlineVariant</item>
         <!-- Intro colors -->
         <item name="dot_color">?attr/colorSurfaceVariant</item>
         <item name="dot_color_selected">?attr/colorOnSurfaceVariant</item>
@@ -159,6 +161,7 @@
         <item name="colorSurfaceDim">#000000</item>
         <item name="colorSurfaceBright">#000000</item>
         <item name="colorCode">@android:color/white</item>
+        <item name="colorCodeHidden">#2F2F2F</item>
         <item name="colorProgressbar">@android:color/white</item>
     </style>
 
@@ -179,6 +182,7 @@
         <item name="colorSurfaceDim">#000000</item>
         <item name="colorSurfaceBright">#000000</item>
         <item name="colorCode">@android:color/white</item>
+        <item name="colorCodeHidden">#2F2F2F</item>
         <item name="colorProgressbar">@android:color/white</item>
     </style>
 


### PR DESCRIPTION
Difference before vs after:

<img src="https://github.com/user-attachments/assets/4cfc4109-8edf-4d16-9f05-7a0647e1514d" width="300"/>
<img src="https://github.com/user-attachments/assets/0004f8f5-8f52-47ea-8990-3d03531b13b7" width="300"/>


I like this a lot better, please let me know if you have any suggestions.

Fixes #672