### PR TITLE
Add configurable tap action behaviour

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -80,6 +80,33 @@ public class Preferences {
 
             _prefs.edit().remove(prefCopyOnTapKey).apply();
         }
+
+        String prefCopyBehaviorKey = "pref_current_copy_behavior";
+        if (_prefs.contains(prefCopyBehaviorKey)
+                && !_prefs.contains("pref_single_tap_action")
+                && !_prefs.contains("pref_double_tap_action")) {
+            CopyBehavior copyBehavior = getCopyBehavior();
+
+            switch (copyBehavior) {
+                case SINGLETAP:
+                    setSingleTapAction(TapAction.COPY);
+                    setDoubleTapAction(TapAction.NONE);
+                    break;
+
+                case DOUBLETAP:
+                    setSingleTapAction(TapAction.NONE);
+                    setDoubleTapAction(TapAction.COPY);
+                    break;
+
+                case NEVER:
+                default:
+                    setSingleTapAction(TapAction.NONE);
+                    setDoubleTapAction(TapAction.NONE);
+                    break;
+            }
+
+            _prefs.edit().remove(prefCopyBehaviorKey).apply();
+        }
     }
 
     public boolean isTapToRevealEnabled() {
@@ -578,6 +605,28 @@ public class Preferences {
 
     public void setCopyBehavior(CopyBehavior copyBehavior) {
         _prefs.edit().putInt("pref_current_copy_behavior", copyBehavior.ordinal()).apply();
+    }
+
+    public TapAction getSingleTapAction() {
+        int def = TapAction.COPY.ordinal();
+        return TapAction.fromInteger(_prefs.getInt("pref_single_tap_action", def));
+    }
+
+    public void setSingleTapAction(TapAction tapAction) {
+        _prefs.edit().putInt("pref_single_tap_action", tapAction.ordinal()).apply();
+    }
+
+    public TapAction getDoubleTapAction() {
+        int def = TapAction.NONE.ordinal();
+        return TapAction.fromInteger(_prefs.getInt("pref_double_tap_action", def));
+    }
+
+    public void setDoubleTapAction(TapAction tapAction) {
+        _prefs.edit().putInt("pref_double_tap_action", tapAction.ordinal()).apply();
+    }
+
+    public boolean isReserveFirstTapEnabled() {
+        return _prefs.getBoolean("pref_reserve_first_tap", false);
     }
 
     public boolean isMinimizeOnCopyEnabled() {

--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -82,30 +82,38 @@ public class Preferences {
         }
 
         String prefCopyBehaviorKey = "pref_current_copy_behavior";
+        String prefSingleTapActionKey = "pref_single_tap_action";
+        String prefDoubleTapActionKey = "pref_double_tap_action";
         if (_prefs.contains(prefCopyBehaviorKey)
-                && !_prefs.contains("pref_single_tap_action")
-                && !_prefs.contains("pref_double_tap_action")) {
+                && !_prefs.contains(prefSingleTapActionKey)
+                && !_prefs.contains(prefDoubleTapActionKey)) {
             CopyBehavior copyBehavior = getCopyBehavior();
+            TapAction singleTapAction;
+            TapAction doubleTapAction;
 
             switch (copyBehavior) {
                 case SINGLETAP:
-                    setSingleTapAction(TapAction.COPY);
-                    setDoubleTapAction(TapAction.NONE);
+                    singleTapAction = TapAction.COPY;
+                    doubleTapAction = TapAction.NONE;
                     break;
 
                 case DOUBLETAP:
-                    setSingleTapAction(TapAction.NONE);
-                    setDoubleTapAction(TapAction.COPY);
+                    singleTapAction = TapAction.NONE;
+                    doubleTapAction = TapAction.COPY;
                     break;
 
                 case NEVER:
                 default:
-                    setSingleTapAction(TapAction.NONE);
-                    setDoubleTapAction(TapAction.NONE);
+                    singleTapAction = TapAction.NONE;
+                    doubleTapAction = TapAction.NONE;
                     break;
             }
 
-            _prefs.edit().remove(prefCopyBehaviorKey).apply();
+            _prefs.edit()
+                    .putInt(prefSingleTapActionKey, singleTapAction.ordinal())
+                    .putInt(prefDoubleTapActionKey, doubleTapAction.ordinal())
+                    .remove(prefCopyBehaviorKey)
+                    .apply();
         }
     }
 
@@ -608,7 +616,7 @@ public class Preferences {
     }
 
     public TapAction getSingleTapAction() {
-        int def = TapAction.COPY.ordinal();
+        int def = TapAction.NONE.ordinal();
         return TapAction.fromInteger(_prefs.getInt("pref_single_tap_action", def));
     }
 
@@ -626,7 +634,7 @@ public class Preferences {
     }
 
     public boolean isReserveFirstTapEnabled() {
-        return _prefs.getBoolean("pref_reserve_first_tap", false);
+        return isTapToRevealEnabled() && _prefs.getBoolean("pref_reserve_first_tap", false);
     }
 
     public void setReserveFirstTapEnabled(boolean enabled) {

--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -629,6 +629,10 @@ public class Preferences {
         return _prefs.getBoolean("pref_reserve_first_tap", false);
     }
 
+    public void setReserveFirstTapEnabled(boolean enabled) {
+        _prefs.edit().putBoolean("pref_reserve_first_tap", enabled).apply();
+    }
+
     public boolean isMinimizeOnCopyEnabled() {
         return _prefs.getBoolean("pref_minimize_on_copy", false);
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/TapAction.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/TapAction.java
@@ -1,0 +1,21 @@
+package com.beemdevelopment.aegis;
+
+public enum TapAction {
+    COPY,
+    EDIT,
+    NONE;
+
+    private static TapAction[] _values;
+
+    static {
+        _values = values();
+    }
+
+    public static TapAction fromInteger(int x) {
+        if (x < 0 || x >= _values.length) {
+            return NONE;
+        }
+
+        return _values[x];
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -1237,6 +1237,10 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     @Override
     public void onDeselect(VaultEntry entry) {
         _selectedEntries.remove(entry);
+
+        if (_selectedEntries.isEmpty() && _actionMode != null) {
+            _actionMode.finish();
+        }
     }
 
     private void setIsMultipleSelected(boolean multipleSelected) {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -224,12 +224,14 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _entryListView.setShowNextCode(_prefs.getShowNextCode());
         _entryListView.setOnlyShowNecessaryAccountNames(_prefs.onlyShowNecessaryAccountNames());
         _entryListView.setHighlightEntry(_prefs.isEntryHighlightEnabled());
+        _entryListView.setSingleTapAction(_prefs.getSingleTapAction());
+        _entryListView.setDoubleTapAction(_prefs.getDoubleTapAction());
+        _entryListView.setReserveFirstTap(_prefs.isReserveFirstTapEnabled());
         _entryListView.setPauseFocused(_prefs.isPauseFocusedEnabled());
         _entryListView.setTapToReveal(_prefs.isTapToRevealEnabled());
         _entryListView.setTapToRevealTime(_prefs.getTapToRevealTime());
         _entryListView.setViewMode(_prefs.getCurrentViewMode());
         _entryListView.setSortCategory(_prefs.getCurrentSortCategory(), false);
-        _entryListView.setCopyBehavior(_prefs.getCopyBehavior());
         _entryListView.setSearchBehaviorMask(_prefs.getSearchBehaviorMask());
         _prefGroupFilter = _prefs.getGroupFilter();
 
@@ -1220,6 +1222,11 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                 setIsMultipleSelected(_selectedEntries.size() > 1);
             }
         }
+    }
+
+    @Override
+    public void onEntryEdit(VaultEntry entry) {
+        startEditEntryActivity(entry);
     }
 
     @Override

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/PreferencesActivity.java
@@ -10,7 +10,6 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import com.beemdevelopment.aegis.R;
-import com.beemdevelopment.aegis.ui.fragments.preferences.AppearancePreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.MainPreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.PreferencesFragment;
 import com.beemdevelopment.aegis.helpers.ViewHelper;
@@ -113,10 +112,8 @@ public class PreferencesActivity extends AegisActivity implements
     private class FragmentResumeListener extends FragmentManager.FragmentLifecycleCallbacks {
         @Override
         public void onFragmentStarted(@NonNull FragmentManager fm, @NonNull Fragment f) {
-            if (f instanceof MainPreferencesFragment) {
-                setTitle(R.string.action_settings);
-            } else if (f instanceof AppearancePreferencesFragment) {
-                _prefTitle = getString(R.string.pref_section_appearance_title);
+            if (f instanceof PreferencesFragment) {
+                _prefTitle = ((PreferencesFragment) f).getPreferenceScreen().getTitle();
                 setTitle(_prefTitle);
             }
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BehaviorPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BehaviorPreferencesFragment.java
@@ -71,17 +71,6 @@ public class BehaviorPreferencesFragment extends PreferencesFragment {
             return true;
         });
 
-        Preference tapActions = findPreference("pref_tap_actions");
-        if (tapActions != null) {
-            tapActions.setOnPreferenceClickListener(preference -> {
-                getParentFragmentManager()
-                        .beginTransaction()
-                        .replace(R.id.content, new TapActionsPreferencesFragment())
-                        .addToBackStack(null)
-                        .commit();
-                return true;
-            });
-        }
     }
 
     private String getSearchBehaviorSummary() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BehaviorPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/BehaviorPreferencesFragment.java
@@ -6,7 +6,6 @@ import android.widget.Button;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.Preference;
 
-import com.beemdevelopment.aegis.CopyBehavior;
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
@@ -63,26 +62,6 @@ public class BehaviorPreferencesFragment extends PreferencesFragment {
             return true;
         });
 
-        int currentCopyBehavior = _prefs.getCopyBehavior().ordinal();
-        Preference copyBehaviorPreference = requirePreference("pref_copy_behavior");
-        copyBehaviorPreference.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.copy_behavior_titles)[currentCopyBehavior]));
-        copyBehaviorPreference.setOnPreferenceClickListener(preference -> {
-            int currentCopyBehavior1 = _prefs.getCopyBehavior().ordinal();
-
-            Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(requireContext())
-                    .setTitle(getString(R.string.choose_copy_behavior))
-                    .setSingleChoiceItems(R.array.copy_behavior_titles, currentCopyBehavior1, (dialog, which) -> {
-                        int i = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
-                        _prefs.setCopyBehavior(CopyBehavior.fromInteger(i));
-                        copyBehaviorPreference.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.copy_behavior_titles)[i]));
-                        dialog.dismiss();
-                    })
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .create());
-
-            return true;
-        });
-
         Preference entryPausePreference = requirePreference("pref_pause_entry");
         entryPausePreference.setEnabled(_prefs.isTapToRevealEnabled() || _prefs.isEntryHighlightEnabled());
 
@@ -91,6 +70,18 @@ public class BehaviorPreferencesFragment extends PreferencesFragment {
             entryPausePreference.setEnabled(_prefs.isTapToRevealEnabled() || (boolean) newValue);
             return true;
         });
+
+        Preference tapActions = findPreference("pref_tap_actions");
+        if (tapActions != null) {
+            tapActions.setOnPreferenceClickListener(preference -> {
+                getParentFragmentManager()
+                        .beginTransaction()
+                        .replace(R.id.content, new TapActionsPreferencesFragment())
+                        .addToBackStack(null)
+                        .commit();
+                return true;
+            });
+        }
     }
 
     private String getSearchBehaviorSummary() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/TapActionsPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/TapActionsPreferencesFragment.java
