### PR TITLE
Add ability to re-enable biometrics

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -62,6 +62,7 @@ public class AuthActivity extends AegisActivity {
     private BiometricSlot _bioSlot;
     private BiometricPrompt _bioPrompt;
     private Button _decryptButton;
+    private boolean _keystoreInvalidated;
 
     private int _failedUnlockAttempts;
 
@@ -162,6 +163,8 @@ public class AuthActivity extends AegisActivity {
                 boxBiometricInfo.setVisibility(View.VISIBLE);
                 biometricsButton.setVisibility(View.GONE);
             }
+
+            _keystoreInvalidated = invalidated;
         }
 
         _decryptButton.setOnClickListener(v -> {
@@ -306,7 +309,9 @@ public class AuthActivity extends AegisActivity {
             return;
         }
 
-        setResult(RESULT_OK);
+        Intent result = new Intent();
+        result.putExtra("keystoreInvalidated", _keystoreInvalidated);
+        setResult(RESULT_OK, result);
         finish();
     }
 

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/AuthActivity.java
@@ -311,6 +311,7 @@ public class AuthActivity extends AegisActivity {
 
         Intent result = new Intent();
         result.putExtra("keystoreInvalidated", _keystoreInvalidated);
+        result.putExtra("passwordReminderNeeded", _prefs.isPasswordReminderNeeded());
         setResult(RESULT_OK, result);
         finish();
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -63,6 +63,7 @@ import com.beemdevelopment.aegis.ui.fragments.preferences.SecurityPreferencesFra
 import com.beemdevelopment.aegis.ui.models.ErrorCardInfo;
 import com.beemdevelopment.aegis.ui.models.VaultGroupModel;
 import com.beemdevelopment.aegis.ui.tasks.IconOptimizationTask;
+import com.beemdevelopment.aegis.ui.tasks.PasswordSlotDecryptTask;
 import com.beemdevelopment.aegis.ui.tasks.QrDecodeTask;
 import com.beemdevelopment.aegis.ui.views.EntryListView;
 import com.beemdevelopment.aegis.util.ClipboardUtils;
@@ -74,6 +75,8 @@ import com.beemdevelopment.aegis.vault.VaultFile;
 import com.beemdevelopment.aegis.vault.VaultGroup;
 import com.beemdevelopment.aegis.vault.VaultRepository;
 import com.beemdevelopment.aegis.vault.VaultRepositoryException;
+import com.beemdevelopment.aegis.vault.slots.PasswordSlot;
+import com.beemdevelopment.aegis.vault.slots.SlotList;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
 import com.google.android.material.color.MaterialColors;
@@ -107,6 +110,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     private boolean _isDoingIntro;
     private boolean _isAuthenticating;
     private boolean _keystoreInvalidated;
+    private boolean _passwordReminderNeeded;
 
     private String _submittedSearchQuery;
     private String _pendingSearchQuery;
@@ -140,6 +144,8 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                     Intent data = activityResult.getData();
                     _keystoreInvalidated = data != null
                             && data.getBooleanExtra("keystoreInvalidated", false);
+                    _passwordReminderNeeded = data != null
+                            && data.getBooleanExtra("passwordReminderNeeded", false);
                     onDecryptResult();
                 }
             });
@@ -211,6 +217,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             _isDoingIntro = savedInstanceState.getBoolean("isDoingIntro");
             _isAuthenticating = savedInstanceState.getBoolean("isAuthenticating");
             _keystoreInvalidated = savedInstanceState.getBoolean("keystoreInvalidated");
+            _passwordReminderNeeded = savedInstanceState.getBoolean("passwordReminderNeeded");
         }
 
         _lockBackPressHandler = new LockBackPressHandler();
@@ -427,6 +434,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         instance.putBoolean("isDoingIntro", _isDoingIntro);
         instance.putBoolean("isAuthenticating", _isAuthenticating);
         instance.putBoolean("keystoreInvalidated", _keystoreInvalidated);
