### PR TITLE
feat: change behavior of overwrite entrys

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/EditEntryActivity.java
@@ -918,12 +918,25 @@ public class EditEntryActivity extends AegisActivity {
                     .setTitle(R.string.dialog_duplicate_entry_overwrite_dialog_title)
                     .setMessage(message)
                     .setPositiveButton(R.string.action_delete, (d, which) -> {
-                        for (VaultEntry dup : duplicates) {
-                            _vaultManager.getVault().removeEntry(dup);
+                        VaultEntry anchor = duplicates.get(0);
+
+                        if (_textNote.getText().length() == 0 && !anchor.getNote().isEmpty()) {
+                            _textNote.setText(anchor.getNote());
                         }
 
+                        if (_selectedGroups.isEmpty() && !anchor.getGroups().isEmpty()) {
+                            _selectedGroups.addAll(anchor.getGroups());
+                        }
+
+                        for (int i = 1; i < duplicates.size(); i++) {
+                            _vaultManager.getVault().removeEntry(duplicates.get(i));
+                        }
+
+                        _origEntry = anchor;
+                        _isNew = false;
+
                         dialog.dismiss();
-                        addAndFinish(newEntry);
+                        onSave();
                     })
                     .setNegativeButton(android.R.string.no, null)
                     .show();


### PR DESCRIPTION
This PR implements the changes requested in https://github.com/beemdevelopment/Aegis/issues/1716.

This replaces the Delete-and-Create implementation with an In-Place update when overwriting duplicate entries. Previously, overwriting an entry would delete the existing record and append a new one to the bottom of the vault. By identifying the first duplicate entry as an anchor and persisting its UUID, the changes ensures that vault.replaceEntry() is triggered instead of addEntry(), maintaining the entry's exact index, sort order in the UI, favorite status and usage frequency metadata.

Also i thought would be better if the implementation includes a smart merging logic to preserve existing Notes or Group assignments. If the new entry screen has an empty note field or no selected groups, the application preserves the existing notes and group assignments from the anchor rather than wiping them. Explicit new inputs still overwrite old data to allow for intentional updates.   

Fixes https://github.com/beemdevelopment/Aegis/issues/1716

Please let me know if you think the implementation should be done in another way and if the proposed merging behavior for notes and groups aligns with the desired behavior.