### PR TITLE
Use custom NoAutofill field to avoid password manager issues

### DIFF
--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -197,7 +197,7 @@
                             app:passwordToggleTint="?attr/colorOnSurface"
                             app:passwordToggleEnabled="true">
 
-                            <com.google.android.material.textfield.TextInputEditText
+                            <com.beemdevelopment.aegis.ui.components.NoAutofillEditText
                                 android:id="@+id/text_secret"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"


### PR DESCRIPTION
We've received reports that sometimes the Google Password Manager popup would show up when (manually) editing the Secret within an TOTP entry. This popup asks the user whether the secret value should be used as password for Aegis. When the user accidentally clicks on 'Yes', their master password used for unlocking the vault will get overwritten by the TOTP secret.

Since the AutofillServices are a pain the ass to deal with I had to use our custom TextInput which completely disables all autofill features.

Example:
<img width="421" height="920" alt="2026-01-18-192516_hyprshot" src="https://github.com/user-attachments/assets/02af42ea-60eb-4981-92c1-397e525ee667" />