+        instance.putBoolean("passwordReminderNeeded", _passwordReminderNeeded);
 
         if (_groupFilter != null) {
             instance.putSerializable("prefGroupFilter", new HashSet<>(_groupFilter));
@@ -472,6 +480,8 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     }
 
     private void onPreferencesResult() {
+        _passwordReminderNeeded = _prefs.isPasswordReminderNeeded();
+
         // refresh the entire entry list if needed
         if (_loaded) {
             recreate();
@@ -1180,6 +1190,8 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
                     startPreferencesActivity(BackupsPreferencesFragment.class, "pref_backups");
                 });
             });
+        } else if (_passwordReminderNeeded) {
+            info = new ErrorCardInfo(getString(R.string.password_reminder_bar_message), view -> showPasswordReminderPrompt());
         } else if (_prefs.isBackupsReminderNeeded() && _prefs.isBackupReminderEnabled()) {
             String text;
             Date date = _prefs.getLatestBackupOrExportTime();
@@ -1211,6 +1223,37 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         }
 
         _entryListView.setErrorCardInfo(info);
+    }
+
+    private void showPasswordReminderPrompt() {
+        Dialogs.showPasswordInputDialog(this, R.string.pref_password_reminder_title, R.string.password_reminder, password -> {
+            List<PasswordSlot> slots = _vaultManager.getVault().getCredentials().getSlots().findRegularPasswordSlots();
+            PasswordSlotDecryptTask.Params params = new PasswordSlotDecryptTask.Params(slots, password);
+            PasswordSlotDecryptTask task = new PasswordSlotDecryptTask(this, this::onPasswordReminderResult);
+            task.execute(getLifecycle(), params);
+        }, null);
+    }
+
+    private void onPasswordReminderResult(PasswordSlotDecryptTask.Result result) {
+        if (result == null) {
+            Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(this, R.style.ThemeOverlay_Aegis_AlertDialog_Error)
+                    .setTitle(R.string.unlock_vault_error)
+                    .setMessage(R.string.unlock_vault_error_description)
+                    .setIconAttribute(android.R.attr.alertDialogIcon)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .create());
+            return;
+        }
+
+        if (result.isSlotRepaired()) {
+            SlotList slots = _vaultManager.getVault().getCredentials().getSlots();
+            slots.replace(result.getSlot());
+            saveAndBackupVault();
+        }
+
+        _prefs.resetPasswordReminderTimestamp();
+        _passwordReminderNeeded = false;
+        updateErrorCard();
     }
 
     private void showPlaintextExportWarningOptions() {

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/MainActivity.java
@@ -59,6 +59,7 @@ import com.beemdevelopment.aegis.otp.OtpInfoException;
 import com.beemdevelopment.aegis.ui.dialogs.Dialogs;
 import com.beemdevelopment.aegis.ui.fragments.preferences.BackupsPreferencesFragment;
 import com.beemdevelopment.aegis.ui.fragments.preferences.PreferencesFragment;
+import com.beemdevelopment.aegis.ui.fragments.preferences.SecurityPreferencesFragment;
 import com.beemdevelopment.aegis.ui.models.ErrorCardInfo;
 import com.beemdevelopment.aegis.ui.models.VaultGroupModel;
 import com.beemdevelopment.aegis.ui.tasks.IconOptimizationTask;
@@ -105,6 +106,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
     private boolean _isDPadPressed;
     private boolean _isDoingIntro;
     private boolean _isAuthenticating;
+    private boolean _keystoreInvalidated;
 
     private String _submittedSearchQuery;
     private String _pendingSearchQuery;
@@ -135,6 +137,9 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             registerForActivityResult(new StartActivityForResult(), activityResult -> {
                 _isAuthenticating = false;
                 if (activityResult.getResultCode() == RESULT_OK) {
+                    Intent data = activityResult.getData();
+                    _keystoreInvalidated = data != null
+                            && data.getBooleanExtra("keystoreInvalidated", false);
                     onDecryptResult();
                 }
             });
@@ -205,6 +210,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
             _submittedSearchQuery = savedInstanceState.getString("submittedSearchQuery");
             _isDoingIntro = savedInstanceState.getBoolean("isDoingIntro");
             _isAuthenticating = savedInstanceState.getBoolean("isAuthenticating");
+            _keystoreInvalidated = savedInstanceState.getBoolean("keystoreInvalidated");
         }
 
         _lockBackPressHandler = new LockBackPressHandler();
