### PR TITLE
Add "uniqueId" parameter to Google Authenticator .proto schema

### DIFF
--- a/app/src/main/proto/google_auth.proto
+++ b/app/src/main/proto/google_auth.proto
@@ -32,6 +32,7 @@ message MigrationPayload {
     DigitCount digits = 5;
     OtpType type = 6;
     int64 counter = 7;
+    string uniqueId = 8;
   }
 
   repeated OtpParameters otp_parameters = 1;


### PR DESCRIPTION
Opened for #1681. 

As mentioned in the issue, this makes no material difference to Aegis's ability to import Google Authenticator data, however, you may wish to include it regardless. 

No problem if rejected, given the above.