@@ -1,0 +1,67 @@
+package com.beemdevelopment.aegis.ui.fragments.preferences;
+
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.Preference;
+import androidx.preference.SwitchPreferenceCompat;
+
+import com.beemdevelopment.aegis.R;
+import com.beemdevelopment.aegis.TapAction;
+import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+public class TapActionsPreferencesFragment extends PreferencesFragment {
+
+    @Override
+    public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
+        setPreferencesFromResource(R.xml.preferences_tap_actions, rootKey);
+
+        boolean isTapToRevealEnabled = _prefs.isTapToRevealEnabled();
+        SwitchPreferenceCompat reserveFirstTap = requirePreference("pref_reserve_first_tap");
+        Preference tapActionsHint = requirePreference("pref_tap_actions_hint");
+        reserveFirstTap.setEnabled(isTapToRevealEnabled);
+        tapActionsHint.setVisible(isTapToRevealEnabled);
+
+        Preference singleTapAction = requirePreference("pref_single_tap_action");
+        singleTapAction.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.pref_tap_action_entries)[_prefs.getSingleTapAction().ordinal()]));
+        singleTapAction.setOnPreferenceClickListener(preference -> {
+            int currentSingleTapAction = _prefs.getSingleTapAction().ordinal();
+            Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.choose_single_tap_action))
+                    .setSingleChoiceItems(R.array.pref_tap_action_entries, currentSingleTapAction, (dialog, which) -> {
+                        int i = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
+                        singleTapAction.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.pref_tap_action_entries)[i]));
+
+                        _prefs.setSingleTapAction(TapAction.fromInteger(i));
+                        dialog.dismiss();
+                    })
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .create());
+
+            return true;
+        });
+
+        Preference doubleTapAction = requirePreference("pref_double_tap_action");
+        doubleTapAction.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.pref_tap_action_entries)[_prefs.getDoubleTapAction().ordinal()]));
+        doubleTapAction.setOnPreferenceClickListener(preference -> {
+            int currentDoubleTapAction = _prefs.getDoubleTapAction().ordinal();
+
+            Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.choose_double_tap_action))
+                    .setSingleChoiceItems(R.array.pref_tap_action_entries, currentDoubleTapAction, (dialog, which) -> {
+                        int i = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
+                        doubleTapAction.setSummary(String.format("%s: %s", getString(R.string.selected), getResources().getStringArray(R.array.pref_tap_action_entries)[i]));
+
+                        _prefs.setDoubleTapAction(TapAction.fromInteger(i));
+                        dialog.dismiss();
+                    })
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .create());
+
+            return true;
+        });
+    }
+}

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/TapActionsPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/TapActionsPreferencesFragment.java
@@ -22,6 +22,12 @@ public class TapActionsPreferencesFragment extends PreferencesFragment {
         boolean isTapToRevealEnabled = _prefs.isTapToRevealEnabled();
         SwitchPreferenceCompat reserveFirstTap = requirePreference("pref_reserve_first_tap");
         Preference tapActionsHint = requirePreference("pref_tap_actions_hint");
+
+        if (!isTapToRevealEnabled && reserveFirstTap.isChecked()) {
+            reserveFirstTap.setChecked(false);
+            _prefs.setReserveFirstTapEnabled(false);
+        }
+
         reserveFirstTap.setEnabled(isTapToRevealEnabled);
         tapActionsHint.setVisible(isTapToRevealEnabled);
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/TapActionsPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/TapActionsPreferencesFragment.java
@@ -1,6 +1,4 @@
 package com.beemdevelopment.aegis.ui.fragments.preferences;
-
-
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
@@ -22,11 +20,6 @@ public class TapActionsPreferencesFragment extends PreferencesFragment {
         boolean isTapToRevealEnabled = _prefs.isTapToRevealEnabled();
         SwitchPreferenceCompat reserveFirstTap = requirePreference("pref_reserve_first_tap");
         Preference tapActionsHint = requirePreference("pref_tap_actions_hint");
-
-        if (!isTapToRevealEnabled && reserveFirstTap.isChecked()) {
-            reserveFirstTap.setChecked(false);
-            _prefs.setReserveFirstTapEnabled(false);
-        }
 
         reserveFirstTap.setEnabled(isTapToRevealEnabled);
         tapActionsHint.setVisible(isTapToRevealEnabled);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -79,20 +79,12 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private Handler _doubleTapHandler;
     private boolean _pauseFocused;
 
+    // keeps track of the EntryHolders that are currently bound
     private List<EntryHolder> _holders;
-
-    private enum TapPhase {
-        REVEAL_OR_FOCUS,
-        FUNCTION,
-        HIDE_OR_UNFOCUS
-    }
 
     private TapAction _singleTapAction;
     private TapAction _doubleTapAction;
     private boolean _reserveFirstTap;
-
-    @Nullable private VaultEntry _phaseEntry;
-    private TapPhase _tapPhase = TapPhase.REVEAL_OR_FOCUS;
 
     @Nullable private VaultEntry _pendingTapEntry;
     @Nullable private Runnable _pendingSingleTapRunnable;
@@ -196,6 +188,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     public void setEntries(List<VaultEntry> entries) {
+        // TODO: Move these fields to separate dedicated model for the UI
         for (VaultEntry entry : entries) {
             entry.setUsageCount(_usageCounts.containsKey(entry.getUUID()) ? _usageCounts.get(entry.getUUID()) : 0);
             entry.setLastUsedTimestamp(_lastUsedTimestamps.containsKey(entry.getUUID()) ? _lastUsedTimestamps.get(entry.getUUID()) : 0);
@@ -225,6 +218,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         if (_searchFilter != null) {
             String[] tokens = _searchFilter.toLowerCase().split("\\s+");
 
+            // Return true if not all tokens match at least one of the relevant fields
             return !Arrays.stream(tokens)
                     .allMatch(token ->
                             ((_searchBehaviorMask & Preferences.SEARCH_IN_ISSUER) != 0 && issuer.contains(token)) ||
@@ -311,6 +305,9 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         _entryList = newEntryList;
         updatePeriodUniformity();
 
+        // This scroll position trick is required in order to not have the recycler view
+        // jump to some random position after a large change (like resorting entries)
+        // Related: https://issuetracker.google.com/issues/70149059
         int scrollPos = _view.getScrollPosition();
         diffRes.dispatchUpdatesTo(this);
         _view.scrollToPosition(scrollPos);
@@ -374,6 +371,8 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     @Override
     public void onItemDrop(int position) {
+        // moving entries is not allowed when a filter is applied
+        // footer cant be moved, nor can items be moved below it
         if (!_groupFilter.isEmpty() || _entryList.isPositionFooter(position) || _entryList.isPositionErrorCard(position)) {
             return;
         }
@@ -384,18 +383,22 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     @Override
     public void onItemMove(int firstPosition, int secondPosition) {
+        // Moving entries is not allowed when a filter is applied. The footer can't be
+        // moved, nor can items be moved below it
         if (!_groupFilter.isEmpty()
                 || _entryList.isPositionFooter(firstPosition) || _entryList.isPositionFooter(secondPosition)
                 || _entryList.isPositionErrorCard(firstPosition) || _entryList.isPositionErrorCard(secondPosition)) {
             return;
         }
 
+        // Notify the vault about the entry position change first
         int firstIndex = _entryList.translateEntryPosToIndex(firstPosition);
         int secondIndex = _entryList.translateEntryPosToIndex(secondPosition);
         VaultEntry firstEntry = _entryList.getShownEntries().get(firstIndex);
         VaultEntry secondEntry = _entryList.getShownEntries().get(secondIndex);
         _view.onEntryMove(firstEntry, secondEntry);
 
+        // Then update the visual end
         List<VaultEntry> newEntries = new ArrayList<>(_entryList.getEntries());
         CollectionUtils.move(newEntries, newEntries.indexOf(firstEntry), newEntries.indexOf(secondEntry));
         replaceEntryList(new EntryList(
@@ -461,6 +464,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             boolean showProgress = entry.getInfo() instanceof TotpInfo && ((TotpInfo) entry.getInfo()).getPeriod() != getMostFrequentPeriod();
             boolean showAccountName = true;
             if (_onlyShowNecessaryAccountNames) {
+                // Only show account name when there's multiple entries found with the same issuer.
                 showAccountName = _entryList.getEntries().stream()
                         .filter(x -> x.getIssuer().equals(entry.getIssuer()))
                         .count() > 1;
@@ -482,58 +486,32 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         cancelPendingSingleTap();
 
                         if (_selectedEntries.contains(entry)) {
-                            _view.onDeselect(entry);
                             removeSelectedEntry(entry);
                             entryHolder.setFocusedAndAnimate(false);
+                            _view.onDeselect(entry);
                         } else {
                             entryHolder.setFocusedAndAnimate(true);
                             addSelectedEntry(entry);
                             _view.onSelect(entry);
                         }
+
+                        _view.onEntryClick(entry);
                         return;
                     }
 
-                    boolean hasDoubleTapAction = _doubleTapAction != TapAction.NONE;
-
-                    if (!hasDoubleTapAction) {
-                        ensurePhaseForEntry(entry);
-
-                        if (_tapPhase == TapPhase.REVEAL_OR_FOCUS
-                                && _focusedEntry != null
-                                && _focusedEntry.equals(entry)
-                                && (_tapToReveal || _highlightEntry || _tempHighlightEntry)) {
-                            resetFocus();
-                            resetTapPhase();
-                            return;
-                        }
-
-                        if (_tapPhase == TapPhase.REVEAL_OR_FOCUS && needsRevealOrHighlight(entry)) {
-                            focusEntry(entry, _tapToRevealTime);
-                            _tapPhase = TapPhase.FUNCTION;
-
-                            if (_reserveFirstTap) {
-                                return;
-                            }
-                        }
-
-                        if (_reserveFirstTap && _tapPhase == TapPhase.HIDE_OR_UNFOCUS
-                                && _focusedEntry != null && _focusedEntry.equals(entry)) {
-                            resetFocus();
-                            resetTapPhase();
-                            return;
-                        }
-
-                        runTapAction(entryHolder, entry, _singleTapAction);
+                    if (_doubleTapAction == TapAction.NONE) {
+                        handleSingleTap(entryHolder, entry);
                         return;
                     }
 
+                    // Only defer the single-tap flow when it can still become a double tap.
                     if (_pendingSingleTapRunnable != null) {
                         if (_pendingTapEntry != null && _pendingTapEntry.equals(entry)) {
                             cancelPendingSingleTap();
                             runTapAction(entryHolder, entry, _doubleTapAction);
                             return;
                         } else {
-                            cancelPendingSingleTap();
+                            runPendingSingleTap();
                         }
                     }
 
@@ -544,37 +522,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         public void run() {
                             _pendingSingleTapRunnable = null;
                             _pendingTapEntry = null;
-
-                            ensurePhaseForEntry(entry);
-
-                            if (_tapPhase == TapPhase.REVEAL_OR_FOCUS
-                                    && _focusedEntry != null
-                                    && _focusedEntry.equals(entry)
-                                    && (_tapToReveal || _highlightEntry || _tempHighlightEntry)) {
-                                resetFocus();
-                                resetTapPhase();
-                                return;
-                            }
-
-                            if (_tapPhase == TapPhase.REVEAL_OR_FOCUS && needsRevealOrHighlight(entry)) {
-                                focusEntry(entry, _tapToRevealTime);
-
-                                if (_reserveFirstTap) {
-                                    _tapPhase = TapPhase.FUNCTION;
-                                    return;
-                                }
-
-                                _tapPhase = TapPhase.FUNCTION;
-                            }
-
-                            if (_reserveFirstTap && _tapPhase == TapPhase.HIDE_OR_UNFOCUS
-                                    && _focusedEntry != null && _focusedEntry.equals(entry)) {
-                                resetFocus();
-                                resetTapPhase();
-                                return;
-                            }
-
-                            runTapAction(entryHolder, entry, _singleTapAction);
+                            handleSingleTap(entryHolder, entry);
                         }
                     };
 
@@ -603,6 +551,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             entryHolder.itemView.setOnTouchListener(new View.OnTouchListener() {
                 @Override
                 public boolean onTouch(View v, MotionEvent event) {
+                    // Start drag if this is the only item selected
                     if (event.getActionMasked() == MotionEvent.ACTION_MOVE
                             && isEntryDraggable(entryHolder.getEntry())) {
                         _view.startDrag(entryHolder);
@@ -615,6 +564,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             entryHolder.setOnRefreshClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    // this will only be called if the entry is of type HotpInfo
                     try {
                         ((HotpInfo) entry.getInfo()).incrementCounter();
                         focusEntry(entry, _tapToRevealTime);
@@ -622,7 +572,11 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         throw new RuntimeException(e);
                     }
 
+                    // notify the listener that the counter has been incremented
+                    // this gives it a chance to save the vault
                     _view.onEntryChange(entry);
+
+                    // finally, refresh the code in the UI
                     entryHolder.refreshCode();
                 }
             });
@@ -641,31 +595,32 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
     }
 
-    private void resetTapPhase() {
-        _phaseEntry = null;
-        _tapPhase = TapPhase.REVEAL_OR_FOCUS;
-    }
-
-    private void ensurePhaseForEntry(VaultEntry entry) {
-        if (_phaseEntry == null || !_phaseEntry.equals(entry)) {
-            _phaseEntry = entry;
-            _tapPhase = TapPhase.REVEAL_OR_FOCUS;
+    private void runPendingSingleTap() {
+        Runnable runnable = _pendingSingleTapRunnable;
+        if (runnable != null) {
+            _doubleTapHandler.removeCallbacks(runnable);
+            runnable.run();
         }
     }
 
-    private boolean needsRevealOrHighlight(VaultEntry entry) {
-        if (_tapToReveal && (_focusedEntry == null || !_focusedEntry.equals(entry))) {
-            return true;
+    private void handleSingleTap(EntryHolder entryHolder, VaultEntry entry) {
+        if ((_tapToReveal || _highlightEntry || _tempHighlightEntry)
+                && entry.equals(_focusedEntry)) {
+            resetFocus();
+        } else if (_tapToReveal || _highlightEntry || _tempHighlightEntry) {
+            focusEntry(entry, _tapToRevealTime);
+
+            // Highlighting is visual feedback, so only hidden codes can reserve the first tap.
+            if (_tapToReveal && _reserveFirstTap) {
+                incrementUsageCount(entry);
+                return;
+            }
         }
-        if ((_highlightEntry || _tempHighlightEntry) && (_focusedEntry == null || !_focusedEntry.equals(entry))) {
-            return true;
-        }
-        return false;
+
+        runTapAction(entryHolder, entry, _singleTapAction);
     }
 
     private void runTapAction(EntryHolder entryHolder, VaultEntry entry, TapAction action) {
-        ensurePhaseForEntry(entry);
-
         boolean handled = false;
 
         switch (action) {
@@ -689,8 +644,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         if (!handled) {
             _view.onEntryClick(entry);
         }
-
-        _tapPhase = TapPhase.HIDE_OR_UNFOCUS;
     }
 
     private void updatePeriodUniformity() {
@@ -797,8 +750,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
         _focusedEntry = null;
         _tempHighlightEntry = false;
-
-        resetTapPhase();
     }
 
     private void updateDraggableStatus() {
@@ -956,6 +907,8 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
 
         public int getItemCount() {
+            // Always at least one item because of the footer
+            // Two in case there's also an error card
             int baseCount = 1;
             if (isErrorCardShown()) {
                 baseCount++;
@@ -981,6 +934,9 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             return position == (getItemCount() - 1);
         }
 
+        /**
+         * Translates the given entry position in the recycler view, to its index in the shown entries list.
+         */
         public int translateEntryPosToIndex(int position) {
             if (position == NO_POSITION) {
                 return NO_POSITION;
@@ -993,6 +949,9 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             return position;
         }
 
+        /**
+         * Translates the given entry index in the shown entries list, to its position in the recycler view.
+         */
         public int translateEntryIndexToPos(int index) {
             if (index == NO_POSITION) {
                 return NO_POSITION;

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -20,10 +20,10 @@ import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.beemdevelopment.aegis.AccountNamePosition;
-import com.beemdevelopment.aegis.CopyBehavior;
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
+import com.beemdevelopment.aegis.TapAction;
 import com.beemdevelopment.aegis.ViewMode;
 import com.beemdevelopment.aegis.helpers.ItemTouchHelperAdapter;
 import com.beemdevelopment.aegis.helpers.comparators.FavoriteComparator;
@@ -58,7 +58,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private Map<UUID, Integer> _usageCounts;
     private Map<UUID, Long> _lastUsedTimestamps;
     private VaultEntry _focusedEntry;
-    private VaultEntry _clickedEntry;
     private Preferences.CodeGrouping _codeGroupSize;
     private AccountNamePosition _accountNamePosition;
     private boolean _showIcon;
@@ -69,7 +68,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private boolean _tempHighlightEntry;
     private boolean _tapToReveal;
     private int _tapToRevealTime;
-    private CopyBehavior _copyBehavior;
     private int _searchBehaviorMask;
     private Set<UUID> _groupFilter;
     private SortCategory _sortCategory;
@@ -81,8 +79,23 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private Handler _doubleTapHandler;
     private boolean _pauseFocused;
 
-    // keeps track of the EntryHolders that are currently bound
     private List<EntryHolder> _holders;
+
+    private enum TapPhase {
+        REVEAL_OR_FOCUS,
+        FUNCTION,
+        HIDE_OR_UNFOCUS
+    }
+
+    private TapAction _singleTapAction;
+    private TapAction _doubleTapAction;
+    private boolean _reserveFirstTap;
+
+    @Nullable private VaultEntry _phaseEntry;
+    private TapPhase _tapPhase = TapPhase.REVEAL_OR_FOCUS;
+
+    @Nullable private VaultEntry _pendingTapEntry;
+    @Nullable private Runnable _pendingSingleTapRunnable;
 
     public EntryAdapter(EntryListView view) {
         _entryList = new EntryList();
@@ -95,6 +108,9 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     public void destroy() {
+        _doubleTapHandler.removeCallbacksAndMessages(null);
+        _dimHandler.removeCallbacksAndMessages(null);
+
         for (EntryHolder holder : _holders) {
             holder.destroy();
         }
@@ -141,7 +157,17 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         _tempHighlightEntry = highlightEntry;
     }
 
-    public void setCopyBehavior(CopyBehavior copyBehavior) { _copyBehavior = copyBehavior; }
+    public void setSingleTapAction(TapAction action) {
+        _singleTapAction = action;
+    }
+
+    public void setDoubleTapAction(TapAction action) {
+        _doubleTapAction = action;
+    }
+
+    public void setReserveFirstTap(boolean reserveFirstTap) {
+        _reserveFirstTap = reserveFirstTap;
+    }
 
     public void setSearchBehaviorMask(int searchBehaviorMask) { _searchBehaviorMask = searchBehaviorMask; }
 
@@ -170,7 +196,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     public void setEntries(List<VaultEntry> entries) {
-        // TODO: Move these fields to separate dedicated model for the UI
         for (VaultEntry entry : entries) {
             entry.setUsageCount(_usageCounts.containsKey(entry.getUUID()) ? _usageCounts.get(entry.getUUID()) : 0);
             entry.setLastUsedTimestamp(_lastUsedTimestamps.containsKey(entry.getUUID()) ? _lastUsedTimestamps.get(entry.getUUID()) : 0);
@@ -200,7 +225,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         if (_searchFilter != null) {
             String[] tokens = _searchFilter.toLowerCase().split("\\s+");
 
-            // Return true if not all tokens match at least one of the relevant fields
             return !Arrays.stream(tokens)
                     .allMatch(token ->
                             ((_searchBehaviorMask & Preferences.SEARCH_IN_ISSUER) != 0 && issuer.contains(token)) ||
@@ -287,9 +311,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         _entryList = newEntryList;
         updatePeriodUniformity();
 
-        // This scroll position trick is required in order to not have the recycler view
-        // jump to some random position after a large change (like resorting entries)
-        // Related: https://issuetracker.google.com/issues/70149059
         int scrollPos = _view.getScrollPosition();
         diffRes.dispatchUpdatesTo(this);
         _view.scrollToPosition(scrollPos);
@@ -353,8 +374,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     @Override
     public void onItemDrop(int position) {
-        // moving entries is not allowed when a filter is applied
-        // footer cant be moved, nor can items be moved below it
         if (!_groupFilter.isEmpty() || _entryList.isPositionFooter(position) || _entryList.isPositionErrorCard(position)) {
             return;
         }
@@ -365,22 +384,18 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     @Override
     public void onItemMove(int firstPosition, int secondPosition) {
-        // Moving entries is not allowed when a filter is applied. The footer can't be
-        // moved, nor can items be moved below it
         if (!_groupFilter.isEmpty()
                 || _entryList.isPositionFooter(firstPosition) || _entryList.isPositionFooter(secondPosition)
                 || _entryList.isPositionErrorCard(firstPosition) || _entryList.isPositionErrorCard(secondPosition)) {
             return;
         }
 
-        // Notify the vault about the entry position change first
         int firstIndex = _entryList.translateEntryPosToIndex(firstPosition);
         int secondIndex = _entryList.translateEntryPosToIndex(secondPosition);
         VaultEntry firstEntry = _entryList.getShownEntries().get(firstIndex);
         VaultEntry secondEntry = _entryList.getShownEntries().get(secondIndex);
         _view.onEntryMove(firstEntry, secondEntry);
 
-        // Then update the visual end
         List<VaultEntry> newEntries = new ArrayList<>(_entryList.getEntries());
         CollectionUtils.move(newEntries, newEntries.indexOf(firstEntry), newEntries.indexOf(secondEntry));
         replaceEntryList(new EntryList(
@@ -446,7 +461,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             boolean showProgress = entry.getInfo() instanceof TotpInfo && ((TotpInfo) entry.getInfo()).getPeriod() != getMostFrequentPeriod();
             boolean showAccountName = true;
             if (_onlyShowNecessaryAccountNames) {
-                // Only show account name when there's multiple entries found with the same issuer.
                 showAccountName = _entryList.getEntries().stream()
                         .filter(x -> x.getIssuer().equals(entry.getIssuer()))
                         .count() > 1;
@@ -464,43 +478,9 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             entryHolder.itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    boolean handled = false;
+                    if (!_selectedEntries.isEmpty()) {
+                        cancelPendingSingleTap();
 
-                    if (_selectedEntries.isEmpty()) {
-                        if (_highlightEntry || _tempHighlightEntry || _tapToReveal) {
-                            if (_focusedEntry != null && _focusedEntry.equals(entry)) {
-                                resetFocus();
-                            } else {
-                                focusEntry(entry, _tapToRevealTime);
-
-                                // Prevent copying when singletap is set and the entry is being revealed
-                                handled = _copyBehavior == CopyBehavior.SINGLETAP && _tapToReveal;
-                            }
-                        }
-
-                        switch (_copyBehavior) {
-                            case SINGLETAP:
-                                if (!handled) {
-                                    _view.onEntryCopy(entry);
-                                    entryHolder.animateCopyText();
-                                    _clickedEntry = null;
-                                }
-                                break;
-                            case DOUBLETAP:
-                                _doubleTapHandler.postDelayed(() -> _clickedEntry = null, ViewConfiguration.getDoubleTapTimeout());
-
-                                if(entry == _clickedEntry) {
-                                    _view.onEntryCopy(entry);
-                                    entryHolder.animateCopyText();
-                                    _clickedEntry = null;
-                                } else {
-                                    _clickedEntry = entry;
-                                }
-                                break;
-                        }
-
-                        incrementUsageCount(entry);
-                    } else {
                         if (_selectedEntries.contains(entry)) {
                             _view.onDeselect(entry);
                             removeSelectedEntry(entry);
@@ -510,13 +490,54 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                             addSelectedEntry(entry);
                             _view.onSelect(entry);
                         }
+                        return;
                     }
 
-                    if (!handled) {
-                        _view.onEntryClick(entry);
+                    ensurePhaseForEntry(entry);
+
+                    if (_tapPhase == TapPhase.REVEAL_OR_FOCUS && needsRevealOrHighlight(entry)) {
+                        focusEntry(entry, _tapToRevealTime);
+                        _tapPhase = TapPhase.FUNCTION;
+
+                        if (_reserveFirstTap) {
+                            return;
+                        }
                     }
+
+                    if (_reserveFirstTap && _tapPhase == TapPhase.HIDE_OR_UNFOCUS
+                            && _focusedEntry != null && _focusedEntry.equals(entry)) {
+                        cancelPendingSingleTap();
+                        resetFocus();
+                        resetTapPhase();
+                        return;
+                    }
+
+                    if (_pendingSingleTapRunnable != null) {
+                        if (_pendingTapEntry != null && _pendingTapEntry.equals(entry)) {
+                            cancelPendingSingleTap();
+                            runTapAction(entryHolder, entry, _doubleTapAction);
+                            return;
+                        } else {
+                            cancelPendingSingleTap();
+                        }
+                    }
+
+                    _pendingTapEntry = entry;
+
+                    _pendingSingleTapRunnable = new Runnable() {
+                        @Override
+                        public void run() {
+                            _pendingSingleTapRunnable = null;
+                            _pendingTapEntry = null;
+
+                            runTapAction(entryHolder, entry, _singleTapAction);
+                        }
+                    };
+
+                    _doubleTapHandler.postDelayed(_pendingSingleTapRunnable, ViewConfiguration.getDoubleTapTimeout());
                 }
             });
+
             entryHolder.itemView.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
@@ -534,10 +555,10 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                     return returnVal;
                 }
             });
+
             entryHolder.itemView.setOnTouchListener(new View.OnTouchListener() {
                 @Override
                 public boolean onTouch(View v, MotionEvent event) {
-                    // Start drag if this is the only item selected
                     if (event.getActionMasked() == MotionEvent.ACTION_MOVE
                             && isEntryDraggable(entryHolder.getEntry())) {
                         _view.startDrag(entryHolder);
@@ -546,10 +567,10 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                     return false;
                 }
             });
+
             entryHolder.setOnRefreshClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    // this will only be called if the entry is of type HotpInfo
                     try {
                         ((HotpInfo) entry.getInfo()).incrementCounter();
                         focusEntry(entry, _tapToRevealTime);
@@ -557,11 +578,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         throw new RuntimeException(e);
                     }
 
-                    // notify the listener that the counter has been incremented
-                    // this gives it a chance to save the vault
                     _view.onEntryChange(entry);
-
-                    // finally, refresh the code in the UI
                     entryHolder.refreshCode();
                 }
             });
@@ -570,6 +587,66 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         } else if (holder instanceof FooterView) {
             ((FooterView) holder).refresh();
         }
+    }
+
+    private void cancelPendingSingleTap() {
+        if (_pendingSingleTapRunnable != null) {
+            _doubleTapHandler.removeCallbacks(_pendingSingleTapRunnable);
+            _pendingSingleTapRunnable = null;
+            _pendingTapEntry = null;
+        }
+    }
+
+    private void resetTapPhase() {
+        _phaseEntry = null;
+        _tapPhase = TapPhase.REVEAL_OR_FOCUS;
+    }
+
+    private void ensurePhaseForEntry(VaultEntry entry) {
+        if (_phaseEntry == null || !_phaseEntry.equals(entry)) {
+            _phaseEntry = entry;
+            _tapPhase = TapPhase.REVEAL_OR_FOCUS;
+        }
+    }
+
+    private boolean needsRevealOrHighlight(VaultEntry entry) {
+        if (_tapToReveal && (_focusedEntry == null || !_focusedEntry.equals(entry))) {
+            return true;
+        }
+        if ((_highlightEntry || _tempHighlightEntry) && (_focusedEntry == null || !_focusedEntry.equals(entry))) {
+            return true;
+        }
+        return false;
+    }
+
+    private void runTapAction(EntryHolder entryHolder, VaultEntry entry, TapAction action) {
+        ensurePhaseForEntry(entry);
+
+        boolean handled = false;
+
+        switch (action) {
+            case COPY:
+                _view.onEntryCopy(entry);
+                entryHolder.animateCopyText();
+                handled = true;
+                break;
+
+            case EDIT:
+                _view.onEntryEdit(entry);
+                handled = true;
+                break;
+
+            case NONE:
+                break;
+        }
+
+        incrementUsageCount(entry);
+
+        if (!handled) {
+            _view.onEntryClick(entry);
+        }
+
+        _tapPhase = TapPhase.HIDE_OR_UNFOCUS;
     }
 
     private void updatePeriodUniformity() {
@@ -676,6 +753,8 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
         _focusedEntry = null;
         _tempHighlightEntry = false;
+
+        resetTapPhase();
     }
 
     private void updateDraggableStatus() {
@@ -833,8 +912,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
 
         public int getItemCount() {
-            // Always at least one item because of the footer
-            // Two in case there's also an error card
             int baseCount = 1;
             if (isErrorCardShown()) {
                 baseCount++;
@@ -860,9 +937,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             return position == (getItemCount() - 1);
         }
 
-        /**
-         * Translates the given entry position in the recycler view, to its index in the shown entries list.
-         */
         public int translateEntryPosToIndex(int position) {
             if (position == NO_POSITION) {
                 return NO_POSITION;
@@ -875,9 +949,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             return position;
         }
 
-        /**
-         * Translates the given entry index in the shown entries list, to its position in the recycler view.
-         */
         public int translateEntryIndexToPos(int index) {
             if (index == NO_POSITION) {
                 return NO_POSITION;
@@ -957,6 +1028,7 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         void onEntryDrop(VaultEntry entry);
         void onEntryChange(VaultEntry entry);
         void onEntryCopy(VaultEntry entry);
+        void onEntryEdit(VaultEntry entry);
         void onPeriodUniformityChanged(boolean uniform, int period);
         void onSelect(VaultEntry entry);
         void onDeselect(VaultEntry entry);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -493,22 +493,37 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         return;
                     }
 
-                    ensurePhaseForEntry(entry);
+                    boolean hasDoubleTapAction = _doubleTapAction != TapAction.NONE;
 
-                    if (_tapPhase == TapPhase.REVEAL_OR_FOCUS && needsRevealOrHighlight(entry)) {
-                        focusEntry(entry, _tapToRevealTime);
-                        _tapPhase = TapPhase.FUNCTION;
+                    if (!hasDoubleTapAction) {
+                        ensurePhaseForEntry(entry);
 
-                        if (_reserveFirstTap) {
+                        if (_tapPhase == TapPhase.REVEAL_OR_FOCUS
+                                && _focusedEntry != null
+                                && _focusedEntry.equals(entry)
+                                && (_tapToReveal || _highlightEntry || _tempHighlightEntry)) {
+                            resetFocus();
+                            resetTapPhase();
                             return;
                         }
-                    }
 
-                    if (_reserveFirstTap && _tapPhase == TapPhase.HIDE_OR_UNFOCUS
-                            && _focusedEntry != null && _focusedEntry.equals(entry)) {
-                        cancelPendingSingleTap();
-                        resetFocus();
-                        resetTapPhase();
+                        if (_tapPhase == TapPhase.REVEAL_OR_FOCUS && needsRevealOrHighlight(entry)) {
+                            focusEntry(entry, _tapToRevealTime);
+                            _tapPhase = TapPhase.FUNCTION;
+
+                            if (_reserveFirstTap) {
+                                return;
+                            }
+                        }
+
+                        if (_reserveFirstTap && _tapPhase == TapPhase.HIDE_OR_UNFOCUS
+                                && _focusedEntry != null && _focusedEntry.equals(entry)) {
+                            resetFocus();
+                            resetTapPhase();
+                            return;
+                        }
+
+                        runTapAction(entryHolder, entry, _singleTapAction);
                         return;
                     }
 
@@ -529,6 +544,35 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         public void run() {
                             _pendingSingleTapRunnable = null;
                             _pendingTapEntry = null;
+
+                            ensurePhaseForEntry(entry);
+
+                            if (_tapPhase == TapPhase.REVEAL_OR_FOCUS
+                                    && _focusedEntry != null
+                                    && _focusedEntry.equals(entry)
+                                    && (_tapToReveal || _highlightEntry || _tempHighlightEntry)) {
+                                resetFocus();
+                                resetTapPhase();
+                                return;
+                            }
+
+                            if (_tapPhase == TapPhase.REVEAL_OR_FOCUS && needsRevealOrHighlight(entry)) {
+                                focusEntry(entry, _tapToRevealTime);
+
+                                if (_reserveFirstTap) {
+                                    _tapPhase = TapPhase.FUNCTION;
+                                    return;
+                                }
+
+                                _tapPhase = TapPhase.FUNCTION;
+                            }
+
+                            if (_reserveFirstTap && _tapPhase == TapPhase.HIDE_OR_UNFOCUS
+                                    && _focusedEntry != null && _focusedEntry.equals(entry)) {
+                                resetFocus();
+                                resetTapPhase();
+                                return;
+                            }
 
                             runTapAction(entryHolder, entry, _singleTapAction);
                         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -29,7 +29,6 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.beemdevelopment.aegis.AccountNamePosition;
-import com.beemdevelopment.aegis.CopyBehavior;
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryListView.java
@@ -33,6 +33,7 @@ import com.beemdevelopment.aegis.CopyBehavior;
 import com.beemdevelopment.aegis.Preferences;
 import com.beemdevelopment.aegis.R;
 import com.beemdevelopment.aegis.SortCategory;
+import com.beemdevelopment.aegis.TapAction;
 import com.beemdevelopment.aegis.VibrationPatterns;
 import com.beemdevelopment.aegis.ViewMode;
 import com.beemdevelopment.aegis.helpers.AnimationsHelper;
@@ -231,10 +232,6 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         _touchCallback.setIsLongPressDragEnabled(enabled && _adapter.isDragAndDropAllowed());
     }
 
-    public void setCopyBehavior(CopyBehavior copyBehavior) {
-        _adapter.setCopyBehavior(copyBehavior);
-    }
-
     public void setSearchBehaviorMask(int searchBehaviorMask) {
         _adapter.setSearchBehaviorMask(searchBehaviorMask);
     }
@@ -359,6 +356,13 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
     }
 
     @Override
+    public void onEntryEdit(VaultEntry entry) {
+        if (_listener != null) {
+            _listener.onEntryEdit(entry);
+        }
+    }
+
+    @Override
     public void onSelect(VaultEntry entry) {
         if (_listener != null) {
             _listener.onSelect(entry);
@@ -420,6 +424,18 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
 
     public void setHighlightEntry(boolean highlightEntry) {
         _adapter.setHighlightEntry(highlightEntry);
+    }
+
+    public void setSingleTapAction(TapAction action) {
+        _adapter.setSingleTapAction(action);
+    }
+
+    public void setDoubleTapAction(TapAction action) {
+        _adapter.setDoubleTapAction(action);
+    }
+
+    public void setReserveFirstTap(boolean reserveFirstTap) {
+        _adapter.setReserveFirstTap(reserveFirstTap);
     }
 
     public void setPauseFocused(boolean pauseFocused) {
@@ -555,6 +571,7 @@ public class EntryListView extends Fragment implements EntryAdapter.Listener {
         void onEntryChange(VaultEntry entry);
         void onEntryCopy(VaultEntry entry);
         void onLongEntryClick(VaultEntry entry);
+        void onEntryEdit(VaultEntry entry);
         void onScroll(int dx, int dy);
         void onSelect(VaultEntry entry);
         void onDeselect(VaultEntry entry);

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -319,7 +319,6 @@
     <string name="choose_theme">حدد السمة المطلوبة</string>
     <string name="choose_account_name_position">حدد موضع اسم الحساب المطلوب</string>
     <string name="choose_view_mode">حدد وضع العرض المطلوب</string>
-    <string name="choose_copy_behavior">حدد سلوك نُسختك</string>
     <string name="parsing_file_error">حدث خطأ أثناء محاولة تحليل الملف</string>
     <string name="file_not_found">خطأ: لم يتم العثور على الملف</string>
     <string name="reading_file_error">حدث خطأ أثناء محاولة قراءة الملف</string>
@@ -424,7 +423,6 @@
     <string name="pref_groups_multiselect_summary">السماح باختيار مجموعات متعددة في نفس الوقت</string>
     <string name="pref_minimize_on_copy_title">تصغير عند النسخ</string>
     <string name="pref_minimize_on_copy_summary">تصغير التطبيق بعد نسخ رمز</string>
-    <string name="pref_copy_behavior_title">انسخ الرموز إلى الحافظة</string>
     <string name="pref_search_behavior_title">سلوك البحث</string>
     <string name="pref_pause_entry_title">جمّد الرموز عند النقر عليها</string>
     <string name="pref_pause_entry_summary">أوقف التحديث التلقائي للرموز عن طريق النقر عليها. لن يُحدِّث الرموز مادام أنها مُركّزة. يتطلب \"ابرز الرموز عندما تُنقر\" أو \"انقر للكشف\".</string>
@@ -604,9 +602,6 @@
     <string name="pref_grouping_size_two">مجموعات من 2</string>
     <string name="pref_grouping_size_three">مجموعات من 3</string>
     <string name="pref_grouping_size_four">مجموعات من 4</string>
-    <string name="pref_copy_behavior_never">أبدًا</string>
-    <string name="pref_copy_behavior_single_tap">نقرة واحدة</string>
-    <string name="pref_copy_behavior_double_tap">نقرتين</string>
     <string name="pref_account_name_position_hidden">مختفي</string>
     <string name="pref_account_name_position_end">بجانب المصدر</string>
     <string name="pref_account_name_position_below">أسفل المصدر</string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -461,9 +461,6 @@
     <string name="pref_grouping_size_two">Grupos de 2</string>
     <string name="pref_grouping_size_three">Grupos de 3</string>
     <string name="pref_grouping_size_four">Grupos de 4</string>
-    <string name="pref_copy_behavior_never">Enxamás</string>
-    <string name="pref_copy_behavior_single_tap">Un toque</string>
-    <string name="pref_copy_behavior_double_tap">Dos toques</string>
     <string name="pref_account_name_position_end">Al llau l\'emisor</string>
     <string name="pref_account_name_position_below">Embaxo l\'emisor</string>
     <plurals name="time_elapsed_minutes" tools:ignore="UnusedResources">

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Изберете желаната тема</string>
     <string name="choose_account_name_position">Изберете къде да бъде показано името на профила</string>
     <string name="choose_view_mode">Изберете желания изглед на списъка</string>
-    <string name="choose_copy_behavior">Изберете действие, което да копира</string>
     <string name="parsing_file_error">Грешка при анализиране на файла</string>
     <string name="file_not_found">Грешка: Файлът не е намерен</string>
     <string name="reading_file_error">Грешка при прочитане на файла</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Дава възможност за избиране на няколко групи едновременно</string>
     <string name="pref_minimize_on_copy_title">Свиване при копиране</string>
     <string name="pref_minimize_on_copy_summary">Приложението се свива при копиране на код за достъп</string>
-    <string name="pref_copy_behavior_title">Копиране на кодове за защита в междинната памет</string>
     <string name="pref_search_behavior_title">Начин на търсене</string>
     <string name="pref_pause_entry_title">Замразяване на запис при докосване</string>
     <string name="pref_pause_entry_summary">Спира автоматичното опресняване на кодовете след докосване. Необходимо е да е включено или „Осветяване на запис при докосване“, или „Показване при докосване“.</string>
@@ -549,9 +547,6 @@
     <string name="pref_grouping_size_two">В групи по 2</string>
     <string name="pref_grouping_size_three">В групи по 3</string>
     <string name="pref_grouping_size_four">В групи по 4</string>
-    <string name="pref_copy_behavior_never">Никога</string>
-    <string name="pref_copy_behavior_single_tap">Единично докосване</string>
-    <string name="pref_copy_behavior_double_tap">Двойно докосване</string>
     <string name="pref_account_name_position_hidden">Скрито</string>
     <string name="pref_account_name_position_end">До издателя</string>
     <string name="pref_account_name_position_below">Под издателя</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Tria l\'aparença</string>
     <string name="choose_account_name_position">Selecciona la posició del nom del compte que desitges</string>
     <string name="choose_view_mode">Tria el mode de visualització</string>
-    <string name="choose_copy_behavior">Selecciona el comportament de còpia que desitges</string>
     <string name="parsing_file_error">S\'ha produït un error en analitzar el fitxer</string>
     <string name="file_not_found">Error: no s\'ha trobat el fitxer</string>
     <string name="reading_file_error">S\'ha produït un error mentre s\'intentava carregar el fitxer</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Permet la selecció de múltiples grups al mateix temps</string>
     <string name="pref_minimize_on_copy_title">Minimitzar al copiar</string>
     <string name="pref_minimize_on_copy_summary">Minimitzar l\'aplicació després de copiar una fitxa</string>
-    <string name="pref_copy_behavior_title">Copia les fitxes al porta-retalls</string>
     <string name="pref_search_behavior_title">Comportament de la cerca</string>
     <string name="pref_pause_entry_title">Congela la fitxa al tocar</string>
     <string name="pref_pause_entry_summary">Pausa l\'actualització automàtica de la fitxa al tocar-la. No s\'actualitzará mentre estigui marcada. Cal tenir \"Il·lumina les fitxes al tocar\" o \"Toca per a mostrar\".</string>
@@ -547,9 +545,6 @@
     <string name="pref_grouping_size_two">Grups de 2</string>
     <string name="pref_grouping_size_three">Grups de 3</string>
     <string name="pref_grouping_size_four">Grups de 4</string>
-    <string name="pref_copy_behavior_never">Mai</string>
-    <string name="pref_copy_behavior_single_tap">Un toc</string>
-    <string name="pref_copy_behavior_double_tap">Doble toc</string>
     <string name="pref_account_name_position_hidden">Ocult</string>
     <string name="pref_account_name_position_end">Al costat de l\'emissor</string>
     <string name="pref_account_name_position_below">A sota de l\'emissor</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -307,7 +307,6 @@
     <string name="choose_theme">Vyberte si vzhled rozhraní</string>
     <string name="choose_account_name_position">Vyberte požadovanou pozici názvu účtu</string>
     <string name="choose_view_mode">Vyberte si režim zobrazení</string>
-    <string name="choose_copy_behavior">Vyberte požadované chování kopírování</string>
     <string name="parsing_file_error">Při zpracování souboru došlo k chybě</string>
     <string name="file_not_found">Chyba: Soubor nenalezen</string>
     <string name="reading_file_error">Při pokusu o čtení souboru došlo k chybě</string>
@@ -404,7 +403,6 @@
     <string name="pref_groups_multiselect_summary">Povolit současný výběr více skupin</string>
     <string name="pref_minimize_on_copy_title">Minimalizovat při kopírování</string>
     <string name="pref_minimize_on_copy_summary">Minimalizovat aplikaci po zkopírování tokenu</string>
-    <string name="pref_copy_behavior_title">Zkopírovat tokeny do schránky</string>
     <string name="pref_search_behavior_title">Chování vyhledávání</string>
     <string name="pref_pause_entry_title">Zmrazit tokeny po klepnutí</string>
     <string name="pref_pause_entry_summary">Pozastavit automatické obnovování tokenů klepnutím na ně. Tokeny nebudou aktualizovány, dokud jsou zaměřeny. Vyžaduje \"Zvýraznit tokeny po klepnutí\" nebo \"Klepnutím zobrazit\".</string>
@@ -576,9 +574,6 @@
     <string name="pref_grouping_size_two">Skupiny 2</string>
     <string name="pref_grouping_size_three">Skupiny 3</string>
     <string name="pref_grouping_size_four">Skupiny 4</string>
-    <string name="pref_copy_behavior_never">Nikdy</string>
-    <string name="pref_copy_behavior_single_tap">Jedno klepnutí</string>
-    <string name="pref_copy_behavior_double_tap">Dvojité klepnutí</string>
     <string name="pref_account_name_position_hidden">Skryté</string>
     <string name="pref_account_name_position_end">Vedle poskytovatele</string>
     <string name="pref_account_name_position_below">Pod poskytovatelem</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Vælg ønskede tema</string>
     <string name="choose_account_name_position">Vælg ønskede placering af kontonavn</string>
     <string name="choose_view_mode">Vælg ønskede visningstilstand</string>
-    <string name="choose_copy_behavior">Vælg ønskede kopieringsadfærd</string>
     <string name="parsing_file_error">En fejl opstod under forsøget på at fortolke filen</string>
     <string name="file_not_found">Fejl: Fil ikke fundet</string>
     <string name="reading_file_error">En fejl opstod under forsøg på at læse filen</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Muliggør valg af flere grupper samtidig</string>
     <string name="pref_minimize_on_copy_title">Minimér under kopiering</string>
     <string name="pref_minimize_on_copy_summary">Minimér appen efter kopiering af et token</string>
-    <string name="pref_copy_behavior_title">Kopiér tokener til udklipsholder</string>
     <string name="pref_search_behavior_title">Søgeadfærd</string>
     <string name="pref_pause_entry_title">Frys tokener ved tryk</string>
     <string name="pref_pause_entry_summary">Pausér automatisk opdatering af tokener ved at trykke på dem. Tokener opdateres ikke, så længe de er fokuseret. Kræver \"Fremhæv tokener ved tryk\" eller \"Tryk for at vise\".</string>
@@ -548,9 +546,6 @@
     <string name="pref_grouping_size_two">Grupper af 2</string>
     <string name="pref_grouping_size_three">Grupper af 3</string>
     <string name="pref_grouping_size_four">Grupper af 4</string>
-    <string name="pref_copy_behavior_never">Aldrig</string>
-    <string name="pref_copy_behavior_single_tap">Enkelt tryk</string>
-    <string name="pref_copy_behavior_double_tap">Dobbelttryk</string>
     <string name="pref_account_name_position_hidden">Skjult</string>
     <string name="pref_account_name_position_end">Ved siden af udstederen</string>
     <string name="pref_account_name_position_below">Under udstederen</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Wähle das gewünschte Design aus</string>
     <string name="choose_account_name_position">Wähle die gewünschte Position des Kontonamens</string>
     <string name="choose_view_mode">Wähle den gewünschten Darstellungsstil aus</string>
-    <string name="choose_copy_behavior">Wähle dein gewünschtes Verhalten fürs Kopieren</string>
     <string name="parsing_file_error">Beim Analysieren der Datei ist ein Fehler aufgetreten</string>
     <string name="file_not_found">Fehler: Datei nicht gefunden</string>
     <string name="reading_file_error">Beim Lesen der Datei ist ein Fehler aufgetreten</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Das Auswählen mehrerer Gruppen auf einmal ermöglichen</string>
     <string name="pref_minimize_on_copy_title">Beim Kopieren minimieren</string>
     <string name="pref_minimize_on_copy_summary">App nach dem Kopieren eines Tokens minimieren</string>
-    <string name="pref_copy_behavior_title">Token in die Zwischenablage kopieren</string>
     <string name="pref_search_behavior_title">Suchverhalten</string>
     <string name="pref_pause_entry_title">Token beim Antippen einfrieren</string>
     <string name="pref_pause_entry_summary">Automatisches Aktualisieren der Token durch Antippen anhalten. Die Token werden nicht aktualisiert, solange sie hervorgehoben sind. Erfordert »Token beim Antippen hervorheben« oder »Zum Aufdecken antippen«.</string>
@@ -548,9 +546,6 @@
     <string name="pref_grouping_size_two">2er-Gruppen</string>
     <string name="pref_grouping_size_three">3er-Gruppen</string>
     <string name="pref_grouping_size_four">4er-Gruppen</string>
-    <string name="pref_copy_behavior_never">Niemals</string>
-    <string name="pref_copy_behavior_single_tap">Einmal antippen</string>
-    <string name="pref_copy_behavior_double_tap">Zweimal antippen</string>
     <string name="pref_account_name_position_hidden">Ausgeblendet</string>
     <string name="pref_account_name_position_end">Neben dem Herausgeber</string>
     <string name="pref_account_name_position_below">Unterhalb des Herausgebers</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Επιλέξτε το θέμα που θέλετε</string>
     <string name="choose_account_name_position">Επιλέξτε την επιθυμητή θέση ονόματος λογαριασμού</string>
     <string name="choose_view_mode">Επιλέξτε τη λειτουργία προβολής που θέλετε</string>
-    <string name="choose_copy_behavior">Επιλέξτε την επιθυμητή συμπεριφορά αντιγραφής</string>
     <string name="parsing_file_error">Παρουσιάστηκε σφάλμα κατά την προσπάθεια ανάλυσης του αρχείου</string>
     <string name="file_not_found">Σφάλμα: Το αρχείο δεν βρέθηκε</string>
     <string name="reading_file_error">Παρουσιάστηκε σφάλμα κατά την προσπάθεια ανάγνωσης του αρχείου</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Να επιτρέπεται η επιλογή πολλαπλών ομάδων ταυτόχρονα</string>
     <string name="pref_minimize_on_copy_title">Ελαχιστοποίηση κατά την αντιγραφή</string>
     <string name="pref_minimize_on_copy_summary">Ελαχιστοποίηση της εφαρμογής μετά την αντιγραφή ενός αναγνωριστικού</string>
-    <string name="pref_copy_behavior_title">Αντιγραφή αναγνωριστικών στο πρόχειρο</string>
     <string name="pref_search_behavior_title">Συμπεριφορά αναζήτησης</string>
     <string name="pref_pause_entry_title">Πάγωμα αναγνωριστικών όταν πατηθούν</string>
     <string name="pref_pause_entry_summary">Παύση της αυτόματης ανανέωσης των αναγνωριστικών πατώντας τα. Τα αναγνωριστικά δεν θα ενημερώνονται όσο είναι συγκεντρωμένα. Απαιτεί \"Επισήμανση αναγνωριστικών όταν πατηθούν\" ή \"Πατήστε για αποκάλυψη\".</string>
@@ -548,9 +546,6 @@
     <string name="pref_grouping_size_two">Ομάδες των 2</string>
     <string name="pref_grouping_size_three">Ομάδες των 3</string>
     <string name="pref_grouping_size_four">Ομάδες των 4</string>
-    <string name="pref_copy_behavior_never">Ποτέ</string>
-    <string name="pref_copy_behavior_single_tap">Μονό άγγιγμα</string>
-    <string name="pref_copy_behavior_double_tap">Διπλό άγγιγμα</string>
     <string name="pref_account_name_position_hidden">Κρυφό</string>
     <string name="pref_account_name_position_end">Δίπλα στον εκδότη</string>
     <string name="pref_account_name_position_below">Κάτω από τον εκδότη</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Elige el esquema de colores que más te guste</string>
     <string name="choose_account_name_position">Elige una posición para ubicar el nombre de la cuenta</string>
     <string name="choose_view_mode">Elige un modo de visualización</string>
-    <string name="choose_copy_behavior">Seleccione el comportamiento de copia deseado</string>
     <string name="parsing_file_error">Se ha producido un error al intentar procesar el archivo</string>
     <string name="file_not_found">Error: Archivo no encontrado</string>
     <string name="reading_file_error">Se ha producido un error al intentar leer el archivo</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Permite seleccionar varios grupos a la vez</string>
     <string name="pref_minimize_on_copy_title">Minimizar al copiar</string>
     <string name="pref_minimize_on_copy_summary">Minimiza la aplicación tras copiar claves</string>
-    <string name="pref_copy_behavior_title">Copiar claves en el portapapeles</string>
     <string name="pref_search_behavior_title">Comportamiento de búsqueda</string>
     <string name="pref_pause_entry_title">Congelar claves al tocarlas</string>
     <string name="pref_pause_entry_summary">Pausa la recarga automática de las claves al tocarlas, por lo que no irán cambiando según expiran. Es necesario que también actives «Resaltar códigos al pulsar» o «Pulsar para mostrar».</string>
@@ -549,9 +547,6 @@
     <string name="pref_grouping_size_two">En grupos de dos</string>
     <string name="pref_grouping_size_three">En grupos de tres</string>
     <string name="pref_grouping_size_four">En grupos de cuatro</string>
-    <string name="pref_copy_behavior_never">Nunca</string>
-    <string name="pref_copy_behavior_single_tap">Un toque</string>
-    <string name="pref_copy_behavior_double_tap">Dos toques</string>
     <string name="pref_account_name_position_hidden">Oculto</string>
     <string name="pref_account_name_position_end">Junto al emisor</string>
     <string name="pref_account_name_position_below">Debajo del emisor</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Valid soovitud kujundus</string>
     <string name="choose_account_name_position">Vali sinu kasutajakonto nime asukoht</string>
     <string name="choose_view_mode">Vali sinu soovitud vaade</string>
-    <string name="choose_copy_behavior">Vali soovitud käitumine kopeerimisel</string>
     <string name="parsing_file_error">Faili töötlemisel tekkis viga</string>
     <string name="file_not_found">Viga: faili ei leidu</string>
     <string name="reading_file_error">Faili lugemisel tekkis viga</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Võimalda mitme grupi korraga valimist</string>
     <string name="pref_minimize_on_copy_title">Kopeerimisel peida rakendus</string>
     <string name="pref_minimize_on_copy_summary">Peale kinnituskoodi kopeerimist minimeeri rakendus</string>
-    <string name="pref_copy_behavior_title">Kopeeri kinnituskoodid lõikelauale</string>
     <string name="pref_search_behavior_title">Otsingu toimimine</string>
     <string name="pref_pause_entry_title">Peale puudutamist peata kinnituskoodide muutumine</string>
     <string name="pref_pause_entry_summary">Puudutamisel peata kinnituskoodide automaatne uuendamine - seni kuni ta on fookuses kood ei muutu. Eeldab, et „Puudutamisel tõsta kinnituskood esile“ või „Näitamiseks puuduta“ on sisse lülitatud.</string>
@@ -543,9 +541,6 @@
     <string name="pref_grouping_size_two">Rühmita kahekaupa</string>
     <string name="pref_grouping_size_three">Rühmita kolmekaupa</string>
     <string name="pref_grouping_size_four">Rühmita neljakaupa</string>
-    <string name="pref_copy_behavior_never">Ära kopeeri iialgi</string>
-    <string name="pref_copy_behavior_single_tap">Kopeeri ühe puudutusega</string>
-    <string name="pref_copy_behavior_double_tap">Kopeeri kahe puudutusega</string>
     <string name="pref_account_name_position_hidden">Peidetud</string>
     <string name="pref_account_name_position_end">Väljaandja kõrval</string>
     <string name="pref_account_name_position_below">Väljaandja all</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Hautatu zure itxura</string>
     <string name="choose_account_name_position">Aukeratu zure kontuaren izenaren posizioa</string>
     <string name="choose_view_mode">Aukeratu nahi duzun ikuspegia</string>
-    <string name="choose_copy_behavior">Aukeratu kopia egiteko nahi duzun portaera</string>
     <string name="parsing_file_error">Errorea gertatu da fitxategia analizatzen saiatzean</string>
     <string name="file_not_found">Errorea: Ez da fitxategia aurkitu</string>
     <string name="reading_file_error">Errorea gertatu da fitxategia irakurtzen saiatzean</string>
@@ -369,7 +368,6 @@
     <string name="pref_groups_multiselect_summary">Talde bat baino gehiago aldi berean aukeratzea baimendu</string>
     <string name="pref_minimize_on_copy_title">Txikitu kopiatzean</string>
     <string name="pref_minimize_on_copy_summary">Aplikazioa txikitu tokena kopiatutakoan</string>
-    <string name="pref_copy_behavior_title">Kopiatu tokenak arbelera</string>
     <string name="pref_search_behavior_title">Bilaketaren portaera</string>
     <string name="pref_pause_entry_title">Izoztu tokenak ukitzean</string>
     <string name="pref_pause_entry_summary">Gelditu tokenak automatikoki freskatzea beraietan sakatzean. Tokenak ez dira eguneratuko ukitzen ez badituzu. \"Nabarmendu tokenak ukitzean\" edo \"Sakatu erakusteko\" aukeratuta izatea eskatzen du.</string>
@@ -531,9 +529,6 @@
     <string name="pref_grouping_size_two">2ko taldeak</string>
     <string name="pref_grouping_size_three">3ko taldeak</string>
     <string name="pref_grouping_size_four">4ko taldeak</string>
-    <string name="pref_copy_behavior_never">Inoiz ez</string>
-    <string name="pref_copy_behavior_single_tap">Ukitu bat</string>
-    <string name="pref_copy_behavior_double_tap">Bi ikutu</string>
     <string name="pref_account_name_position_hidden">Ezkutua</string>
     <string name="pref_account_name_position_end">Jaulkitzailearen ostean</string>
     <string name="pref_account_name_position_below">Jaulkitzailearen azpian</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Valitse haluamasi teema</string>
     <string name="choose_account_name_position">Valitse haluamasi tilin nimen sijainti</string>
     <string name="choose_view_mode">Valitse haluamasi näkymätila</string>
-    <string name="choose_copy_behavior">Valitse haluttu kopiointikäyttäytyminen</string>
     <string name="parsing_file_error">Tiedoston jäsentämisessä tapahtui virhe</string>
     <string name="file_not_found">Virhe: Tiedostoa ei löydy</string>
     <string name="reading_file_error">Tiedoston lukemisessa tapahtui virhe</string>
@@ -376,7 +375,6 @@
     <string name="pref_groups_multiselect_summary">Salli useiden ryhmien valitseminen samanaikaisesti</string>
     <string name="pref_minimize_on_copy_title">Pienennä kopioidessa</string>
     <string name="pref_minimize_on_copy_summary">Pienennä sovellus todennuskoodin kopioinnin jälkeen</string>
-    <string name="pref_copy_behavior_title">Kopioi todennuskoodit leikepöydälle</string>
     <string name="pref_search_behavior_title">Hakukäyttäytyminen</string>
     <string name="pref_pause_entry_title">Jäädytä todennuskoodit napauttamalla</string>
     <string name="pref_pause_entry_summary">Keskeytä todennuskoodien automaattinen päivitys napauttamalla niitä. Todennuskoodit eivät päivity automaattisesti, niin kauan kun ne ovat valittuina. Vaatii \"Korosta todennuskoodit napauttamalla\" tai \"Paljasta napauttamalla\" -asetusten käyttöönottoa.</string>
@@ -540,9 +538,6 @@
     <string name="pref_grouping_size_two">Kahden ryhmissä</string>
     <string name="pref_grouping_size_three">Kolmen ryhmissä</string>
     <string name="pref_grouping_size_four">Neljän ryhmissä</string>
-    <string name="pref_copy_behavior_never">Ei koskaan</string>
-    <string name="pref_copy_behavior_single_tap">Yksi napautus</string>
-    <string name="pref_copy_behavior_double_tap">Kaksoisnapautus</string>
     <string name="pref_account_name_position_hidden">Piilotettu</string>
     <string name="pref_account_name_position_end">Myöntäjän vierellä</string>
     <string name="pref_account_name_position_below">Myöntäjän alla</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Sélectionner le thème que vous désirez</string>
     <string name="choose_account_name_position">Sélectionner la position que vous désirez pour le nom de compte</string>
     <string name="choose_view_mode">Sélectionner le mode d\'affichage que vous désirez</string>
-    <string name="choose_copy_behavior">Sélectionner le comportement de copie que vous désirez</string>
     <string name="parsing_file_error">Une erreur est survenue en essayant d\'analyser le fichier</string>
     <string name="file_not_found">Erreur : Fichier introuvable</string>
     <string name="reading_file_error">Une erreur est survenue en essayant de lire le fichier</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Autoriser la sélection de plusieurs groupes en même temps</string>
     <string name="pref_minimize_on_copy_title">Minimiser lors de la copie</string>
     <string name="pref_minimize_on_copy_summary">Minimiser l\'application après avoir copié un jeton</string>
-    <string name="pref_copy_behavior_title">Copier les jetons dans le presse-papier</string>
     <string name="pref_search_behavior_title">Comportement de recherche</string>
     <string name="pref_pause_entry_title">Geler les jetons lorsqu\'ils sont appuyés</string>
     <string name="pref_pause_entry_summary">Mettre en pause l\'actualisation automatique des jetons en appuyant dessus. Les jetons ne seront plus mis à jour tant qu\'ils seront ciblés. Nécessite « Surligner les jetons lorsqu\'ils sont appuyés » ou « Appuyer pour révéler ».</string>
@@ -549,9 +547,6 @@
     <string name="pref_grouping_size_two">Groupes de 2</string>
     <string name="pref_grouping_size_three">Groupes de 3</string>
     <string name="pref_grouping_size_four">Groupes de 4</string>
-    <string name="pref_copy_behavior_never">Jamais</string>
-    <string name="pref_copy_behavior_single_tap">Appui simple</string>
-    <string name="pref_copy_behavior_double_tap">Appui double</string>
     <string name="pref_account_name_position_hidden">Masqué</string>
     <string name="pref_account_name_position_end">À côté de l\'émetteur</string>
     <string name="pref_account_name_position_below">En dessous de l\'émetteur</string>

--- a/app/src/main/res/values-fy-rNL/strings.xml
+++ b/app/src/main/res/values-fy-rNL/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Selektearje jo winske tema</string>
     <string name="choose_account_name_position">Selektearje jo winske accountnammeposysje</string>
     <string name="choose_view_mode">Selektearje jo winske werjeftemodus</string>
-    <string name="choose_copy_behavior">Selektearje it winske gedrach foar kopiearjen</string>
     <string name="parsing_file_error">Der is in flater bard wylst it oersetten fan it bestân</string>
     <string name="file_not_found">Flater: Bestân net fûn</string>
     <string name="reading_file_error">Der is in flater bard wylst it lêzen fan it bestân</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Seleksje fan meardere groepen tagelyk tastean</string>
     <string name="pref_minimize_on_copy_title">By kopiearjen minimalisearje</string>
     <string name="pref_minimize_on_copy_summary">App nei kopiearjen fan in koade minimalisearje</string>
-    <string name="pref_copy_behavior_title">Koaden nei it klamboerd kopiearje</string>
     <string name="pref_search_behavior_title">Sykgedrach</string>
     <string name="pref_pause_entry_title">Tokens by oantikken befrieze</string>
     <string name="pref_pause_entry_summary">Automatysk ferfarskjen fan koaden troch derop te tikken stopje. Koaden sille net bywurke wurde sa lang se fokust binne. Fereasket ‘Koaden markearje nei oantikken’ of ‘Oantikke om te toanen’.</string>
@@ -548,9 +546,6 @@
     <string name="pref_grouping_size_two">Groepen fan 2</string>
     <string name="pref_grouping_size_three">Groepen fan 3</string>
     <string name="pref_grouping_size_four">Groepen fan 4</string>
-    <string name="pref_copy_behavior_never">Nea</string>
-    <string name="pref_copy_behavior_single_tap">Inkelde tik</string>
-    <string name="pref_copy_behavior_double_tap">Dûbele tik</string>
     <string name="pref_account_name_position_hidden">Ferstoppe</string>
     <string name="pref_account_name_position_end">Njonken de útjouwer</string>
     <string name="pref_account_name_position_below">Under de útjouwer</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Escolle o tema que prefires</string>
     <string name="choose_account_name_position">Escolle a posición que prefires para o nome de conta</string>
     <string name="choose_view_mode">Escolle o modo de visualización que prefires</string>
-    <string name="choose_copy_behavior">Escolle o comportamento de copia que prefires</string>
     <string name="parsing_file_error">Ocorreu un erro ao intentar analizar o ficheiro</string>
     <string name="file_not_found">Erro: Ficheiro non atopado</string>
     <string name="reading_file_error">Ocorreu un erro ao intentar ler o ficheiro</string>
@@ -369,7 +368,6 @@
     <string name="pref_groups_multiselect_summary">Permite ter seleccionados varios grupos ao mesmo tempo</string>
     <string name="pref_minimize_on_copy_title">Minimizar ao copiar</string>
     <string name="pref_minimize_on_copy_summary">Minimiza a aplicación despois de copiar un token</string>
-    <string name="pref_copy_behavior_title">Copiar códigos no portapapeis</string>
     <string name="pref_search_behavior_title">Comportamento da busca</string>
     <string name="pref_pause_entry_title">Conxelar tokens ao premelos</string>
     <string name="pref_pause_entry_summary">Pausa a actualización automática dos tokens ao premer neles. Os tokens non se actualizarán mentres teñan o foco. Require \"Resaltar tokens ao premelos\" ou \"Tocar para mostrar\".</string>
@@ -533,9 +531,6 @@
     <string name="pref_grouping_size_two">Grupos de 2</string>
     <string name="pref_grouping_size_three">Grupos de 3</string>
     <string name="pref_grouping_size_four">Grupos de 4</string>
-    <string name="pref_copy_behavior_never">Nunca</string>
-    <string name="pref_copy_behavior_single_tap">Un toque</string>
-    <string name="pref_copy_behavior_double_tap">Dobre toque</string>
     <string name="pref_account_name_position_hidden">Oculto</string>
     <string name="pref_account_name_position_end">Ao lado do provedor</string>
     <string name="pref_account_name_position_below">Debaixo do provedor</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Válassza ki a kívánt témát</string>
     <string name="choose_account_name_position">Válassza ki a kívánt fióknév-pozíciót</string>
     <string name="choose_view_mode">Válassza ki a kívánt nézetmódot</string>
-    <string name="choose_copy_behavior">Válassza ki a kívánt másolási viselkedést</string>
     <string name="parsing_file_error">Hiba történt a fájl feldolgozásakor</string>
     <string name="file_not_found">Hiba: A fájl nem található</string>
     <string name="reading_file_error">Hiba történt a fájl olvasásakor</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Több csoport egyidejű kiválasztásának engedélyezése</string>
     <string name="pref_minimize_on_copy_title">Minimalizálás másoláskor</string>
     <string name="pref_minimize_on_copy_summary">Az alkalmazás minimalizálása a token másolása után</string>
-    <string name="pref_copy_behavior_title">Tokenek másolása a vágólapra</string>
     <string name="pref_search_behavior_title">Keresés viselkedése</string>
     <string name="pref_pause_entry_title">Tokenek befagyasztása koppintáskor</string>
     <string name="pref_pause_entry_summary">A tokenek automatikus frissítésének szüneteltetése koppintás után. A tokenek addig nem frissülnek, míg fókuszban vannak. Ehhez szükséges a „Tokenek kiemelése koppintáskor” vagy a „Koppintás a felfedéshez\" beállítás.</string>
@@ -548,9 +546,6 @@
     <string name="pref_grouping_size_two">2-es csoportok</string>
     <string name="pref_grouping_size_three">3-as csoportok</string>
     <string name="pref_grouping_size_four">4-es csoportok</string>
-    <string name="pref_copy_behavior_never">Soha</string>
-    <string name="pref_copy_behavior_single_tap">Egy koppintás</string>
-    <string name="pref_copy_behavior_double_tap">Dupla koppintás</string>
     <string name="pref_account_name_position_hidden">Rejtett</string>
     <string name="pref_account_name_position_end">A kibocsátó mellett</string>
     <string name="pref_account_name_position_below">A kibocsátó alatt</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -289,7 +289,6 @@
     <string name="choose_theme">Pilih tema yang Anda inginkan</string>
     <string name="choose_account_name_position">Pilih posisi nama akun yang Anda inginkan</string>
     <string name="choose_view_mode">Pilih mode tampilan yang Anda inginkan</string>
-    <string name="choose_copy_behavior">Pilih perilaku penyalinan yang Anda inginkan</string>
     <string name="parsing_file_error">Terjadi kesalahan saat mengurai berkas</string>
     <string name="file_not_found">Kesalahan: Berkas tidak ditemukan</string>
     <string name="reading_file_error">Terjadi kesalahan saat membaca berkas</string>
@@ -360,7 +359,6 @@
     <string name="pref_groups_multiselect_summary">Mengizinkan memilih beberapa grup pada saat yang sama</string>
     <string name="pref_minimize_on_copy_title">Meminimalkan penyalinan</string>
     <string name="pref_minimize_on_copy_summary">Meminimalkan aplikasi setelah menyalin token</string>
-    <string name="pref_copy_behavior_title">Menyalin token ke papan klip</string>
     <string name="pref_search_behavior_title">Aktivitas pencarian</string>
     <string name="pref_pause_entry_title">Bekukan token ketika disentuh</string>
     <string name="pref_pause_entry_summary">Hentikan penyegaran otomatis token dengan menyentuh mereka. Token tidak akan diperbarui selama mereka difokuskan. Membutuhkan \"Sorot token saat disentuh\" atau \"Sentuh untuk melihat.\"</string>
@@ -520,9 +518,6 @@
     <string name="pref_grouping_size_two">Dua kelompok</string>
     <string name="pref_grouping_size_three">Tiga kelompok</string>
     <string name="pref_grouping_size_four">Empat kelompok</string>
-    <string name="pref_copy_behavior_never">Tidak pernah</string>
-    <string name="pref_copy_behavior_single_tap">Ketuk sekali</string>
-    <string name="pref_copy_behavior_double_tap">Ketuk dua kali</string>
     <string name="pref_account_name_position_hidden">Tersembunyi</string>
     <string name="pref_account_name_position_end">Di sebelah emiten</string>
     <string name="pref_account_name_position_below">Di bawah emiten</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Seleziona il tema</string>
     <string name="choose_account_name_position">Seleziona la tua posizione preferita per il nome dell\'account</string>
     <string name="choose_view_mode">Seleziona la modalità di visualizzazione</string>
-    <string name="choose_copy_behavior">Seleziona il comportamento desiderato per la copia</string>
     <string name="parsing_file_error">Si è verificato un errore durante l\'analisi del file</string>
     <string name="file_not_found">Errore: File non trovato</string>
     <string name="reading_file_error">Si è verificato un errore nel tentativo di leggere il file</string>
@@ -369,7 +368,6 @@
     <string name="pref_groups_multiselect_summary">Consente la selezione multipla di più gruppi contemporaneamente</string>
     <string name="pref_minimize_on_copy_title">Minimizza alla copia</string>
     <string name="pref_minimize_on_copy_summary">Minimizza l\'app dopo aver copiato un token</string>
-    <string name="pref_copy_behavior_title">Copia i token negli appunti</string>
     <string name="pref_search_behavior_title">Comportamento di ricerca</string>
     <string name="pref_pause_entry_title">Blocca i token con un tocco</string>
     <string name="pref_pause_entry_summary">Metti in pausa l\'aggiornamento automatico dei token toccandoli. I token non si aggiorneranno finché sono evidenziati. Richiede \"Evidenzia i token al tocco\" o \"Tocca per mostrare\".</string>
@@ -532,9 +530,6 @@
     <string name="pref_grouping_size_two">Gruppi di 2</string>
     <string name="pref_grouping_size_three">Gruppi di 3</string>
     <string name="pref_grouping_size_four">Gruppi di 4</string>
-    <string name="pref_copy_behavior_never">Mai</string>
-    <string name="pref_copy_behavior_single_tap">Tocco singolo</string>
-    <string name="pref_copy_behavior_double_tap">Doppio tocco</string>
     <string name="pref_account_name_position_hidden">Nascosto</string>
     <string name="pref_account_name_position_end">Accanto al servizio</string>
     <string name="pref_account_name_position_below">Sotto all\'emittente</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -236,7 +236,6 @@
     <string name="choose_theme">テーマを選択してください</string>
     <string name="choose_account_name_position">アカウント名の位置を選択</string>
     <string name="choose_view_mode">表示モードを選択してください</string>
-    <string name="choose_copy_behavior">コピー時の動作を選択</string>
     <string name="parsing_file_error">ファイルの解析中にエラーが発生しました</string>
     <string name="file_not_found">エラー: ファイルが見つかりません</string>
     <string name="reading_file_error">ファイルの読み取り中にエラーが発生しました</string>
@@ -297,7 +296,6 @@
     <string name="pref_highlight_entry_summary">タップ時に一時的に強調表示することで、トークンが互いに区別しやすくなります。</string>
     <string name="pref_minimize_on_copy_title">コピー時に最小化</string>
     <string name="pref_minimize_on_copy_summary">トークンをコピーした後にアプリを最小化する</string>
-    <string name="pref_copy_behavior_title">トークンをクリップボードにコピー</string>
     <string name="pref_pause_entry_title">タップ時にトークンの更新を停止</string>
     <string name="pref_pause_entry_summary">トークンをタップすると、トークンの自動更新を一時停止します。フォーカスされている限り、トークンは更新されません。 「タップ時にトークンを強調表示する」または「タップして表示」の設定が必要です。</string>
     <string name="pin_keyboard_description">PINキーボードを有効にするにはパスワードを入力してください。これはパスワードが数字のみで構成されている場合にのみ機能します。</string>
@@ -439,9 +437,6 @@
     <string name="pref_grouping_size_two">2桁でグループ化</string>
     <string name="pref_grouping_size_three">3桁でグループ化</string>
     <string name="pref_grouping_size_four">4桁でグループ化</string>
-    <string name="pref_copy_behavior_never">何もしない</string>
-    <string name="pref_copy_behavior_single_tap">シングルタップ</string>
-    <string name="pref_copy_behavior_double_tap">ダブルタップ</string>
     <string name="pref_account_name_position_hidden">非表示</string>
     <string name="pref_account_name_position_end">次の発行者</string>
     <string name="pref_account_name_position_below">前の発行者</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -290,7 +290,6 @@
     <string name="choose_theme">원하는 테마를 선택해주세요</string>
     <string name="choose_account_name_position">계정 이름 위치를 선택해주세요</string>
     <string name="choose_view_mode">보기 모드를 선택해주세요</string>
-    <string name="choose_copy_behavior">복사 방법을 선택해주세요</string>
     <string name="parsing_file_error">파일 파싱 중 오류 발생</string>
     <string name="file_not_found">오류: 파일을 찾을 수 없습니다</string>
     <string name="reading_file_error">파일을 읽던 중 오류가 발생했습니다</string>
@@ -375,7 +374,6 @@
     <string name="pref_groups_multiselect_summary">한 번에 여러 개의 그룹을 선택할 수 있게 합니다</string>
     <string name="pref_minimize_on_copy_title">복사할 때 최소화하기</string>
     <string name="pref_minimize_on_copy_summary">토큰을 복사한 후, 앱을 최소화합니다</string>
-    <string name="pref_copy_behavior_title">클립보드에 토큰 복사하기</string>
     <string name="pref_search_behavior_title">검색 행동</string>
     <string name="pref_pause_entry_title">터치되었을 때 토큰 얼리기</string>
     <string name="pref_pause_entry_summary">토큰을 탭하여 토큰의 자동 새로 고침을 일시 중지합니다. 토큰이 초점이 맞춰져 있는 동안에는 토큰이 업데이트되지 않습니다. “탭하면 토큰 강조 표시” 또는 ‘탭하여 표시’가 필요합니다.</string>
@@ -534,9 +532,6 @@
     <string name="pref_grouping_size_two">2개 그룹</string>
     <string name="pref_grouping_size_three">3개 그룹</string>
     <string name="pref_grouping_size_four">4개 그룹</string>
-    <string name="pref_copy_behavior_never">없음</string>
-    <string name="pref_copy_behavior_single_tap">단일 탭</string>
-    <string name="pref_copy_behavior_double_tap">두 번 탭</string>
     <string name="pref_account_name_position_hidden">숨김</string>
     <string name="pref_account_name_position_end">공급자 옆에</string>
     <string name="pref_account_name_position_below">공급자 아래에</string>

--- a/app/src/main/res/values-lt-rLT/strings.xml
+++ b/app/src/main/res/values-lt-rLT/strings.xml
@@ -306,5 +306,4 @@
     <string name="groups">Grupės</string>
     <string name="pref_focus_search">Paleidus programėlę, fokusuoti paiešką</string>
     <string name="pref_focus_search_summary">Atvėrus programėlę, nedelsiant fokusuoti paieškos laukelį.</string>
-    <string name="pref_copy_behavior_never">Niekada</string>
 </resources>

--- a/app/src/main/res/values-lv-rLV/strings.xml
+++ b/app/src/main/res/values-lv-rLV/strings.xml
@@ -301,7 +301,6 @@
     <string name="choose_theme">Atlasīt vēlamo izskatu</string>
     <string name="choose_account_name_position">Atlasīt vēlamo konta nosaukuma atrašanās vietu</string>
     <string name="choose_view_mode">Atlasīt vēlamo skata veidu</string>
-    <string name="choose_copy_behavior">Atlasīt vēlamo kopēšanas uzvedību</string>
     <string name="parsing_file_error">Atgadījusies kļūda datnes satura apstrādāšanā</string>
     <string name="file_not_found">Kļūda: datne nav atrasta</string>
     <string name="reading_file_error">Atgadījusies kļūda datnes nolasīšanā</string>
@@ -394,7 +393,6 @@
     <string name="pref_groups_multiselect_summary">Ļaut vienlaicīgi atlasīt vairākas kopas</string>
     <string name="pref_minimize_on_copy_title">Samazināt pēc ievietošanas starpliktuvē</string>
     <string name="pref_minimize_on_copy_summary">Samazināt lietotni pēc koda ievietošanas starpliktuvē</string>
-    <string name="pref_copy_behavior_title">Ievietot tekstvienības starpliktuvē</string>
     <string name="pref_search_behavior_title">Meklēšanas uzvedība</string>
     <string name="pref_pause_entry_title">Iesaldēt kodus pēc piesišanas tiem</string>
     <string name="pref_pause_entry_summary">Apturēt kodu atsvaidzināšanu, kad piesit. Kods netiks atjaunots, kamēr vien tas ir izcelts. Ir nepieciešams ieslēgt iestatījumu \"Izcelt kodus, kad piesit\" vai \"Piesist, lai atklātu\".</string>
@@ -562,9 +560,6 @@
     <string name="pref_grouping_size_two">Kopas no 2</string>
     <string name="pref_grouping_size_three">Kopas no 3</string>
     <string name="pref_grouping_size_four">Kopas no 4</string>
-    <string name="pref_copy_behavior_never">Nekad</string>
-    <string name="pref_copy_behavior_single_tap">Viens piesitiens</string>
-    <string name="pref_copy_behavior_double_tap">Divkāršs piesitiens</string>
     <string name="pref_account_name_position_hidden">Paslēpts</string>
     <string name="pref_account_name_position_end">Aiz izdevēja</string>
     <string name="pref_account_name_position_below">Zem izdevēja</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -240,7 +240,6 @@
     <string name="choose_theme">നിങ്ങൾ ആഗ്രഹിക്കുന്ന തീം തിരഞ്ഞെടുക്കുക</string>
     <string name="choose_account_name_position">നിങ്ങൾ ആഗ്രഹിക്കുന്ന അക്കൗണ്ട് പേര് സ്ഥാനം തിരഞ്ഞെടുക്കുക</string>
     <string name="choose_view_mode">നിങ്ങൾക്ക് ആവശ്യമുള്ള വ്യൂ മോഡ് തിരഞ്ഞെടുക്കുക</string>
-    <string name="choose_copy_behavior">നിങ്ങൾ ആഗ്രഹിക്കുന്ന പകർപ്പ് സ്വഭാവം തിരഞ്ഞെടുക്കുക</string>
     <string name="parsing_file_error">ഫയൽ പാഴ്‌സ് ചെയ്യാൻ ശ്രമിക്കുന്നതിനിടെ ഒരു പിശക് സംഭവിച്ചു</string>
     <string name="file_not_found">പിശക്: ഫയൽ കണ്ടെത്തിയില്ല</string>
     <string name="reading_file_error">ഫയൽ വായിക്കാൻ ശ്രമിക്കുന്നതിനിടെ ഒരു പിശക് സംഭവിച്ചു</string>
@@ -306,7 +305,6 @@
     <string name="pref_highlight_entry_summary">ടാപ്പുചെയ്യുമ്പോൾ താൽക്കാലികമായി ഹൈലൈറ്റ് ചെയ്തുകൊണ്ട് പരസ്പരം വേർതിരിച്ചറിയാൻ ടോക്കണുകൾ എളുപ്പമാക്കുക</string>
     <string name="pref_minimize_on_copy_title">പകർപ്പിൽ ചെറുതാക്കുക</string>
     <string name="pref_minimize_on_copy_summary">ഒരു ടോക്കൺ പകർത്തിയ ശേഷം ആപ്പ് ചെറുതാക്കുക</string>
-    <string name="pref_copy_behavior_title">ക്ലിപ്പ്ബോർഡിലേക്ക് ടോക്കണുകൾ പകർത്തുക</string>
     <string name="pref_pause_entry_title">ടാപ്പുചെയ്യുമ്പോൾ ടോക്കണുകൾ ഫ്രീസ് ചെയ്യുക</string>
     <string name="pref_pause_entry_summary">ടോക്കണുകൾ ടാപ്പുചെയ്യുന്നതിലൂടെ അവയുടെ യാന്ത്രിക പുതുക്കൽ താൽക്കാലികമായി നിർത്തുക. ടോക്കണുകൾ ഫോക്കസ് ചെയ്തിരിക്കുന്നിടത്തോളം കാലം അവ അപ്‌ഡേറ്റ് ചെയ്യില്ല. \"ടാപ്പുചെയ്യുമ്പോൾ ടോക്കണുകൾ ഹൈലൈറ്റ് ചെയ്യുക\" അല്ലെങ്കിൽ \"വെളിപ്പെടുത്താൻ ടാപ്പ് ചെയ്യുക\" ആവശ്യമാണ്.</string>
     <string name="pin_keyboard_description">പിൻ കീബോർഡ് പ്രവർത്തനക്ഷമമാക്കാൻ നിങ്ങളുടെ പാസ്‌വേഡ് നൽകുക. നിങ്ങളുടെ പാസ്‌വേഡിൽ അക്കങ്ങൾ മാത്രം അടങ്ങിയിട്ടുണ്ടെങ്കിൽ മാത്രമേ ഇത് പ്രവർത്തിക്കൂ എന്നത് ശ്രദ്ധിക്കുക</string>
@@ -443,9 +441,6 @@
     <string name="pref_grouping_size_two">രണ്ടു പേരുടെ ഗ്രൂപ്പുകൾ</string>
     <string name="pref_grouping_size_three">മൂന്ന് പേരടങ്ങുന്ന ഗ്രൂപ്പുകൾ</string>
     <string name="pref_grouping_size_four">നാലംഗ സംഘങ്ങൾ</string>
-    <string name="pref_copy_behavior_never">ഒരിക്കലും പകർത്തരുത്</string>
-    <string name="pref_copy_behavior_single_tap">ഒറ്റ ടാപ്പ്</string>
-    <string name="pref_copy_behavior_double_tap">രണ്ടുതവണ ടാപ്പ് ചെയ്യുക</string>
     <string name="pref_account_name_position_hidden">മറച്ചിരിക്കുന്നു</string>
     <string name="pref_account_name_position_end">പ്രസാധകൻ്റെ അടുത്ത്</string>
     <string name="pref_account_name_position_below">പ്രസാധകൻ്റെ താഴെ</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -291,7 +291,6 @@
     <string name="choose_theme">Velg ønsket tema</string>
     <string name="choose_account_name_position">Velg ønsket plassering av brukernavn</string>
     <string name="choose_view_mode">Velg ønsket visningsmodus</string>
-    <string name="choose_copy_behavior">Velg ønsket oppførsel for kopiering</string>
     <string name="parsing_file_error">Det oppsto en feil under forsøk på å analysere filen</string>
     <string name="file_not_found">Feil: Finner ikke filen</string>
     <string name="reading_file_error">Det oppsto en feil under forsøk på å lese filen</string>
@@ -357,7 +356,6 @@
     <string name="pref_highlight_entry_summary">Gjør det lettere å skille mellom koder ved å fremheve dem ved trykk</string>
     <string name="pref_minimize_on_copy_title">Minimer ved kopi</string>
     <string name="pref_minimize_on_copy_summary">Minimer appen etter å ha kopiert en kode</string>
-    <string name="pref_copy_behavior_title">Kopier koder til utklippstavlen</string>
     <string name="pref_pause_entry_title">Frys koder ved trykk</string>
     <string name="pref_pause_entry_summary">Pause autmatisk oppdatering av koder ved å trykke på dem. Koder vil ikke oppdateres så lenge de er i fokus. Krever «Fremhev koder ved trykk» eller «Trykk for å vise».</string>
     <string name="pin_keyboard_description">Skriv inn passordet ditt for å aktivere PIN-tastaturet. Merk at dette kun fungerer dersom passordet bare består av tall</string>
@@ -472,9 +470,6 @@
     <string name="pref_grouping_size_two">Grupper på 2</string>
     <string name="pref_grouping_size_three">Grupper på 3</string>
     <string name="pref_grouping_size_four">Grupper på 4</string>
-    <string name="pref_copy_behavior_never">Aldri</string>
-    <string name="pref_copy_behavior_single_tap">Enkelttrykk</string>
-    <string name="pref_copy_behavior_double_tap">Dobbelttrykk</string>
     <string name="pref_account_name_position_hidden">Skjult</string>
     <string name="pref_account_name_position_end">Ved siden av utstederen</string>
     <string name="pref_account_name_position_below">Under utstederen</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Selecteer je gewenste thema</string>
     <string name="choose_account_name_position">Selecteer de plaats van de accountnaam</string>
     <string name="choose_view_mode">Selecteer je gewenste weergavemodus</string>
-    <string name="choose_copy_behavior">Selecteer het gedrag voor kopiëren</string>
     <string name="parsing_file_error">Er is een fout opgetreden tijdens het vertalen van het bestand</string>
     <string name="file_not_found">Fout: Bestand niet gevonden</string>
     <string name="reading_file_error">Er is een fout opgetreden tijdens het lezen van het bestand</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Selectie van meerdere groepen tegelijkertijd toestaan</string>
     <string name="pref_minimize_on_copy_title">Na kopiëren minimaliseren</string>
     <string name="pref_minimize_on_copy_summary">Na kopiëren van een code de app minimaliseren</string>
-    <string name="pref_copy_behavior_title">Codes naar het klembord kopiëren</string>
     <string name="pref_search_behavior_title">Zoekgedrag</string>
     <string name="pref_pause_entry_title">Codes bevriezen na aantikken</string>
     <string name="pref_pause_entry_summary">Pauzeer automatisch verversen van codes door erop te tikken. Codes zullen niet worden bijgewerkt zolang ze gefocust zijn. Vereist ‘Codes markeren na aantikken’ of ‘Aantikken om te laten zien’.</string>
@@ -549,9 +547,6 @@
     <string name="pref_grouping_size_two">Groepen van 2</string>
     <string name="pref_grouping_size_three">Groepen van 3</string>
     <string name="pref_grouping_size_four">Groepen van 4</string>
-    <string name="pref_copy_behavior_never">Nooit</string>
-    <string name="pref_copy_behavior_single_tap">Enkele tik</string>
-    <string name="pref_copy_behavior_double_tap">Dubbele tik</string>
     <string name="pref_account_name_position_hidden">Verborgen</string>
     <string name="pref_account_name_position_end">Naast de uitgever</string>
     <string name="pref_account_name_position_below">Onder de uitgever</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -307,7 +307,6 @@
     <string name="choose_theme">Wybierz motyw jaki chcesz</string>
     <string name="choose_account_name_position">Wybierz miejsce nazwy konta</string>
     <string name="choose_view_mode">Wybierz widok jaki chcesz</string>
-    <string name="choose_copy_behavior">Wybierz pożądane zachowanie kopii</string>
     <string name="parsing_file_error">Wystąpił błąd podczas przetwarzania pliku</string>
     <string name="file_not_found">Błąd: Nie znaleziono pliku</string>
     <string name="reading_file_error">Wystąpił błąd podczas odczytywania pliku</string>
@@ -404,7 +403,6 @@
     <string name="pref_groups_multiselect_summary">Zezwalaj na wybór wielu grup jednocześnie</string>
     <string name="pref_minimize_on_copy_title">Zminimalizuj przy skopiowaniu</string>
     <string name="pref_minimize_on_copy_summary">Zminimalizuj aplikację po skopiowaniu tokenu</string>
-    <string name="pref_copy_behavior_title">Skopiuj tokeny do schowka</string>
     <string name="pref_search_behavior_title">Zachowanie wyszukiwania</string>
     <string name="pref_pause_entry_title">Zamroź tokeny po naciśnięciu</string>
     <string name="pref_pause_entry_summary">Wstrzymaj automatyczne odświeżanie tokenów poprzez dotknięcie ich. Tokeny nie będą aktualizowane tak długo, jak długo są podświetlone. Wymaga \"Podświetl tokeny podczas kliknięcia\" lub \"Kliknij, aby odkryć\".</string>
@@ -579,9 +577,6 @@ zlokalizowanego w wewnętrznym katalogu Steam.</string>
     <string name="pref_grouping_size_two">Grupy z 2 elementami</string>
     <string name="pref_grouping_size_three">Grupy z 3 elementami</string>
     <string name="pref_grouping_size_four">Grupy z 4 elementami</string>
-    <string name="pref_copy_behavior_never">Nigdy</string>
-    <string name="pref_copy_behavior_single_tap">Pojedyncze dotknięcie</string>
-    <string name="pref_copy_behavior_double_tap">Podwójne dotknięcie</string>
     <string name="pref_account_name_position_hidden">Ukryta</string>
     <string name="pref_account_name_position_end">Obok wydawcy</string>
     <string name="pref_account_name_position_below">Pod wydawcą</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Selecione o tema desejado</string>
     <string name="choose_account_name_position">Selecione a posição desejada para o nome da conta</string>
     <string name="choose_view_mode">Selecione o modo desejado para visualização</string>
-    <string name="choose_copy_behavior">Selecione o comportamento desejado para copiar</string>
     <string name="parsing_file_error">Ocorreu um erro ao tentar interpretar o arquivo</string>
     <string name="file_not_found">Erro: Arquivo não encontrado</string>
     <string name="reading_file_error">Ocorreu um erro ao tentar ler o arquivo</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Permitir a seleção de vários grupos ao mesmo tempo</string>
     <string name="pref_minimize_on_copy_title">Minimizar ao copiar</string>
     <string name="pref_minimize_on_copy_summary">Minimizar o aplicativo após copiar um token</string>
-    <string name="pref_copy_behavior_title">Copiar tokens pra área de transferência</string>
     <string name="pref_search_behavior_title">Comportamento da pesquisa</string>
     <string name="pref_pause_entry_title">Congelar tokens ao tocar</string>
     <string name="pref_pause_entry_summary">Pausar a atualização automática dos tokens ao tocá-los. Tokens não serão atualizados desde que o foco esteja neles. Requer \"Destacar tokens ao tocar\" ou \"Tocar para revelar\".</string>
@@ -549,9 +547,6 @@
     <string name="pref_grouping_size_two">Grupos de 2</string>
     <string name="pref_grouping_size_three">Grupos de 3</string>
     <string name="pref_grouping_size_four">Grupos de 4</string>
-    <string name="pref_copy_behavior_never">Nunca</string>
-    <string name="pref_copy_behavior_single_tap">Um toque</string>
-    <string name="pref_copy_behavior_double_tap">Dois toques</string>
     <string name="pref_account_name_position_hidden">Oculto</string>
     <string name="pref_account_name_position_end">Ao lado do nome do serviço</string>
     <string name="pref_account_name_position_below">Abaixo do nome do serviço</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Selecione o tema</string>
     <string name="choose_account_name_position">Selecione a posição do nome da conta desejada</string>
     <string name="choose_view_mode">Selecione o modo de visualização</string>
-    <string name="choose_copy_behavior">Selecione o estilo de cópia que deseja efetuar </string>
     <string name="parsing_file_error">Ocorreu um erro ao tentar analisar o ficheiro</string>
     <string name="file_not_found">Erro: Ficheiro não encontrado</string>
     <string name="reading_file_error">Ocorreu um erro ao tentar ler o ficheiro</string>
@@ -384,7 +383,6 @@
     <string name="pref_groups_multiselect_summary">Permitir a seleção de vários grupos ao mesmo tempo</string>
     <string name="pref_minimize_on_copy_title">Minimizar ao copiar</string>
     <string name="pref_minimize_on_copy_summary">Após copiar um token, minimizar a aplicação </string>
-    <string name="pref_copy_behavior_title">Copiar tokens para a área de transferência</string>
     <string name="pref_search_behavior_title">Comportamento da pesquisa</string>
     <string name="pref_pause_entry_title">Congelar tokens quando tocados</string>
     <string name="pref_pause_entry_summary">Pausar a atualização automática dos tokens ao tocar neles. Os tokens não serão atualizados desde que estejam em foco. Requer \"Realçar tokens quando tocados\" ou \"Toque para mostrar\".</string>
@@ -545,9 +543,6 @@
     <string name="pref_grouping_size_two">Grupos de 2</string>
     <string name="pref_grouping_size_three">Grupos de 3</string>
     <string name="pref_grouping_size_four">Grupos de 4</string>
-    <string name="pref_copy_behavior_never">Nunca</string>
-    <string name="pref_copy_behavior_single_tap">Apenas um toque</string>
-    <string name="pref_copy_behavior_double_tap">Duplo toque</string>
     <string name="pref_account_name_position_hidden">Ocultar / Ocultos</string>
     <string name="pref_account_name_position_end">Ao lado do emissor</string>
     <string name="pref_account_name_position_below">Abaixo do emissor</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -301,7 +301,6 @@
     <string name="choose_theme">Selectează tema dorită</string>
     <string name="choose_account_name_position">Selectați poziția dorită a numelui de cont</string>
     <string name="choose_view_mode">Selectează modul de vizualizare dorit</string>
-    <string name="choose_copy_behavior">Selectați comportamentul dorit la copiere</string>
     <string name="parsing_file_error">A apărut o eroare în timpul analizării fișierului</string>
     <string name="file_not_found">Eroare: Fișierul nu a fost găsit</string>
     <string name="reading_file_error">A apărut o eroare în timpul citirii fișierului</string>
@@ -382,7 +381,6 @@
     <string name="pref_groups_multiselect_summary">Permite selecția mai multor grupuri în același timp</string>
     <string name="pref_minimize_on_copy_title">Minimizează după copiere</string>
     <string name="pref_minimize_on_copy_summary">Minimizează aplicația după copierea unui token</string>
-    <string name="pref_copy_behavior_title">Copiați tokenul în clipboard</string>
     <string name="pref_search_behavior_title">Mod de căutare</string>
     <string name="pref_pause_entry_title">Îngheață jetoanele când sunt apăsate</string>
     <string name="pref_pause_entry_summary">Oprește reîmprospătarea automată a jetoanelor prin apăsarea lor. Token-urile nu se vor actualiza atâta timp cât sunt evidențiate. Necesită \"Evidențierea tokenurilor atunci când sunt apasate\" sau \"Atinge pentru a arăta\".</string>
@@ -541,9 +539,6 @@
     <string name="pref_grouping_size_two">Grupuri a câte 2</string>
     <string name="pref_grouping_size_three">Grupuri a câte 3</string>
     <string name="pref_grouping_size_four">Grupuri a câte 4</string>
-    <string name="pref_copy_behavior_never">Niciodată</string>
-    <string name="pref_copy_behavior_single_tap">O singură atingere</string>
-    <string name="pref_copy_behavior_double_tap">Atingere dublă</string>
     <string name="pref_account_name_position_hidden">Ascuns</string>
     <string name="pref_account_name_position_end">Alături de emitent</string>
     <string name="pref_account_name_position_below">Sub emitent</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -307,7 +307,6 @@
     <string name="choose_theme">Выберите тему</string>
     <string name="choose_account_name_position">Выберите место названия учётной записи</string>
     <string name="choose_view_mode">Выберите режим отображения</string>
-    <string name="choose_copy_behavior">Настройка копирования</string>
     <string name="parsing_file_error">Произошла ошибка при попытке разобрать файл</string>
     <string name="file_not_found">Ошибка: файл не найден</string>
     <string name="reading_file_error">Произошла ошибка при попытке прочитать файл</string>
@@ -404,7 +403,6 @@
     <string name="pref_groups_multiselect_summary">Разрешить одновременный выбор нескольких групп</string>
     <string name="pref_minimize_on_copy_title">Сворачивать при копировании</string>
     <string name="pref_minimize_on_copy_summary">Сворачивать приложение после копирования ключа</string>
-    <string name="pref_copy_behavior_title">Копировать ключи в буфер обмена</string>
     <string name="pref_search_behavior_title">Поведение поиска</string>
     <string name="pref_pause_entry_title">Замораживать ключи при нажатии</string>
     <string name="pref_pause_entry_summary">Приостановить автоматическое обновление ключей принажатии на них. Ключи не будут обновляться до тех пор, пока отображаются. Для обновления потребуется «Выделять ключи при нажатии» или «Отображение по нажатию».</string>
@@ -578,9 +576,6 @@
     <string name="pref_grouping_size_two">Группы по 2</string>
     <string name="pref_grouping_size_three">Группы по 3</string>
     <string name="pref_grouping_size_four">Группы по 4</string>
-    <string name="pref_copy_behavior_never">Не копировать</string>
-    <string name="pref_copy_behavior_single_tap">Одиночным нажатием</string>
-    <string name="pref_copy_behavior_double_tap">Двойным нажатием</string>
     <string name="pref_account_name_position_hidden">Скрыта</string>
     <string name="pref_account_name_position_end">После эмитента</string>
     <string name="pref_account_name_position_below">Под эмитентом</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -272,7 +272,6 @@
     <string name="choose_theme">Vyberte si vašu želanú tému</string>
     <string name="choose_account_name_position">Vyberte si vašu želanú pozíciu názvu účtu</string>
     <string name="choose_view_mode">Vyberte si váš želaný režim zobrazenia</string>
-    <string name="choose_copy_behavior">Vyberte si vaše želané správanie kopírovania</string>
     <string name="parsing_file_error">Pri pokuse o analyzovanie súboru došlo k chybe</string>
     <string name="file_not_found">Chyba: Súbor nenájdený</string>
     <string name="reading_file_error">Pri pokuse o prečitanie súboru sa vyskytla chyba</string>
@@ -330,7 +329,6 @@
     <string name="pref_highlight_entry_title">Zvýrazniť tokeny po klepnutí</string>
     <string name="pref_minimize_on_copy_title">Minimalizovať pri kopírovaní</string>
     <string name="pref_minimize_on_copy_summary">Minimalizujte aplikáciu po skopírovaní tokenu</string>
-    <string name="pref_copy_behavior_title">Kopírovať tokeny do schránky</string>
     <string name="pref_search_behavior_title">Správanie pri vyhľadávaní</string>
     <string name="pref_pause_entry_title">Zmraziť tokeny po klepnutí</string>
     <string name="pin_keyboard_disabled">Heslo bolo zmenené. Klávesnica pre PIN sa už nebude zobrazovať.</string>
@@ -428,9 +426,6 @@
     <string name="pref_grouping_size_two">Zoskupovať po 2</string>
     <string name="pref_grouping_size_three">Zoskupovať po 3</string>
     <string name="pref_grouping_size_four">Zoskupovať po 4</string>
-    <string name="pref_copy_behavior_never">Nikdy</string>
-    <string name="pref_copy_behavior_single_tap">Jedno klepnutie</string>
-    <string name="pref_copy_behavior_double_tap">Dvojité poklepanie</string>
     <string name="pref_account_name_position_hidden">Skryté</string>
     <plurals name="time_elapsed_seconds" tools:ignore="UnusedResources">
         <item quantity="one">Pred %d sekundou</item>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -298,7 +298,6 @@
     <string name="choose_theme">Изаберите жељену тему</string>
     <string name="choose_account_name_position">Изаберите жељени положај назива налога</string>
     <string name="choose_view_mode">Изаберите жељени режим приказа</string>
-    <string name="choose_copy_behavior">Изаберите жељено понашање копирања</string>
     <string name="parsing_file_error">Дошло је до грешке приликом покушаја рашчлањивања фајла</string>
     <string name="file_not_found">Грешка: Фајл није пронађен</string>
     <string name="reading_file_error">Дошло је до грешке приликом покушаја читања фајла</string>
@@ -373,7 +372,6 @@
     <string name="pref_highlight_entry_summary">Привремено нагласи токене на додир како би били видљивији</string>
     <string name="pref_minimize_on_copy_title">Минимизирај приликом копирања</string>
     <string name="pref_minimize_on_copy_summary">Минимизирајте апликацију након копирања токена</string>
-    <string name="pref_copy_behavior_title">Копирај токене у привремену меморију</string>
     <string name="pref_search_behavior_title">Понашање претраге</string>
     <string name="pref_pause_entry_title">Замрзните токене на додир</string>
     <string name="pref_pause_entry_summary">Паузирајте аутоматско освежавање токена тако што ћете их додирнути. Токени се неће ажурирати све док су фокусирани. Ово захтева опције „Истакни токене приликом додира” или „Додирни за откривање”.</string>
@@ -538,9 +536,6 @@
     <string name="pref_grouping_size_two">Груписање по 2</string>
     <string name="pref_grouping_size_three">Груписање по 3</string>
     <string name="pref_grouping_size_four">Груписање по 4</string>
-    <string name="pref_copy_behavior_never">Никада</string>
-    <string name="pref_copy_behavior_single_tap">Један додир</string>
-    <string name="pref_copy_behavior_double_tap">Дупли додир</string>
     <string name="pref_account_name_position_hidden">Скривено</string>
     <string name="pref_account_name_position_end">Поред издавача</string>
     <string name="pref_account_name_position_below">Испод издавача</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -295,7 +295,6 @@
     <string name="choose_theme">Välj önskat tema</string>
     <string name="choose_account_name_position">Välj önskad kontonamnsplacering</string>
     <string name="choose_view_mode">Välj önskat visningsläge</string>
-    <string name="choose_copy_behavior">Välj önskat kopieringsbeteende</string>
     <string name="parsing_file_error">Ett fel uppstod när filen skulle tolkas</string>
     <string name="file_not_found">Fel: Filen hittades inte</string>
     <string name="reading_file_error">Ett fel uppstod när filen skulle läsas</string>
@@ -380,7 +379,6 @@
     <string name="pref_groups_multiselect_summary">Tillåt val av flera grupper samtidigt</string>
     <string name="pref_minimize_on_copy_title">Minimera vid kopiering</string>
     <string name="pref_minimize_on_copy_summary">Minimerar appen efter att en pollett har kopierats</string>
-    <string name="pref_copy_behavior_title">Kopiera polletter till urklipp</string>
     <string name="pref_search_behavior_title">Sökbeteende</string>
     <string name="pref_pause_entry_title">Frys polletter vid tryck</string>
     <string name="pref_pause_entry_summary">Pausa automatisk uppdatering av polletterna genom att trycka på dem. Polletterna kommer inte att uppdateras så länge som de är i fokus. Kräver \"Markera polletter vid tryck\" eller \"Tryck för att visa\".</string>
@@ -544,9 +542,6 @@
     <string name="pref_grouping_size_two">Grupper av 2</string>
     <string name="pref_grouping_size_three">Grupper av 3</string>
     <string name="pref_grouping_size_four">Grupper av 4</string>
-    <string name="pref_copy_behavior_never">Aldrig</string>
-    <string name="pref_copy_behavior_single_tap">Enkeltryck</string>
-    <string name="pref_copy_behavior_double_tap">Dubbeltryck</string>
     <string name="pref_account_name_position_hidden">Dolt</string>
     <string name="pref_account_name_position_end">Bredvid utfärdaren</string>
     <string name="pref_account_name_position_below">Nedanför utfärdaren</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -244,7 +244,6 @@
     <string name="choose_theme">İstediğiniz temayı seçin</string>
     <string name="choose_account_name_position">İstediğiniz hesap adı pozisyonunu seçin</string>
     <string name="choose_view_mode">İstediğiniz görünüm biçimini seçin</string>
-    <string name="choose_copy_behavior">İstediğiniz kopyalama davranışını seçin</string>
     <string name="parsing_file_error">Dosyayı anlamlandırmaya çalışırken hata meydana geldi</string>
     <string name="file_not_found">Hata: Dosya bulunamadı</string>
     <string name="reading_file_error">Dosyayı okumaya çalışırken bir hata meydana geldi</string>
@@ -310,7 +309,6 @@
     <string name="pref_highlight_entry_summary">Kodların birbirlerinden ayırt edilmelerini kolaylaştırmak için geçici olarak belirginleştir</string>
     <string name="pref_minimize_on_copy_title">Kopyalarken simge durumuna küçült</string>
     <string name="pref_minimize_on_copy_summary">Bir anahtarı kopyaladıktan sonra uygulamayı simge durumuna küçültün</string>
-    <string name="pref_copy_behavior_title">Erişim anahtarlarını panoya kopyala</string>
     <string name="pref_pause_entry_title">Dokunulduğunda kodların yenilenmesini önle</string>
     <string name="pref_pause_entry_summary">Kodlara dokunarak yenilenmelerini önleyin. Odakta oldukları sürece kodlar yenilenmeyecektir. \"Dokunulan kodları belirt\" veya \"Görmek için dokunun\" açık olmasını gerektirir.</string>
     <string name="pin_keyboard_description">PIN klavyesini etkinleştirmek için şifrenizi girin. Bu şifreniz yalnızca rakamlardan oluşuyorsa çalışır</string>
@@ -455,9 +453,6 @@
     <string name="pref_grouping_size_two">2\'li grup</string>
     <string name="pref_grouping_size_three">3\'lü grup</string>
     <string name="pref_grouping_size_four">4\'lü grup</string>
-    <string name="pref_copy_behavior_never">Asla</string>
-    <string name="pref_copy_behavior_single_tap">Tek dokunuş</string>
-    <string name="pref_copy_behavior_double_tap">Çift dokunuş</string>
     <string name="pref_account_name_position_hidden">Gizli</string>
     <string name="pref_account_name_position_end">Yayınlayanın yanında</string>
     <string name="pref_account_name_position_below">Yayınlayanın altında</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -307,7 +307,6 @@
     <string name="choose_theme">Виберіть бажану тему</string>
     <string name="choose_account_name_position">Виберіть бажане розташування імені облікового запису</string>
     <string name="choose_view_mode">Виберіть бажаний режим перегляду</string>
-    <string name="choose_copy_behavior">Виберіть бажану поведінку копіювання</string>
     <string name="parsing_file_error">Сталася помилка під час спроби проаналізувати файл</string>
     <string name="file_not_found">Помилка: Файл не знайдено</string>
     <string name="reading_file_error">Сталася помилка при спробі прочитати файл</string>
@@ -404,7 +403,6 @@
     <string name="pref_groups_multiselect_summary">Дозволити вибір декількох груп одночасно</string>
     <string name="pref_minimize_on_copy_title">Згортати при копіюванні</string>
     <string name="pref_minimize_on_copy_summary">Згортати додаток після копіювання токена</string>
-    <string name="pref_copy_behavior_title">Скопіювати токени в буфер обміну</string>
     <string name="pref_search_behavior_title">Поведінка пошуку</string>
     <string name="pref_pause_entry_title">Заморожувати токени при натисканні</string>
     <string name="pref_pause_entry_summary">Призупиніть автоматичне оновлення токенів, натиснувши на них. Токени не будуть оновлюватися, поки вони підсвічені. Потребує увімкненої опції \"Підсвічувати токени при натисканні\", або \"Безпека -> Показувати після дотику\".</string>
@@ -574,9 +572,6 @@
     <string name="pref_grouping_size_two">2 цифри у групі</string>
     <string name="pref_grouping_size_three">3 цифри у групі</string>
     <string name="pref_grouping_size_four">4 цифри у групі</string>
-    <string name="pref_copy_behavior_never">Ніколи</string>
-    <string name="pref_copy_behavior_single_tap">Один дотик</string>
-    <string name="pref_copy_behavior_double_tap">Подвійний дотик</string>
     <string name="pref_account_name_position_hidden">Приховано</string>
     <string name="pref_account_name_position_end">Поруч з емітентом</string>
     <string name="pref_account_name_position_below">Нижче емітента</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -290,7 +290,6 @@
     <string name="choose_theme">Chọn chủ đề bạn thích</string>
     <string name="choose_account_name_position">Chọn vị trí tên tài khoản mà bạn thích</string>
     <string name="choose_view_mode">Chọn chế độ xem bạn thích</string>
-    <string name="choose_copy_behavior">Chọn thao tác sao chép mà bạn thích</string>
     <string name="parsing_file_error">Đã xảy ra lỗi trong khi xử lý file</string>
     <string name="file_not_found">Lỗi: Không tìm thấy tập tin</string>
     <string name="reading_file_error">Đã xảy ra lỗi trong khi đọc tập tin</string>
@@ -375,7 +374,6 @@
     <string name="pref_groups_multiselect_summary">Cho phép chọn nhiều nhãn cùng lúc</string>
     <string name="pref_minimize_on_copy_title">Thu nhỏ ứng dụng</string>
     <string name="pref_minimize_on_copy_summary">Sau khi sao chép một mã</string>
-    <string name="pref_copy_behavior_title">Lưu mã vào bộ nhớ tạm</string>
     <string name="pref_search_behavior_title">Hành vi tìm kiếm</string>
     <string name="pref_pause_entry_title">Đóng băng mã khi nhấn vào</string>
     <string name="pref_pause_entry_summary">Không tự động tạo mã tiếp theo nữa</string>
@@ -535,9 +533,6 @@
     <string name="pref_grouping_size_two">Gộp 2</string>
     <string name="pref_grouping_size_three">Gộp 3</string>
     <string name="pref_grouping_size_four">Gộp 4</string>
-    <string name="pref_copy_behavior_never">Không bao giờ</string>
-    <string name="pref_copy_behavior_single_tap">Nhấn một lần</string>
-    <string name="pref_copy_behavior_double_tap">Nhấn đúp</string>
     <string name="pref_account_name_position_hidden">Ẩn</string>
     <string name="pref_account_name_position_end">Kế bên dịch vụ</string>
     <string name="pref_account_name_position_below">Dưới dịch vụ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -289,7 +289,6 @@
     <string name="choose_theme">选择您想要的主题</string>
     <string name="choose_account_name_position">选择您期望的账户名称位置</string>
     <string name="choose_view_mode">选择您想要的视图模式</string>
-    <string name="choose_copy_behavior">选择如何复制</string>
     <string name="parsing_file_error">试图解析文件时出错</string>
     <string name="file_not_found">错误：文件未找到</string>
     <string name="reading_file_error">试图读取文件时出错</string>
@@ -374,7 +373,6 @@
     <string name="pref_groups_multiselect_summary">允许同时选中多个分组</string>
     <string name="pref_minimize_on_copy_title">复制时最小化</string>
     <string name="pref_minimize_on_copy_summary">复制令牌后最小化应用</string>
-    <string name="pref_copy_behavior_title">复制令牌到剪贴板</string>
     <string name="pref_search_behavior_title">搜索行为</string>
     <string name="pref_pause_entry_title">轻按冻结令牌</string>
     <string name="pref_pause_entry_summary">通过轻按令牌来暂停它们的自动刷新。 只要被聚焦，令牌就不会更新。 需要启用“轻按突出显示令牌”或“轻按显示”。</string>
@@ -534,9 +532,6 @@
     <string name="pref_grouping_size_two">2 位数</string>
     <string name="pref_grouping_size_three">3 位数</string>
     <string name="pref_grouping_size_four">4 位数</string>
-    <string name="pref_copy_behavior_never">从不</string>
-    <string name="pref_copy_behavior_single_tap">单击</string>
-    <string name="pref_copy_behavior_double_tap">双击</string>
     <string name="pref_account_name_position_hidden">隐藏</string>
     <string name="pref_account_name_position_end">发行者旁边</string>
     <string name="pref_account_name_position_below">发行者下方</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -339,7 +339,6 @@
     <string name="pref_highlight_entry_title">強調選取的憑證</string>
     <string name="pref_highlight_entry_summary">輕觸後暫時凸顯該驗證碼以與它者區分</string>
     <string name="pref_minimize_on_copy_title">複製後最小化</string>
-    <string name="pref_copy_behavior_title">複製令牌至剪貼簿</string>
     <string name="pref_search_behavior_title">搜尋行為</string>
     <string name="pref_pause_entry_title">被觸碰時凍結驗證碼</string>
     <string name="pref_pause_entry_summary">輕觸以暫停驗證碼的自動更新機制：只要驗證碼還在焦點上，它們就不會被自動更新。需要啟用「輕觸以顯示」或「強調選取的憑證」功能。</string>
@@ -479,9 +478,6 @@
     <string name="pref_grouping_size_two">分成兩群</string>
     <string name="pref_grouping_size_three">分成三群</string>
     <string name="pref_grouping_size_four">分成四群</string>
-    <string name="pref_copy_behavior_never">從不</string>
-    <string name="pref_copy_behavior_single_tap">輕觸一下</string>
-    <string name="pref_copy_behavior_double_tap">輕觸兩下</string>
     <string name="pref_account_name_position_hidden">隱藏</string>
     <string name="pref_account_name_position_end">在發行者旁</string>
     <string name="pref_account_name_position_below">在發行者下</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -170,9 +170,9 @@
         <item>@string/pref_account_name_position_below</item>
     </string-array>
 
-    <string-array name="copy_behavior_titles">
-        <item>@string/pref_copy_behavior_never</item>
-        <item>@string/pref_copy_behavior_single_tap</item>
-        <item>@string/pref_copy_behavior_double_tap</item>
+    <string-array name="pref_tap_action_entries">
+        <item>@string/pref_tap_action_copy</item>
+        <item>@string/pref_tap_action_edit</item>
+        <item>@string/pref_tap_action_none</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,8 +303,10 @@
     <string name="choose_application">Select the application you\'d like to import from</string>
     <string name="choose_theme">Select your desired theme</string>
     <string name="choose_account_name_position">Select your desired account name position</string>
+    <string name="choose_single_tap_action">Select your desired single tap action</string>
+    <string name="choose_double_tap_action">Select your desired double tap action</string>
     <string name="choose_view_mode">Select your desired view mode</string>
-    <string name="choose_copy_behavior">Select your desired copy behavior</string>
+    <string name="choose_copy_behavior" tools:ignore="UnusedResources">Select your desired copy behavior</string>
     <string name="parsing_file_error">An error occurred while trying to parse the file</string>
     <string name="file_not_found">Error: File not found</string>
     <string name="reading_file_error">An error occurred while trying to read the file</string>
@@ -396,7 +398,7 @@
     <string name="pref_groups_multiselect_summary">Allow the selection of multiple groups at the same time</string>
     <string name="pref_minimize_on_copy_title">Minimize on copy</string>
     <string name="pref_minimize_on_copy_summary">Minimize the app after copying a token</string>
-    <string name="pref_copy_behavior_title">Copy tokens to the clipboard</string>
+    <string name="pref_copy_behavior_title" tools:ignore="UnusedResources">Copy tokens to the clipboard</string>
     <string name="pref_search_behavior_title">Search behavior</string>
     <string name="pref_pause_entry_title">Freeze tokens when tapped</string>
     <string name="pref_pause_entry_summary">Pause automatic refresh of tokens by tapping them. Tokens will not update as long as they are focused. Requires \"Highlight tokens when tapped\" or \"Tap to reveal\".</string>
@@ -586,9 +588,9 @@
     <string name="pref_grouping_size_three">Groups of 3</string>
     <string name="pref_grouping_size_four">Groups of 4</string>
 
-    <string name="pref_copy_behavior_never">Never</string>
-    <string name="pref_copy_behavior_single_tap">Single tap</string>
-    <string name="pref_copy_behavior_double_tap">Double tap</string>
+    <string name="pref_copy_behavior_never" tools:ignore="UnusedResources">Never</string>
+    <string name="pref_copy_behavior_single_tap" tools:ignore="UnusedResources">Single tap</string>
+    <string name="pref_copy_behavior_double_tap" tools:ignore="UnusedResources">Double tap</string>
 
     <string name="pref_account_name_position_hidden">Hidden</string>
     <string name="pref_account_name_position_end">Next to the issuer</string>
@@ -619,4 +621,20 @@
         <item quantity="one">%d item selected</item>
         <item quantity="other">%d items selected</item>
     </plurals>
+
+    <string name="pref_tap_actions_title">Tap actions</string>
+    <string name="pref_tap_actions_summary">Configure single tap, double tap, and first-tap reveal</string>
+
+    <string name="pref_single_tap_action_title">Single tap</string>
+    <string name="pref_double_tap_action_title">Double tap</string>
+
+    <string name="pref_reserve_first_tap_title">Reserve first tap for reveal</string>
+    <string name="pref_reserve_first_tap_summary">When codes are hidden or a highlight is needed, the first tap only reveals/highlights</string>
+
+    <string name="pref_tap_action_copy">Copy</string>
+    <string name="pref_tap_action_edit">Edit</string>
+    <string name="pref_tap_action_none">None</string>
+
+    <string name="pref_tap_actions_hint_title">Tip</string>
+    <string name="pref_tap_actions_hint_summary">To perform an action without revealing hidden codes, assign it to Double tap.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,7 +306,6 @@
     <string name="choose_single_tap_action">Select your desired single tap action</string>
     <string name="choose_double_tap_action">Select your desired double tap action</string>
     <string name="choose_view_mode">Select your desired view mode</string>
-    <string name="choose_copy_behavior" tools:ignore="UnusedResources">Select your desired copy behavior</string>
     <string name="parsing_file_error">An error occurred while trying to parse the file</string>
     <string name="file_not_found">Error: File not found</string>
     <string name="reading_file_error">An error occurred while trying to read the file</string>
@@ -398,7 +397,6 @@
     <string name="pref_groups_multiselect_summary">Allow the selection of multiple groups at the same time</string>
     <string name="pref_minimize_on_copy_title">Minimize on copy</string>
     <string name="pref_minimize_on_copy_summary">Minimize the app after copying a token</string>
-    <string name="pref_copy_behavior_title" tools:ignore="UnusedResources">Copy tokens to the clipboard</string>
     <string name="pref_search_behavior_title">Search behavior</string>
     <string name="pref_pause_entry_title">Freeze tokens when tapped</string>
     <string name="pref_pause_entry_summary">Pause automatic refresh of tokens by tapping them. Tokens will not update as long as they are focused. Requires \"Highlight tokens when tapped\" or \"Tap to reveal\".</string>
@@ -588,10 +586,6 @@
     <string name="pref_grouping_size_three">Groups of 3</string>
     <string name="pref_grouping_size_four">Groups of 4</string>
 
-    <string name="pref_copy_behavior_never" tools:ignore="UnusedResources">Never</string>
-    <string name="pref_copy_behavior_single_tap" tools:ignore="UnusedResources">Single tap</string>
-    <string name="pref_copy_behavior_double_tap" tools:ignore="UnusedResources">Double tap</string>
-
     <string name="pref_account_name_position_hidden">Hidden</string>
     <string name="pref_account_name_position_end">Next to the issuer</string>
     <string name="pref_account_name_position_below">Below the issuer</string>
@@ -629,12 +623,11 @@
     <string name="pref_double_tap_action_title">Double tap</string>
 
     <string name="pref_reserve_first_tap_title">Reserve first tap for reveal</string>
-    <string name="pref_reserve_first_tap_summary">When codes are hidden or a highlight is needed, the first tap only reveals/highlights</string>
+    <string name="pref_reserve_first_tap_summary">When codes are hidden, the first tap only reveals them</string>
 
     <string name="pref_tap_action_copy">Copy</string>
     <string name="pref_tap_action_edit">Edit</string>
     <string name="pref_tap_action_none">None</string>
 
-    <string name="pref_tap_actions_hint_title">Tip</string>
-    <string name="pref_tap_actions_hint_summary">To perform an action without revealing hidden codes, assign it to Double tap.</string>
+    <string name="pref_tap_actions_hint_summary"><i>To perform an action without revealing hidden codes, assign it to Double tap.</i></string>
 </resources>

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -24,6 +24,7 @@
         app:iconSpaceReserved="false" />
 
     <Preference
+        android:fragment="com.beemdevelopment.aegis.ui.fragments.preferences.TapActionsPreferencesFragment"
         android:key="pref_tap_actions"
         android:title="@string/pref_tap_actions_title"
         android:summary="@string/pref_tap_actions_summary"

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -2,54 +2,59 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_section_behavior_title">
+
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="pref_focus_search"
         android:title="@string/pref_focus_search"
         android:summary="@string/pref_focus_search_summary"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
+
     <Preference
         android:defaultValue="false"
         android:key="pref_search_behavior"
         android:title="@string/pref_search_behavior_title"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
+
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="pref_minimize_on_copy"
         android:title="@string/pref_minimize_on_copy_title"
         android:summary="@string/pref_minimize_on_copy_summary"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
 
     <Preference
-        android:defaultValue="false"
-        android:key="pref_copy_behavior"
-        android:title="@string/pref_copy_behavior_title"
-        app:iconSpaceReserved="false"/>
+        android:key="pref_tap_actions"
+        android:title="@string/pref_tap_actions_title"
+        android:summary="@string/pref_tap_actions_summary"
+        app:iconSpaceReserved="false" />
 
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="pref_haptic_feedback"
         android:title="@string/pref_haptic_feedback_title"
         android:summary="@string/pref_haptic_feedback_summary"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
 
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="pref_groups_multiselect"
         android:title="@string/pref_groups_multiselect_title"
         android:summary="@string/pref_groups_multiselect_summary"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
 
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="pref_highlight_entry"
         android:title="@string/pref_highlight_entry_title"
         android:summary="@string/pref_highlight_entry_summary"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
+
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="pref_pause_entry"
         android:title="@string/pref_pause_entry_title"
         android:summary="@string/pref_pause_entry_summary"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_tap_actions.xml
+++ b/app/src/main/res/xml/preferences_tap_actions.xml
@@ -4,16 +4,14 @@
     android:title="@string/pref_tap_actions_title">
 
     <Preference
-        android:defaultValue="false"
         android:key="pref_single_tap_action"
         android:title="@string/pref_single_tap_action_title"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
 
     <Preference
-        android:defaultValue="false"
         android:key="pref_double_tap_action"
         android:title="@string/pref_double_tap_action_title"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
 
     <androidx.preference.SwitchPreferenceCompat
         android:key="pref_reserve_first_tap"
@@ -24,7 +22,7 @@
 
     <Preference
         android:key="pref_tap_actions_hint"
-        android:title="@string/pref_tap_actions_hint_title"
+        android:persistent="false"
         android:summary="@string/pref_tap_actions_hint_summary"
         android:selectable="false"
         app:iconSpaceReserved="false" />

--- a/app/src/main/res/xml/preferences_tap_actions.xml
+++ b/app/src/main/res/xml/preferences_tap_actions.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/pref_tap_actions_title">
+
+    <Preference
+        android:defaultValue="false"
+        android:key="pref_single_tap_action"
+        android:title="@string/pref_single_tap_action_title"
+        app:iconSpaceReserved="false"/>
+
+    <Preference
+        android:defaultValue="false"
+        android:key="pref_double_tap_action"
+        android:title="@string/pref_double_tap_action_title"
+        app:iconSpaceReserved="false"/>
+
+    <androidx.preference.SwitchPreferenceCompat
+        android:key="pref_reserve_first_tap"
+        android:title="@string/pref_reserve_first_tap_title"
+        android:summary="@string/pref_reserve_first_tap_summary"
+        android:defaultValue="false"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="pref_tap_actions_hint"
+        android:title="@string/pref_tap_actions_hint_title"
+        android:summary="@string/pref_tap_actions_hint_summary"
+        android:selectable="false"
+        app:iconSpaceReserved="false" />
+</PreferenceScreen>

--- a/app/src/test/java/com/beemdevelopment/aegis/PreferencesTest.java
+++ b/app/src/test/java/com/beemdevelopment/aegis/PreferencesTest.java
@@ -11,6 +11,7 @@ import android.content.SharedPreferences;
 import androidx.preference.PreferenceManager;
 import androidx.test.core.app.ApplicationProvider;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -19,18 +20,26 @@ import java.util.Date;
 
 @RunWith(RobolectricTestRunner.class)
 public class PreferencesTest {
+    private Context _context;
+    private SharedPreferences _sharedPrefs;
+
+    @Before
+    public void setUp() {
+        _context = ApplicationProvider.getApplicationContext();
+        _sharedPrefs = PreferenceManager.getDefaultSharedPreferences(_context);
+        _sharedPrefs.edit().clear().commit();
+    }
+
     @Test
     public void testIsPasswordReminderNeeded() {
         long currTime = new Date().getTime();
-        Context context = ApplicationProvider.getApplicationContext();
-        Preferences prefs = new Preferences(context);
-        SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+        Preferences prefs = new Preferences(_context);
 
         // make sure that the password reminder is enabled by default
         assertNotEquals(prefs.getPasswordReminderFrequency(), PassReminderFreq.NEVER);
 
         // if the old preference is set to false, the frequency should be NEVER
-        sharedPrefs.edit().putBoolean("pref_password_reminder", false).apply();
+        _sharedPrefs.edit().putBoolean("pref_password_reminder", false).apply();
         assertEquals(prefs.getPasswordReminderFrequency(), PassReminderFreq.NEVER);
         assertFalse(prefs.isPasswordReminderNeeded());
 
@@ -54,5 +63,37 @@ public class PreferencesTest {
         freq = PassReminderFreq.BIWEEKLY;
         prefs.setPasswordReminderFrequency(freq);
         assertFalse(prefs.isPasswordReminderNeeded(currTime));
+    }
+
+    @Test
+    public void testCopyBehaviorMigration() {
+        CopyBehavior[] copyBehaviors = {
+                CopyBehavior.NEVER,
+                CopyBehavior.SINGLETAP,
+                CopyBehavior.DOUBLETAP
+        };
+        TapAction[] singleTapActions = {
+                TapAction.NONE,
+                TapAction.COPY,
+                TapAction.NONE
+        };
+        TapAction[] doubleTapActions = {
+                TapAction.NONE,
+                TapAction.NONE,
+                TapAction.COPY
+        };
+
+        for (int i = 0; i < copyBehaviors.length; i++) {
+            _sharedPrefs.edit()
+                    .clear()
+                    .putInt("pref_current_copy_behavior", copyBehaviors[i].ordinal())
+                    .commit();
+
+            Preferences prefs = new Preferences(_context);
+
+            assertEquals(singleTapActions[i], prefs.getSingleTapAction());
+            assertEquals(doubleTapActions[i], prefs.getDoubleTapAction());
+            assertFalse(_sharedPrefs.contains("pref_current_copy_behavior"));
+        }
     }
 }


### PR DESCRIPTION
<img width="387" height="387" alt="image" src="https://github.com/user-attachments/assets/1e6e1a6f-ec12-492d-b8fe-1e181ad46f16" />

This PR adds the ability to set the single tap and double tap behaviour respectively. This allows us to branch out to other tap actions like the one mentioned in (but not exclusive to) #1688.

Hopefully this PR fixes issues like the ones described in #1223, #1569, #1064, #1667 and probably many more that I can't find right now. 

I also added a preferences migration for people who already have set up their 'Copy to clipboard' to either single tap or double tap.