@@ -420,6 +426,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         instance.putString("submittedSearchQuery", _submittedSearchQuery);
         instance.putBoolean("isDoingIntro", _isDoingIntro);
         instance.putBoolean("isAuthenticating", _isAuthenticating);
+        instance.putBoolean("keystoreInvalidated", _keystoreInvalidated);
 
         if (_groupFilter != null) {
             instance.putSerializable("prefGroupFilter", new HashSet<>(_groupFilter));
@@ -798,6 +805,7 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         _auditLogRepository.addVaultUnlockedEvent();
 
         loadEntries();
+        updateErrorCard();
     }
 
     private void startScanActivity() {
@@ -1160,41 +1168,50 @@ public class MainActivity extends AegisActivity implements EntryListView.Listene
         }
     }
 
-   private void updateErrorCard() {
-       ErrorCardInfo info = null;
+    private void updateErrorCard() {
+        ErrorCardInfo info = null;
 
-       Preferences.BackupResult backupRes = _prefs.getErroredBackupResult();
-       if (backupRes != null) {
-           info = new ErrorCardInfo(getString(R.string.backup_error_bar_message), view -> {
-               Dialogs.showBackupErrorDialog(this, backupRes, (dialog, which) -> {
-                   startPreferencesActivity(BackupsPreferencesFragment.class, "pref_backups");
-               });
-           });
-       } else if (_prefs.isBackupsReminderNeeded() && _prefs.isBackupReminderEnabled()) {
-           String text;
-           Date date = _prefs.getLatestBackupOrExportTime();
-           if (date != null) {
-               text = getString(R.string.backup_reminder_bar_message_with_latest, TimeUtils.getElapsedSince(this, date));
-           } else {
-               text = getString(R.string.backup_reminder_bar_message);
-           }
-           info = new ErrorCardInfo(text, view -> {
-               Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(this, R.style.ThemeOverlay_Aegis_AlertDialog_Error)
-                       .setTitle(R.string.backup_reminder_bar_dialog_title)
-                       .setMessage(R.string.backup_reminder_bar_dialog_summary)
-                       .setIconAttribute(android.R.attr.alertDialogIcon)
-                       .setPositiveButton(R.string.backup_reminder_bar_dialog_accept, (dialog, whichButton) -> {
-                           startPreferencesActivity(BackupsPreferencesFragment.class, "pref_backups");
+        Preferences.BackupResult backupRes = _prefs.getErroredBackupResult();
+        if (_prefs.isPlaintextBackupWarningNeeded()) {
+            info = new ErrorCardInfo(getString(R.string.backup_plaintext_export_warning), view -> showPlaintextExportWarningOptions());
+        } else if (backupRes != null) {
+            info = new ErrorCardInfo(getString(R.string.backup_error_bar_message), view -> {
+                Dialogs.showBackupErrorDialog(this, backupRes, (dialog, which) -> {
+                    startPreferencesActivity(BackupsPreferencesFragment.class, "pref_backups");
+                });
+            });
+        } else if (_prefs.isBackupsReminderNeeded() && _prefs.isBackupReminderEnabled()) {
+            String text;
+            Date date = _prefs.getLatestBackupOrExportTime();
+            if (date != null) {
+                text = getString(R.string.backup_reminder_bar_message_with_latest, TimeUtils.getElapsedSince(this, date));
+            } else {
+                text = getString(R.string.backup_reminder_bar_message);
+            }
+            info = new ErrorCardInfo(text, view -> {
+                Dialogs.showSecureDialog(new MaterialAlertDialogBuilder(this, R.style.ThemeOverlay_Aegis_AlertDialog_Error)
+                        .setTitle(R.string.backup_reminder_bar_dialog_title)
+                        .setMessage(R.string.backup_reminder_bar_dialog_summary)
+                        .setIconAttribute(android.R.attr.alertDialogIcon)
+                        .setPositiveButton(R.string.backup_reminder_bar_dialog_accept, (dialog, whichButton) -> {
+                            startPreferencesActivity(BackupsPreferencesFragment.class, "pref_backups");
                        })
-                       .setNegativeButton(android.R.string.cancel, null)
-                       .create());
-           });
-       } else if (_prefs.isPlaintextBackupWarningNeeded()) {
-           info = new ErrorCardInfo(getString(R.string.backup_plaintext_export_warning), view -> showPlaintextExportWarningOptions());
-       }
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .create());
+            });
+        } else if (_keystoreInvalidated) {
+            info = new ErrorCardInfo(getString(R.string.biometric_invalidated_bar_message), view -> {
+                _keystoreInvalidated = false;
+                Intent intent = new Intent(this, PreferencesActivity.class);
+                intent.putExtra("fragment", SecurityPreferencesFragment.class);
+                intent.putExtra("pref", "pref_biometrics");
+                intent.putExtra("reenableBiometrics", true);
+                preferenceResultLauncher.launch(intent);
+            });
+        }
 
-       _entryListView.setErrorCardInfo(info);
-   }
+        _entryListView.setErrorCardInfo(info);
+    }
 
     private void showPlaintextExportWarningOptions() {
         View view = LayoutInflater.from(this).inflate(R.layout.dialog_plaintext_warning, null);

--- a/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/SecurityPreferencesFragment.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/fragments/preferences/SecurityPreferencesFragment.java
@@ -51,6 +51,12 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
     public void onResume() {
         super.onResume();
         updateEncryptionPreferences();
+
+        if (requireActivity().getIntent().getBooleanExtra("reenableBiometrics", false)) {
+            requireActivity().getIntent().removeExtra("reenableBiometrics");
+            disableBiometricUnlock();
+            enableBiometricUnlock();
+        }
     }
 
     @Override
@@ -109,36 +115,11 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
 
         _biometricsPreference = requirePreference("pref_biometrics");
         _biometricsPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-            VaultFileCredentials creds = _vaultManager.getVault().getCredentials();
-            SlotList slots = creds.getSlots();
-
-            if (!slots.has(BiometricSlot.class)) {
-                if (BiometricsHelper.isAvailable(requireContext())) {
-                    BiometricSlotInitializer initializer = new BiometricSlotInitializer(SecurityPreferencesFragment.this, new RegisterBiometricsListener());
-                    BiometricPrompt.PromptInfo info = new BiometricPrompt.PromptInfo.Builder()
-                            .setTitle(getString(R.string.set_up_biometric))
-                            .setNegativeButtonText(getString(android.R.string.cancel))
-                            .build();
-                    initializer.authenticate(info);
-                }
+            if ((boolean) newValue) {
+                enableBiometricUnlock();
             } else {
-                // remove the biometric slot
-                BiometricSlot slot = slots.find(BiometricSlot.class);
-                slots.remove(slot);
-                _vaultManager.getVault().setCredentials(creds);
-
-                // remove the KeyStore key
-                try {
-                    KeyStoreHandle handle = new KeyStoreHandle();
-                    handle.deleteKey(slot.getUUID().toString());
-                } catch (KeyStoreHandleException e) {
-                    e.printStackTrace();
-                }
-
-                saveAndBackupVault();
-                updateEncryptionPreferences();
+                disableBiometricUnlock();
             }
-
             return false;
         });
 
@@ -253,6 +234,39 @@ public class SecurityPreferencesFragment extends PreferencesFragment {
             Dialogs.showSetPasswordDialog(requireActivity(), new SetBackupPasswordListener());
             return false;
         });
