### PR TITLE
Update divider decoration when filter/sort changes

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -220,8 +220,8 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _entryListView.setPauseFocused(_prefs.isPauseFocusedEnabled());
         _entryListView.setTapToReveal(_prefs.isTapToRevealEnabled());
         _entryListView.setTapToRevealTime(_prefs.getTapToRevealTime());
-        _entryListView.setSortCategory(_prefs.getCurrentSortCategory(), false);
         _entryListView.setViewMode(_prefs.getCurrentViewMode());
+        _entryListView.setSortCategory(_prefs.getCurrentSortCategory(), false);
         _entryListView.setCopyBehavior(_prefs.getCopyBehavior());
         _entryListView.setSearchBehaviorMask(_prefs.getSearchBehaviorMask());
         _prefGroupFilter = _prefs.getGroupFilter();

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -200,6 +200,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         _adapter.setGroupFilter(groups);
         _touchCallback.setIsLongPressDragEnabled(_adapter.isDragAndDropAllowed());
         updateEmptyState();
+        updateDividerDecoration();
     }
 
     public void setIsLongPressDragEnabled(boolean enabled) {
@@ -232,6 +233,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
     public void setSortCategory(SortCategory sortCategory, boolean apply) {
         _adapter.setSortCategory(sortCategory, apply);
         _touchCallback.setIsLongPressDragEnabled(_adapter.isDragAndDropAllowed());
+        updateDividerDecoration();
     }
 
     public void setUsageCounts(Map<UUID, Integer> usageCounts) {
@@ -253,8 +255,8 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
     public void setSearchFilter(String search) {
         _adapter.setSearchFilter(search);
         _touchCallback.setIsLongPressDragEnabled(_adapter.isDragAndDropAllowed());
-
         updateEmptyState();
+        updateDividerDecoration();
     }
 
     public void setSelectedEntry(VaultEntry entry) {


### PR DESCRIPTION
This fixes an issue where the item decoration may be wrong in some cases. For example, adding a new entry to the bottom of the list may not update the decoration of the item that was previously the last one in the list.

To reproduce, use this vault: https://alexbakker.me/u/mov4455gp5.json. Start without a group filter, apply sorting based on Issuer (A to Z) and enable group multiselect. Then:
- Tap the "Test" chip
- Tap the "Test2" chip
- Tap the "No group" chip
- Notice that the offset between the last 2 entries looks wrong: https://alexbakker.me/u/nedcyiro2q.png

Probably introduced in 9131cae944f354c95873aa1c257e87b0c9b1f210.