### PR TITLE
Prevent malicious icon pack from overwriting other files

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/icons/IconPackManager.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/icons/IconPackManager.java
@@ -95,6 +95,9 @@ public class IconPackManager {
             // extract each of the defined icons to the icon pack directory
             for (IconPack.Icon icon : pack.getIcons()) {
                 File destFile = new File(packDir, icon.getRelativeFilename());
+                if (!destFile.getCanonicalPath().startsWith(packDir.getCanonicalPath() + File.separator)) {
+                    throw new IOException("Attempted to write outside of the icon pack directory");
+                }
                 FileHeader iconHeader = zipFile.getFileHeader(icon.getRelativeFilename());
                 if (iconHeader == null) {
                     throw new IOException(String.format("Unable to find %s relative to the root of the ZIP file", icon.getRelativeFilename()));


### PR DESCRIPTION
A malicious zip file could include paths starting with `../../`, which would result in other files being overwritten.

This change validates each path from the zip file, before writing to the filesystem.

More details on this type of vulnerability here:
https://security.snyk.io/research/zip-slip-vulnerability#:~:text=Exploitable%20Application%20Flow