+    }
+
+    private void enableBiometricUnlock() {
+        if (BiometricsHelper.isAvailable(requireContext())) {
+            BiometricSlotInitializer initializer = new BiometricSlotInitializer(this, new RegisterBiometricsListener());
+            BiometricPrompt.PromptInfo info = new BiometricPrompt.PromptInfo.Builder()
+                    .setTitle(getString(R.string.set_up_biometric))
+                    .setNegativeButtonText(getString(android.R.string.cancel))
+                    .build();
+            initializer.authenticate(info);
+        }
+    }
+
+    private void disableBiometricUnlock() {
+        VaultFileCredentials creds = _vaultManager.getVault().getCredentials();
+        SlotList slots = creds.getSlots();
+        BiometricSlot slot = slots.find(BiometricSlot.class);
+        if (slot == null) {
+            return;
+        }
+
+        slots.remove(slot);
+        _vaultManager.getVault().setCredentials(creds);
+
+        try {
+            KeyStoreHandle handle = new KeyStoreHandle();
+            handle.deleteKey(slot.getUUID().toString());
+        } catch (KeyStoreHandleException e) {
+            e.printStackTrace();
+        }
+
+        saveAndBackupVault();
+        updateEncryptionPreferences();
     }
 
     private void updateEncryptionPreferences() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -467,6 +467,7 @@
     <string name="google_qr_export_unexpected">Expected QR code #%1$d, but scanned #%2$d instead</string>
     <string name="backup_error_bar_message"><b>Vault backup failed recently</b></string>
     <string name="biometric_invalidated_bar_message"><b>Biometric unlock is disabled due to a change in Androids security settings. Tap here to re-enable.</b></string>
