### PR TITLE
feat: add optional data wipe after failed password attempts

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/Preferences.java
@@ -481,6 +481,18 @@ public class Preferences {
         setBackupResult(true, res);
     }
 
+    public boolean isDataWipingEnabled() {
+        return _prefs.getBoolean("pref_enable_data_wiping", false);
+    }
+
+    public int getMaxFailedAttemptsBeforeWipe() {
+        return _prefs.getInt("pref_max_failed_attempts", 10);
+    }
+
+    public void setMaxFailedAttemptsBeforeWipe(int attempts) {
+        _prefs.edit().putInt("pref_max_failed_attempts", attempts).apply();
+    }
+
     @Nullable
     public BackupResult getAndroidBackupResult() {
         return getBackupResult(false);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -1,8 +1,10 @@
 package com.beemdevelopment.aegis.ui;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.text.InputType;
 import android.view.KeyEvent;
 import android.view.View;
@@ -68,6 +70,12 @@ public class AuthActivity extends AegisActivity {
 
     private static final String PREFS_NAME = "auth_prefs";
     private static final String KEY_FAILED_ATTEMPTS = "failed_attempts";
+    private static final String KEY_LOCKOUT_UNTIL = "lockout_until";
+
+    private long _lockoutUntil = 0;
+
+    private TextView _textLockout;
+    private CountDownTimer _lockoutTimer;
 
     // the first time this activity is resumed after creation, it's possible to inhibit showing the
     // biometric prompt by setting 'inhibitBioPrompt' to true through the intent
@@ -79,12 +87,15 @@ public class AuthActivity extends AegisActivity {
         setContentView(R.layout.activity_auth);
 
         _failedUnlockAttempts = getSharedPreferences(PREFS_NAME, MODE_PRIVATE).getInt(KEY_FAILED_ATTEMPTS, 0);
+        _lockoutUntil = getSharedPreferences(PREFS_NAME, MODE_PRIVATE).getLong(KEY_LOCKOUT_UNTIL, 0);
 
         TextInputLayout layoutStandard = findViewById(R.id.layout_standard);
         TextInputLayout layoutNoAutofill = findViewById(R.id.layout_no_autofill);
         EditText editStandard = findViewById(R.id.text_password);
         EditText editNoAutofill = findViewById(R.id.text_password_no_autofill);
-        _textFailedAttempts = findViewById(R.id.text_failed_attempts);
+
+        _textLockout = findViewById(R.id.lockout_message);
+
         updateFailedAttemptsUI();
 
         if (_prefs.isPinKeyboardEnabled()) {
@@ -99,6 +110,11 @@ public class AuthActivity extends AegisActivity {
 
         LinearLayout boxBiometricInfo = findViewById(R.id.box_biometric_info);
         _decryptButton = findViewById(R.id.button_decrypt);
+
+        if (isLockedOut()) {
+            startLockoutCountdown();
+        }
+
         TextView biometricsButton = findViewById(R.id.button_biometrics);
 
         getOnBackPressedDispatcher().addCallback(this, new BackPressHandler());
@@ -176,6 +192,10 @@ public class AuthActivity extends AegisActivity {
             InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
 
+            if (isLockedOut()) {
+                return;
+            }
+
             char[] password = EditTextHelper.getEditTextChars(_textPassword);
 
             if (password.length == 0) {
@@ -233,11 +253,20 @@ public class AuthActivity extends AegisActivity {
             _bioPrompt = showBiometricPrompt();
         }
 
+        if (isLockedOut()) {
+            startLockoutCountdown();
+        }
+
         _inhibitBioPrompt = false;
     }
 
     @Override
     public void onPause() {
+        if (_lockoutTimer != null) {
+            _lockoutTimer.cancel();
+            _lockoutTimer = null;
+        }
+
         if (!isChangingConfigurations() && _bioPrompt != null) {
             _bioPrompt.cancelAuthentication();
             _bioPrompt = null;
@@ -320,8 +349,18 @@ public class AuthActivity extends AegisActivity {
         }
 
         _failedUnlockAttempts = 0;
+        _lockoutUntil = 0;
         saveFailedAttempts();
+        saveLockoutUntil();
         updateFailedAttemptsUI();
+
+        if (_lockoutTimer != null) {
+            _lockoutTimer.cancel();
+            _lockoutTimer = null;
+        }
+
+        _textLockout.setText("");
+        _decryptButton.setEnabled(true);
 
         setResult(RESULT_OK);
         finish();
@@ -338,8 +377,13 @@ public class AuthActivity extends AegisActivity {
 
         _failedUnlockAttempts ++;
 
-        updateFailedAttemptsUI();
+        applyLockout();
         saveFailedAttempts();
+        updateFailedAttemptsUI();
+
+        if (isLockedOut()) {
+            startLockoutCountdown();
+        }
 
         if (_failedUnlockAttempts >= 3) {
             _textPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
@@ -348,17 +392,96 @@ public class AuthActivity extends AegisActivity {
 
     private void updateFailedAttemptsUI() {
         if (_textFailedAttempts != null) {
-            _textFailedAttempts.setText(
-                    getString(R.string.failed_attempts, _failedUnlockAttempts)
-            );
+            _textFailedAttempts.setVisibility(View.GONE);
+        }
+
+        if (_textLockout != null) {
+            if (isLockedOut()) {
+                _textLockout.setVisibility(View.VISIBLE);
+            } else {
+                _textLockout.setText("");
+                _textLockout.setVisibility(View.GONE);
+            }
         }
     }
 
     private void saveFailedAttempts() {
         getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-                .edit()
-                .putInt(KEY_FAILED_ATTEMPTS, _failedUnlockAttempts)
-                .apply();
+            .edit()
+            .putInt(KEY_FAILED_ATTEMPTS, _failedUnlockAttempts)
+            .apply();
+    }
+
+    private void saveLockoutUntil() {
+        getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .edit()
+            .putLong(KEY_LOCKOUT_UNTIL, _lockoutUntil)
+            .apply();
+    }
+
+    private boolean isLockedOut() {
+        return System.currentTimeMillis() < _lockoutUntil;
+    }
+
+    private long getRemainingLockoutMillis() {
+        return Math.max(0, _lockoutUntil - System.currentTimeMillis());
+    }
+
+    private void applyLockout() {
+        if (_failedUnlockAttempts < 3) {
+            return;
+        }
+
+        int step = _failedUnlockAttempts - 3;
+        long base = 60_000; // 1 min
+
+        long timeoutMillis = base * (step + 1) * (step + 2) / 2;
+
+        long maxTimeout = 60 * 60_000; // 1 hour
+        timeoutMillis = Math.min(timeoutMillis, maxTimeout);
+
+        _lockoutUntil = System.currentTimeMillis() + timeoutMillis;
+        saveLockoutUntil();
+    }
+
+    private void startLockoutCountdown() {
+        if (_lockoutTimer != null) {
+            _lockoutTimer.cancel();
+        }
+
+        long remaining = getRemainingLockoutMillis();
+
+        if (remaining <= 0) {
+            _textLockout.setText("");
+            _decryptButton.setEnabled(true);
+            return;
+        }
+
+        _decryptButton.setEnabled(false);
+
+        _lockoutTimer = new CountDownTimer(remaining, 1000) {
+            @Override
+            public void onTick(long millisUntilFinished) {
+                long totalSeconds = (millisUntilFinished + 999) / 1000;
+
+                long minutes = totalSeconds / 60;
+                long seconds = totalSeconds % 60;
+
+                @SuppressLint("DefaultLocale") String timeFormatted = String.format("%02d:%02d", minutes, seconds);
+
+                _textLockout.setText(
+                        getString(R.string.lockout_message, _failedUnlockAttempts, timeFormatted)
+                );
+            }
+
+            @Override
+            public void onFinish() {
+                _textLockout.setText("");
+                _textLockout.setVisibility(View.GONE);
+                _decryptButton.setEnabled(true);
+                _lockoutTimer = null;
+            }
+        }.start();
     }
 
     private class BackPressHandler extends OnBackPressedCallback {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -66,7 +66,6 @@ public class AuthActivity extends AegisActivity {
     private Button _decryptButton;
 
     private int _failedUnlockAttempts;
-    private TextView _textFailedAttempts;
 
     private static final String PREFS_NAME = "auth_prefs";
     private static final String KEY_FAILED_ATTEMPTS = "failed_attempts";
@@ -199,7 +198,8 @@ public class AuthActivity extends AegisActivity {
             char[] password = EditTextHelper.getEditTextChars(_textPassword);
 
             if (password.length == 0) {
-                Toast.makeText(AuthActivity.this, getString(R.string.error_empty_password), Toast.LENGTH_SHORT).show();                return;
+                Toast.makeText(AuthActivity.this, getString(R.string.error_empty_password), Toast.LENGTH_SHORT).show();
+                return;
             }
 
             List<PasswordSlot> slots = _slots.findAll(PasswordSlot.class);
@@ -400,10 +400,6 @@ public class AuthActivity extends AegisActivity {
     }
 
     private void updateFailedAttemptsUI() {
-        if (_textFailedAttempts != null) {
-            _textFailedAttempts.setVisibility(View.GONE);
-        }
-
         if (_textLockout != null) {
             if (isLockedOut()) {
                 _textLockout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -367,6 +367,15 @@ public class AuthActivity extends AegisActivity {
     }
 
     private void onInvalidPassword() {
+        _failedUnlockAttempts++;
+        applyLockout();
+        saveFailedAttempts();
+
+        if (shouldWipeVault()) {
+            wipeVaultAndExit();
+            return;
+        }
+
         Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(AuthActivity.this, R.style.ThemeOverlay_Aegis_AlertDialog_Error)
                 .setTitle(getString(R.string.unlock_vault_error))
                 .setMessage(getString(R.string.unlock_vault_error_description))
@@ -375,10 +384,7 @@ public class AuthActivity extends AegisActivity {
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> selectPassword())
                 .create());
 
-        _failedUnlockAttempts ++;
 
-        applyLockout();
-        saveFailedAttempts();
         updateFailedAttemptsUI();
 
         if (isLockedOut()) {
@@ -482,6 +488,27 @@ public class AuthActivity extends AegisActivity {
                 _lockoutTimer = null;
             }
         }.start();
+    }
+
+    private boolean shouldWipeVault() {
+        return _prefs.isDataWipingEnabled() && _failedUnlockAttempts >= _prefs.getMaxFailedAttemptsBeforeWipe();
+    }
+
+    private void wipeVaultAndExit() {
+        _failedUnlockAttempts = 0;
+        _lockoutUntil = 0;
+        saveFailedAttempts();
+        saveLockoutUntil();
+
+        VaultRepository.deleteFile(this);
+        _vaultManager.lock(false);
+
+        finishApp();
+    }
+
+    private void finishApp() {
+        ExitActivity.exitAppAndRemoveFromRecents(this);
+        finishAndRemoveTask();
     }
 
     private class BackPressHandler extends OnBackPressedCallback {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -66,6 +66,9 @@ public class AuthActivity extends AegisActivity {
     private int _failedUnlockAttempts;
     private TextView _textFailedAttempts;
 
+    private static final String PREFS_NAME = "auth_prefs";
+    private static final String KEY_FAILED_ATTEMPTS = "failed_attempts";
+
     // the first time this activity is resumed after creation, it's possible to inhibit showing the
     // biometric prompt by setting 'inhibitBioPrompt' to true through the intent
     private boolean _inhibitBioPrompt;
@@ -74,6 +77,8 @@ public class AuthActivity extends AegisActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_auth);
+
+        _failedUnlockAttempts = getSharedPreferences(PREFS_NAME, MODE_PRIVATE).getInt(KEY_FAILED_ATTEMPTS, 0);
 
         TextInputLayout layoutStandard = findViewById(R.id.layout_standard);
         TextInputLayout layoutNoAutofill = findViewById(R.id.layout_no_autofill);
@@ -174,8 +179,7 @@ public class AuthActivity extends AegisActivity {
             char[] password = EditTextHelper.getEditTextChars(_textPassword);
 
             if (password.length == 0) {
-                Toast.makeText(AuthActivity.this, "Password cannot be empty", Toast.LENGTH_SHORT).show();
-                return;
+                Toast.makeText(AuthActivity.this, getString(R.string.error_empty_password), Toast.LENGTH_SHORT).show();                return;
             }
 
             List<PasswordSlot> slots = _slots.findAll(PasswordSlot.class);
@@ -331,6 +335,7 @@ public class AuthActivity extends AegisActivity {
         _failedUnlockAttempts ++;
 
         updateFailedAttemptsUI();
+        saveFailedAttempts();
 
         if (_failedUnlockAttempts >= 3) {
             _textPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
@@ -339,8 +344,17 @@ public class AuthActivity extends AegisActivity {
 
     private void updateFailedAttemptsUI() {
         if (_textFailedAttempts != null) {
-            _textFailedAttempts.setText("Failed attempts: " + _failedUnlockAttempts);
+            _textFailedAttempts.setText(
+                    getString(R.string.failed_attempts, _failedUnlockAttempts)
+            );
         }
+    }
+
+    private void saveFailedAttempts() {
+        getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                .edit()
+                .putInt(KEY_FAILED_ATTEMPTS, _failedUnlockAttempts)
+                .apply();
     }
 
     private class BackPressHandler extends OnBackPressedCallback {
@@ -407,6 +421,10 @@ public class AuthActivity extends AegisActivity {
                 Dialogs.showErrorDialog(AuthActivity.this, R.string.biometric_decrypt_error, e);
                 return;
             }
+
+            _failedUnlockAttempts = 0;
+            saveFailedAttempts();
+            updateFailedAttemptsUI();
 
             finish(key, false);
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -319,6 +319,10 @@ public class AuthActivity extends AegisActivity {
             return;
         }
 
+        _failedUnlockAttempts = 0;
+        saveFailedAttempts();
+        updateFailedAttemptsUI();
+
         setResult(RESULT_OK);
         finish();
     }
@@ -421,10 +425,6 @@ public class AuthActivity extends AegisActivity {
                 Dialogs.showErrorDialog(AuthActivity.this, R.string.biometric_decrypt_error, e);
                 return;
             }
-
-            _failedUnlockAttempts = 0;
-            saveFailedAttempts();
-            updateFailedAttemptsUI();
 
             finish(key, false);
         }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -64,6 +64,7 @@ public class AuthActivity extends AegisActivity {
     private Button _decryptButton;
 
     private int _failedUnlockAttempts;
+    private TextView _textFailedAttempts;
 
     // the first time this activity is resumed after creation, it's possible to inhibit showing the
     // biometric prompt by setting 'inhibitBioPrompt' to true through the intent
@@ -78,6 +79,8 @@ public class AuthActivity extends AegisActivity {
         TextInputLayout layoutNoAutofill = findViewById(R.id.layout_no_autofill);
         EditText editStandard = findViewById(R.id.text_password);
         EditText editNoAutofill = findViewById(R.id.text_password_no_autofill);
+        _textFailedAttempts = findViewById(R.id.text_failed_attempts);
+        updateFailedAttemptsUI();
 
         if (_prefs.isPinKeyboardEnabled()) {
             layoutStandard.setVisibility(View.GONE);
@@ -169,6 +172,12 @@ public class AuthActivity extends AegisActivity {
             imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
 
             char[] password = EditTextHelper.getEditTextChars(_textPassword);
+
+            if (password.length == 0) {
+                Toast.makeText(AuthActivity.this, "Password cannot be empty", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
             List<PasswordSlot> slots = _slots.findAll(PasswordSlot.class);
             PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slots, password);
             PasswordSlotDecryptTask task = new PasswordSlotDecryptTask(AuthActivity.this, new PasswordDerivationListener());
@@ -321,8 +330,16 @@ public class AuthActivity extends AegisActivity {
 
         _failedUnlockAttempts ++;
 
+        updateFailedAttemptsUI();
+
         if (_failedUnlockAttempts >= 3) {
             _textPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        }
+    }
+
+    private void updateFailedAttemptsUI() {
+        if (_textFailedAttempts != null) {
+            _textFailedAttempts.setText("Failed attempts: " + _failedUnlockAttempts);
         }
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -376,14 +376,17 @@ public class AuthActivity extends AegisActivity {
             return;
         }
 
-        Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(AuthActivity.this, R.style.ThemeOverlay_Aegis_AlertDialog_Error)
-                .setTitle(getString(R.string.unlock_vault_error))
-                .setMessage(getString(R.string.unlock_vault_error_description))
-                .setCancelable(false)
-                .setIconAttribute(android.R.attr.alertDialogIcon)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> selectPassword())
-                .create());
-
+        if (_prefs.isDataWipingEnabled() && _failedUnlockAttempts == _prefs.getMaxFailedAttemptsBeforeWipe() - 1) {
+            showDangerDialog();
+        } else {
+            Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(AuthActivity.this, R.style.ThemeOverlay_Aegis_AlertDialog_Error)
+                    .setTitle(getString(R.string.unlock_vault_error))
+                    .setMessage(getString(R.string.unlock_vault_error_description))
+                    .setCancelable(false)
+                    .setIconAttribute(android.R.attr.alertDialogIcon)
+                    .setPositiveButton(android.R.string.ok, (dialog, which) -> selectPassword())
+                    .create());
+        }
 
         updateFailedAttemptsUI();
 
@@ -546,6 +549,46 @@ public class AuthActivity extends AegisActivity {
                 onInvalidPassword();
             }
         }
+    }
+
+    private void showDangerDialog() {
+        final int delayMillis = 5000;
+
+        androidx.appcompat.app.AlertDialog dialog = new MaterialAlertDialogBuilder(
+                AuthActivity.this,
+                R.style.ThemeOverlay_Aegis_AlertDialog_Error
+        )
+                .setTitle(getString(R.string.unlock_vault_error_danger))
+                .setMessage(getString(R.string.unlock_vault_error_description_danger))
+                .setCancelable(false)
+                .setIcon(R.drawable.ic_warning_24)
+                .setPositiveButton(getString(android.R.string.ok), null)
+                .create();
+
+        dialog.setOnShowListener(d -> {
+            Button positiveButton = dialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE);
+            positiveButton.setEnabled(false);
+
+            new CountDownTimer(delayMillis, 1000) {
+                @Override
+                public void onTick(long millisUntilFinished) {
+                    long secondsLeft = (millisUntilFinished + 999) / 1000;
+                    positiveButton.setText(getString(R.string.ok_with_timer, secondsLeft));
+                }
+
+                @Override
+                public void onFinish() {
+                    positiveButton.setText(getString(android.R.string.ok));
+                    positiveButton.setEnabled(true);
+                    positiveButton.setOnClickListener(v -> {
+                        dialog.dismiss();
+                        selectPassword();
+                    });
+                }
+            }.start();
+        });
+
+        Dialogs.showSecureDialog(dialog);
     }
 
     private class BiometricPromptListener extends BiometricPrompt.AuthenticationCallback {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/dialogs/Dialogs.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/dialogs/Dialogs.java
@@ -628,6 +628,24 @@ public class Dialogs {
         showSecureDialog(alertDialog);
     }
 
+    public static void showMaxFailedAttemptsPickerDialog(Context context, int currentValue, NumberInputListener listener) {
+        View view = LayoutInflater.from(context).inflate(R.layout.dialog_number_picker, null);
+        NumberPicker numberPicker = view.findViewById(R.id.numberPicker);
+        numberPicker.setMinValue(1);
+        numberPicker.setMaxValue(100);
+        numberPicker.setValue(currentValue);
+        numberPicker.setWrapSelectorWheel(true);
+
+        AlertDialog dialog = new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.pref_max_failed_attempts_title)
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, (dialog1, which) ->
+                        listener.onNumberInputResult(numberPicker.getValue()))
+                .create();
+
+        showSecureDialog(dialog);
+    }
+
     private static void setImporterHelpText(TextView view, DatabaseImporter.Definition definition, boolean isDirect) {
         if (isDirect) {
             view.setText(view.getResources().getString(R.string.importer_help_direct, definition.getName()));

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/SecurityPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/SecurityPreferencesFragment.java
@@ -46,6 +46,8 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
     private SwitchPreferenceCompat _pinKeyboardPreference;
     private SwitchPreference _backupPasswordPreference;
     private Preference _backupPasswordChangePreference;
+    private SwitchPreferenceCompat _dataWipingPreference;
+    private Preference _maxFailedAttemptsPreference;
 
     @Override
     public void onResume() {
@@ -251,6 +253,26 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
         _backupPasswordChangePreference = requirePreference("pref_backup_password_change");
         _backupPasswordChangePreference.setOnPreferenceClickListener(preference -> {
             Dialogs.showSetPasswordDialog(requireActivity(), new SetBackupPasswordListener());
+            return false;
+        });
+
+        _dataWipingPreference = requirePreference("pref_enable_data_wiping");
+        _maxFailedAttemptsPreference = requirePreference("pref_max_failed_attempts");
+        _maxFailedAttemptsPreference.setSummary(
+                getString(R.string.pref_max_failed_attempts_summary, _prefs.getMaxFailedAttemptsBeforeWipe())
+        );
+
+        _maxFailedAttemptsPreference.setOnPreferenceClickListener(preference -> {
+            Dialogs.showMaxFailedAttemptsPickerDialog(
+                    requireContext(),
+                    _prefs.getMaxFailedAttemptsBeforeWipe(),
+                    number -> {
+                        _prefs.setMaxFailedAttemptsBeforeWipe(number);
+                        _maxFailedAttemptsPreference.setSummary(
+                                getString(R.string.pref_max_failed_attempts_summary, number)
+                        );
+                    }
+            );
             return false;
         });
     }

--- a/app/src/main/res/drawable/ic_warning_24.xml
+++ b/app/src/main/res/drawable/ic_warning_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,5.99L19.53,19H4.47L12,5.99M12,2L1,21h22L12,2L12,2z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M13,16l-2,0l0,2l2,0z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M13,10l-2,0l0,5l2,0z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -82,7 +82,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text=""
-                    android:textColor="@android:color/holo_red_dark"
+                    android:textColor="?attr/colorError"
                     android:textSize="14sp"
                     android:layout_marginBottom="16dp"
                     />

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -77,6 +77,16 @@
                         android:inputType="numberPassword"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
+                <TextView
+                    android:id="@+id/text_failed_attempts"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Failed attempts: 0"
+                    android:textColor="@android:color/holo_red_dark"
+                    android:textSize="14sp"
+                    android:paddingBottom="4dp"
+                    />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -78,13 +78,13 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <TextView
-                    android:id="@+id/text_failed_attempts"
+                    android:id="@+id/lockout_message"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Failed attempts: 0"
+                    android:text=""
                     android:textColor="@android:color/holo_red_dark"
                     android:textSize="14sp"
-                    android:paddingBottom="4dp"
+                    android:layout_marginBottom="16dp"
                     />
 
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,10 @@
     <string name="pref_search_behavior_type_groups">Groups</string>
     <string name="pref_set_password_title">Change password</string>
     <string name="pref_set_password_summary">Set a new password which you will need to unlock your vault</string>
+    <string name="pref_enable_data_wiping_title">Enable data wiping</string>
+    <string name="pref_enable_data_wiping_summary">Erase vault data after several successive failed login attempts</string>
+    <string name="pref_max_failed_attempts_title">Maximum failed login attempts</string>
+    <string name="pref_max_failed_attempts_summary">%1$d attempts</string>
 
     <string name="no_events_title">No reported events</string>
     <string name="no_events_description">No important events have been reported within the app</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,9 @@
     <string name="add_new_entry">Add new entry</string>
     <string name="unlock_vault_error">Couldn\'t unlock vault</string>
     <string name="unlock_vault_error_description">Incorrect password. Make sure you didn\'t mistype your password.</string>
+    <string name="unlock_vault_error_danger">Final attempt remaining</string>
+    <string name="unlock_vault_error_description_danger">For security reasons, your vault will be erased after the next failed attempt.</string>
+    <string name="ok_with_timer">OK (%1$d)</string>
     <string name="password_equality_error">Passwords should be identical and non-empty</string>
     <string name="snackbar_authentication_method">Please select an authentication method</string>
     <string name="encrypting_vault">Encrypting the vault</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,6 +624,6 @@
         <item quantity="other">%d items selected</item>
     </plurals>
 
-    <string name="failed_attempts">Failed attempts: %1$d</string>
     <string name="error_empty_password">Password cannot be empty</string>
+    <string name="lockout_message">%1$d failed attempts. Try again in %2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -623,4 +623,7 @@
         <item quantity="one">%d item selected</item>
         <item quantity="other">%d items selected</item>
     </plurals>
+
+    <string name="failed_attempts">Failed attempts: %1$d</string>
+    <string name="error_empty_password">Password cannot be empty</string>
 </resources>

--- a/app/src/main/res/xml/preferences_security.xml
+++ b/app/src/main/res/xml/preferences_security.xml
@@ -82,6 +82,19 @@
             app:iconSpaceReserved="false"/>
 
         <androidx.preference.SwitchPreferenceCompat
+            android:key="pref_enable_data_wiping"
+            android:defaultValue="false"
+            android:title="@string/pref_enable_data_wiping_title"
+            android:summary="@string/pref_enable_data_wiping_summary"
+            app:iconSpaceReserved="false"/>
+
+        <Preference
+            android:key="pref_max_failed_attempts"
+            android:title="@string/pref_max_failed_attempts_title"
+            android:dependency="pref_enable_data_wiping"
+            app:iconSpaceReserved="false"/>
+
+        <androidx.preference.SwitchPreferenceCompat
             android:key="pref_pin_keyboard"
             android:dependency="pref_encryption"
             android:title="@string/pref_pin_keyboard_title"


### PR DESCRIPTION
This PR implements the optional failed-attempt protection proposed in #1749.

It adds a Security setting that allows users to enable automatic vault wiping after a configurable number of failed unlock attempts. The feature is disabled by default. Failed attempts are persisted locally, and after several consecutive failures the authentication screen applies a progressive temporary lockout with a visible countdown.

When data wiping is enabled and the configured limit is reached, the implementation reuses the existing vault deletion functionality to remove the vault file, lock the vault, and exit the app. One attempt before the limit, the user is shown a warning dialog explaining that another failed attempt will erase the vault data.

Fixes #1749

Please let me know if anything needs to be changed in this PR.