### PR TITLE
Use ACTION_OPEN_DOCUMENT for file imports

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/IconPacksManagerFragment.java
@@ -170,7 +170,8 @@ public class IconPacksManagerFragment extends Fragment implements IconPackAdapte
     }
 
     private void startImportIconPack() {
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
         _vaultManager.fireIntentLauncher(this, intent, importResultLauncher);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/ImportExportPreferencesFragment.java
@@ -107,7 +107,8 @@ public class ImportExportPreferencesFragment extends PreferencesFragment {
             Dialogs.showImportersDialog(requireContext(), false, definition -> {
                 _importerDef = definition;
 
-                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
                 intent.setType("*/*");
                 _vaultManager.fireIntentLauncher(this, intent, importSelectResultLauncher);
             });


### PR DESCRIPTION
Fixes #1784

ACTION_GET_CONTENT is problematic on newer Android versions. Switched both the icon pack and JSON import flows over to ACTION_OPEN_DOCUMENT with the CATEGORY_OPENABLE filter, which is the recommended approach and should fix the import issues.