### PR TITLE
Fix encrypt

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
@@ -61,13 +61,12 @@ public class CryptoUtils {
         Cipher cipher = Cipher.getInstance(CRYPTO_AEAD);
 
         // generate the nonce if none is given
-        // we are not allowed to do this ourselves as "setRandomizedEncryptionRequired" is set to true
-        if (nonce != null) {
-            AlgorithmParameterSpec spec = new GCMParameterSpec(CRYPTO_AEAD_TAG_SIZE * 8, nonce);
-            cipher.init(opmode, key, spec);
-        } else {
-            cipher.init(opmode, key);
-        }
+if (nonce != null) {
+    AlgorithmParameterSpec spec = new GCMParameterSpec(CRYPTO_AEAD_TAG_SIZE * 8, nonce);
+    cipher.init(opmode, key, spec);
+} else {
+    cipher.init(opmode, key);
+}
 
         return cipher;
     }

--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
@@ -72,8 +72,9 @@ public class CryptoUtils {
         return cipher;
     }
 
-    public static CryptResult encrypt(byte[] data, Cipher cipher)
-            throws BadPaddingException, IllegalBlockSizeException {
+public static CryptResult encrypt(byte[] data, Cipher cipher)
+        throws BadPaddingException, IllegalBlockSizeException {
+    synchronized (cipher) {
         // split off the tag to store it separately
         byte[] result = cipher.doFinal(data);
         byte[] tag = Arrays.copyOfRange(result, result.length - CRYPTO_AEAD_TAG_SIZE, result.length);
@@ -81,6 +82,7 @@ public class CryptoUtils {
 
         return new CryptResult(encrypted, new CryptParameters(cipher.getIV(), tag));
     }
+}
 
     public static CryptResult decrypt(byte[] encrypted, Cipher cipher, CryptParameters params)
             throws IOException, BadPaddingException, IllegalBlockSizeException {

--- a/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
@@ -60,12 +60,11 @@ public class CryptoUtils {
             InvalidAlgorithmParameterException, InvalidKeyException {
         Cipher cipher = Cipher.getInstance(CRYPTO_AEAD);
 
-        // generate the nonce if none is given
 if (nonce != null) {
     AlgorithmParameterSpec spec = new GCMParameterSpec(CRYPTO_AEAD_TAG_SIZE * 8, nonce);
     cipher.init(opmode, key, spec);
 } else {
-    cipher.init(opmode, key);
+    cipher.init(opmode, key, new byte[0]);
 }
 
         return cipher;


### PR DESCRIPTION
# Fix: `encrypt`

## Explanation

The error is likely due to the fact that the `GCMParameterSpec` object needs to be initialized with a non-null value for its `ivLength` parameter, but the supplied nonce value is null. This can cause the method to fail when it tries to initialize the cipher using the specified parameters.

---

## Modified Method

| Property | Value |
|---|---|
| Method | `encrypt` |
| Class | `com.beemdevelopment.aegis.crypto.CryptoUtils` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/com.beemdevelopment.aegis_81.apk/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/com.beemdevelopment.aegis_81.apk/app/src/main/java/com/beemdevelopment/aegis/crypto/CryptoUtils.java
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline