### PR TITLE
Inverted buttons position in dialog_select_groups

### DIFF
--- a/app/src/main/res/layout/dialog_select_groups.xml
+++ b/app/src/main/res/layout/dialog_select_groups.xml
@@ -100,17 +100,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:orientation="horizontal">
         <Button
-            android:id="@+id/btnSave"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/save"
-            style="@style/Widget.Material3.Button.TextButton" />
-
-        <Button
             android:id="@+id/btnClear"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/clear"
+            style="@style/Widget.Material3.Button.TextButton" />
+
+        <Button
+            android:id="@+id/btnSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/save"
             style="@style/Widget.Material3.Button.TextButton" />
     </LinearLayout>
 


### PR DESCRIPTION
As a user I've always found quite annoying the fact that those two buttons are inverted, all the times happens that I touch the clear button since usually in UIs the rightmost button is the save (or confirm) one.

Feel free to accept or refuse this PR.

PS: I didn't actually test it but I think will work, when I'll have a proper device will do 