### PR TITLE
Use numeric keyboard for 'Period' and 'Digits' fields in entry setup

### DIFF
--- a/app/src/main/res/layout/activity_edit_entry.xml
+++ b/app/src/main/res/layout/activity_edit_entry.xml
@@ -343,7 +343,7 @@
                                 android:id="@+id/text_period_counter"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:inputType="text"/>
+                                android:inputType="number"/>
                         </com.google.android.material.textfield.TextInputLayout>
                         <com.google.android.material.textfield.TextInputLayout
                             android:id="@+id/text_digits_layout"
@@ -356,7 +356,7 @@
                                 android:id="@+id/text_digits"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:inputType="text"/>
+                                android:inputType="number"/>
                         </com.google.android.material.textfield.TextInputLayout>
                     </LinearLayout>
                     <LinearLayout


### PR DESCRIPTION
Closes #1834

Result:
<img width="344" height="320" alt="image" src="https://github.com/user-attachments/assets/b92f58bb-f885-44db-a445-7bbaf0990e33" />
