### PR TITLE
Allow reordering of favorite entries

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/helpers/SimpleItemTouchHelperCallback.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/helpers/SimpleItemTouchHelperCallback.java
@@ -32,14 +32,7 @@ public class SimpleItemTouchHelperCallback extends ItemTouchHelper.Callback {
     }
 
     public void setSelectedEntry(VaultEntry entry) {
-        if (entry == null) {
-            _selectedEntry = null;
-            return;
-        }
-
-        if (!entry.isFavorite()) {
-            _selectedEntry = entry;
-        }
+        _selectedEntry = entry;
     }
 
     @Override
@@ -80,13 +73,21 @@ public class SimpleItemTouchHelperCallback extends ItemTouchHelper.Callback {
     @Override
     public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder,
                           RecyclerView.ViewHolder target) {
-        int targetIndex = _adapter.translateEntryPosToIndex(target.getBindingAdapterPosition());
-        if (targetIndex < _adapter.getShownFavoritesCount()) {
+        int targetPosition = target.getBindingAdapterPosition();
+
+        if (_adapter.isPositionFooter(targetPosition) || _adapter.isPositionErrorCard(targetPosition)) {
+            return false;
+        }
+
+        VaultEntry sourceEntry = _adapter.getEntryAtPosition(viewHolder.getBindingAdapterPosition());
+        VaultEntry targetEntry = _adapter.getEntryAtPosition(targetPosition);
+
+        if (sourceEntry.isFavorite() != targetEntry.isFavorite()) {
             return false;
         }
 
         int firstPosition = viewHolder.getLayoutPosition();
-        int secondPosition = target.getBindingAdapterPosition();
+        int secondPosition = targetPosition;
 
         _adapter.onItemMove(firstPosition, secondPosition);
         _positionChanged = true;

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryAdapter.java
@@ -324,7 +324,6 @@ public class EntryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         return entry != null
                 && isDragAndDropAllowed()
                 && _selectedEntries.size() == 1
-                && !_selectedEntries.get(0).isFavorite()
                 && _selectedEntries.get(0) == entry;
     }
 


### PR DESCRIPTION
This PR implements the changes requested in https://github.com/beemdevelopment/Aegis/issues/1621.

Enables users to rearrange entries within the favorites section using drag-and-drop. Favorites remain grouped above non-favorites, preventing accidental mixing of categories during reordering.

Please let me know if you think the implementation could be improved or if there's an alternative approach you'd prefer for handling this feature.

Fixes https://github.com/beemdevelopment/Aegis/issues/1621