+    <string name="password_reminder_bar_message"><b>Please confirm your vault password</b></string>
     <string
         name="backup_error_dialog_details"
         comment="The first parameter is the type of backup (e.g. built-in or Android backup). The second parameter is an elapsed time in the style of 'x seconds/minutes/days ago'.">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -466,6 +466,7 @@
     </plurals>
     <string name="google_qr_export_unexpected">Expected QR code #%1$d, but scanned #%2$d instead</string>
     <string name="backup_error_bar_message"><b>Vault backup failed recently</b></string>
+    <string name="biometric_invalidated_bar_message"><b>Biometric unlock is disabled due to a change in Androids security settings. Tap here to re-enable.</b></string>
     <string
         name="backup_error_dialog_details"
         comment="The first parameter is the type of backup (e.g. built-in or Android backup). The second parameter is an elapsed time in the style of 'x seconds/minutes/days ago'.">

--- a/app/src/test/java/com/beemdevelopment/aegis/PreferencesTest.java
+++ b/app/src/test/java/com/beemdevelopment/aegis/PreferencesTest.java
@@ -49,6 +49,8 @@ public class PreferencesTest {
         assertTrue(prefs.isPasswordReminderNeeded(currTime));
         prefs.setPasswordReminderTimestamp(currTime - freq.getDurationMillis() - 1);
         assertTrue(prefs.isPasswordReminderNeeded(currTime));
+        prefs.resetPasswordReminderTimestamp();
+        assertFalse(prefs.isPasswordReminderNeeded());
 
         // a password reminder should no longer be needed if it's configured to be less frequent than before
         freq = PassReminderFreq.BIWEEKLY;


### PR DESCRIPTION
This PR adds the ability to re-enable biometrics or to reset the password reminder from within the MainActivity.

1. Re-enabling after keystore got invalidate
This happens whenever a change in Androids security settings (ie adding a fingerprint) is found.
2. Reset the password reminder after the user used biometrics to work around it in the password reminder shown in the AuthActivity.

https://github.com/user-attachments/assets/b0b982b1-376c-4374-b633-e5a92c451210

https://github.com/user-attachments/assets/fcb3be8d-2a38-4d90-8cab-ddaeccf07d10

